### PR TITLE
nrfjprog support in gcc makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ nRF51: http://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-ener
 The nrfjprog utility can be used for programming target devices and reading/writing device memory among other things. It is available in the nRF5x-Tools-* download.
 
 Windows:
-	Download nRF5x-Tools_Win32 and add the path to nrfjprog.exe to your system PATH.
+	Download nRF5x-Tools_Win32 and add the full path of nrfjprog.exe to your system PATH.
 
 Linux:
-	Download Tools_Linux and run 'sudo ln -s <path to nrfjprog.exe> /usr/local/bin/nrfjprog' in your command line.
+	Download nRF5x-Tools_Linux and run 'sudo ln -s <path to nrfjprog.exe> /usr/local/bin/nrfjprog' from your command line.
 
 Run 'nrfjprog' from your command line. The help menu should print and this indicates its path has been properly set.
 
-Now you can use nrfjprog! After building any of the examples just run 'make flash' in your command line to completly erase the chip, program & verify the hex file, and reset and run the application!
+Now you can use nrfjprog! After building any of the examples just run 'make flash' from your command line to completly erase the chip, program & verify the hex file, and reset and run the application!

--- a/README.md
+++ b/README.md
@@ -13,8 +13,20 @@ Note that some peripherals and features of peripherals may not exist for your de
 The header files and tools that are needed can be downloaded from the Nordic web-pages listed below.
 
 Header files are located in the MDK downloads, available for GCC, IAR and Keil.
-The nrfjprog utility can be used for programming and is available in the nRF5x-Tools-* download.
 
 nRF52: http://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-energy/nRF52832
 
 nRF51: http://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-energy/nRF51822
+
+## Using nrfjprog
+The nrfjprog utility can be used for programming target devices and reading/writing device memory among other things. It is available in the nRF5x-Tools-* download.
+
+Windows:
+	Download nRF5x-Tools_Win32 and add the path to nrfjprog.exe to your system PATH.
+
+Linux:
+	Download Tools_Linux and run 'sudo ln -s <path to nrfjprog.exe> /usr/local/bin/nrfjprog' in your command line.
+
+Run 'nrfjprog' from your command line. The help menu should print and this indicates its path has been properly set.
+
+Now you can use nrfjprog! After building any of the examples just run 'make flash' in your command line to completly erase the chip, program & verify the hex file, and reset and run the application!

--- a/common/gcc/Makefile
+++ b/common/gcc/Makefile
@@ -61,15 +61,18 @@ all:
 	$(OBJCOPY) -Oihex $(PROG_NAME).elf   $(PROG_NAME).hex
 	$(OBJCOPY) -Obinary $(PROG_NAME).elf $(PROG_NAME).bin
 
+flash:
+	@echo Flashing: $(PROG_NAME).hex
+	nrfjprog -f NRF52 --program $(PROG_NAME).hex --chiperase --verify
+	nrfjprog -f NRF52 --reset
+
 debug:
 	make -C . DEBUG=yes
-
 
 clean:
 	rm -f  $(PROG_NAME).elf  $(PROG_NAME).o $(PROG_NAME).hex $(PROG_NAME).bin
 	rm -f system_$(DEVICE_LC).o
 	rm -f gcc_startup_$(DEVICE_LC).o
-
 
 check_setup:
 	@echo "xDK_TOP   = " $(xDK_TOP)


### PR DESCRIPTION
Now users can run 'make flash' to program and run their application. Added some documentation to get nrfjprog up and running in both windows and linux.