### PR TITLE
Decouple NordicSnippets from SDK

### DIFF
--- a/common/arm/arm_common_tables.h
+++ b/common/arm/arm_common_tables.h
@@ -1,0 +1,136 @@
+/* ----------------------------------------------------------------------
+* Copyright (C) 2010-2014 ARM Limited. All rights reserved.
+*
+* $Date:        31. July 2014
+* $Revision: 	V1.4.4
+*
+* Project: 	    CMSIS DSP Library
+* Title:	    arm_common_tables.h
+*
+* Description:	This file has extern declaration for common tables like Bitreverse, reciprocal etc which are used across different functions
+*
+* Target Processor: Cortex-M4/Cortex-M3
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*   - Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   - Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in
+*     the documentation and/or other materials provided with the
+*     distribution.
+*   - Neither the name of ARM LIMITED nor the names of its contributors
+*     may be used to endorse or promote products derived from this
+*     software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+* -------------------------------------------------------------------- */
+
+#ifndef _ARM_COMMON_TABLES_H
+#define _ARM_COMMON_TABLES_H
+
+#include "arm_math.h"
+
+extern const uint16_t armBitRevTable[1024];
+extern const q15_t armRecipTableQ15[64];
+extern const q31_t armRecipTableQ31[64];
+//extern const q31_t realCoefAQ31[1024];
+//extern const q31_t realCoefBQ31[1024];
+extern const float32_t twiddleCoef_16[32];
+extern const float32_t twiddleCoef_32[64];
+extern const float32_t twiddleCoef_64[128];
+extern const float32_t twiddleCoef_128[256];
+extern const float32_t twiddleCoef_256[512];
+extern const float32_t twiddleCoef_512[1024];
+extern const float32_t twiddleCoef_1024[2048];
+extern const float32_t twiddleCoef_2048[4096];
+extern const float32_t twiddleCoef_4096[8192];
+#define twiddleCoef twiddleCoef_4096
+extern const q31_t twiddleCoef_16_q31[24];
+extern const q31_t twiddleCoef_32_q31[48];
+extern const q31_t twiddleCoef_64_q31[96];
+extern const q31_t twiddleCoef_128_q31[192];
+extern const q31_t twiddleCoef_256_q31[384];
+extern const q31_t twiddleCoef_512_q31[768];
+extern const q31_t twiddleCoef_1024_q31[1536];
+extern const q31_t twiddleCoef_2048_q31[3072];
+extern const q31_t twiddleCoef_4096_q31[6144];
+extern const q15_t twiddleCoef_16_q15[24];
+extern const q15_t twiddleCoef_32_q15[48];
+extern const q15_t twiddleCoef_64_q15[96];
+extern const q15_t twiddleCoef_128_q15[192];
+extern const q15_t twiddleCoef_256_q15[384];
+extern const q15_t twiddleCoef_512_q15[768];
+extern const q15_t twiddleCoef_1024_q15[1536];
+extern const q15_t twiddleCoef_2048_q15[3072];
+extern const q15_t twiddleCoef_4096_q15[6144];
+extern const float32_t twiddleCoef_rfft_32[32];
+extern const float32_t twiddleCoef_rfft_64[64];
+extern const float32_t twiddleCoef_rfft_128[128];
+extern const float32_t twiddleCoef_rfft_256[256];
+extern const float32_t twiddleCoef_rfft_512[512];
+extern const float32_t twiddleCoef_rfft_1024[1024];
+extern const float32_t twiddleCoef_rfft_2048[2048];
+extern const float32_t twiddleCoef_rfft_4096[4096];
+
+
+/* floating-point bit reversal tables */
+#define ARMBITREVINDEXTABLE__16_TABLE_LENGTH ((uint16_t)20  )
+#define ARMBITREVINDEXTABLE__32_TABLE_LENGTH ((uint16_t)48  )
+#define ARMBITREVINDEXTABLE__64_TABLE_LENGTH ((uint16_t)56  )
+#define ARMBITREVINDEXTABLE_128_TABLE_LENGTH ((uint16_t)208 )
+#define ARMBITREVINDEXTABLE_256_TABLE_LENGTH ((uint16_t)440 )
+#define ARMBITREVINDEXTABLE_512_TABLE_LENGTH ((uint16_t)448 )
+#define ARMBITREVINDEXTABLE1024_TABLE_LENGTH ((uint16_t)1800)
+#define ARMBITREVINDEXTABLE2048_TABLE_LENGTH ((uint16_t)3808)
+#define ARMBITREVINDEXTABLE4096_TABLE_LENGTH ((uint16_t)4032)
+
+extern const uint16_t armBitRevIndexTable16[ARMBITREVINDEXTABLE__16_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable32[ARMBITREVINDEXTABLE__32_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable64[ARMBITREVINDEXTABLE__64_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable128[ARMBITREVINDEXTABLE_128_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable256[ARMBITREVINDEXTABLE_256_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable512[ARMBITREVINDEXTABLE_512_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable1024[ARMBITREVINDEXTABLE1024_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable2048[ARMBITREVINDEXTABLE2048_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable4096[ARMBITREVINDEXTABLE4096_TABLE_LENGTH];
+
+/* fixed-point bit reversal tables */
+#define ARMBITREVINDEXTABLE_FIXED___16_TABLE_LENGTH ((uint16_t)12  )
+#define ARMBITREVINDEXTABLE_FIXED___32_TABLE_LENGTH ((uint16_t)24  )
+#define ARMBITREVINDEXTABLE_FIXED___64_TABLE_LENGTH ((uint16_t)56  )
+#define ARMBITREVINDEXTABLE_FIXED__128_TABLE_LENGTH ((uint16_t)112 )
+#define ARMBITREVINDEXTABLE_FIXED__256_TABLE_LENGTH ((uint16_t)240 )
+#define ARMBITREVINDEXTABLE_FIXED__512_TABLE_LENGTH ((uint16_t)480 )
+#define ARMBITREVINDEXTABLE_FIXED_1024_TABLE_LENGTH ((uint16_t)992 )
+#define ARMBITREVINDEXTABLE_FIXED_2048_TABLE_LENGTH ((uint16_t)1984)
+#define ARMBITREVINDEXTABLE_FIXED_4096_TABLE_LENGTH ((uint16_t)4032)
+
+extern const uint16_t armBitRevIndexTable_fixed_16[ARMBITREVINDEXTABLE_FIXED___16_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable_fixed_32[ARMBITREVINDEXTABLE_FIXED___32_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable_fixed_64[ARMBITREVINDEXTABLE_FIXED___64_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable_fixed_128[ARMBITREVINDEXTABLE_FIXED__128_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable_fixed_256[ARMBITREVINDEXTABLE_FIXED__256_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable_fixed_512[ARMBITREVINDEXTABLE_FIXED__512_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable_fixed_1024[ARMBITREVINDEXTABLE_FIXED_1024_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable_fixed_2048[ARMBITREVINDEXTABLE_FIXED_2048_TABLE_LENGTH];
+extern const uint16_t armBitRevIndexTable_fixed_4096[ARMBITREVINDEXTABLE_FIXED_4096_TABLE_LENGTH];
+
+/* Tables for Fast Math Sine and Cosine */
+extern const float32_t sinTable_f32[FAST_MATH_TABLE_SIZE + 1];
+extern const q31_t sinTable_q31[FAST_MATH_TABLE_SIZE + 1];
+extern const q15_t sinTable_q15[FAST_MATH_TABLE_SIZE + 1];
+
+#endif /*  ARM_COMMON_TABLES_H */

--- a/common/arm/arm_const_structs.h
+++ b/common/arm/arm_const_structs.h
@@ -1,0 +1,79 @@
+/* ----------------------------------------------------------------------
+* Copyright (C) 2010-2014 ARM Limited. All rights reserved.
+*
+* $Date:        31. July 2014
+* $Revision: 	V1.4.4
+*
+* Project: 	    CMSIS DSP Library
+* Title:	    arm_const_structs.h
+*
+* Description:	This file has constant structs that are initialized for
+*              user convenience.  For example, some can be given as
+*              arguments to the arm_cfft_f32() function.
+*
+* Target Processor: Cortex-M4/Cortex-M3
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*   - Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   - Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in
+*     the documentation and/or other materials provided with the
+*     distribution.
+*   - Neither the name of ARM LIMITED nor the names of its contributors
+*     may be used to endorse or promote products derived from this
+*     software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+* -------------------------------------------------------------------- */
+
+#ifndef _ARM_CONST_STRUCTS_H
+#define _ARM_CONST_STRUCTS_H
+
+#include "arm_math.h"
+#include "arm_common_tables.h"
+
+   extern const arm_cfft_instance_f32 arm_cfft_sR_f32_len16;
+   extern const arm_cfft_instance_f32 arm_cfft_sR_f32_len32;
+   extern const arm_cfft_instance_f32 arm_cfft_sR_f32_len64;
+   extern const arm_cfft_instance_f32 arm_cfft_sR_f32_len128;
+   extern const arm_cfft_instance_f32 arm_cfft_sR_f32_len256;
+   extern const arm_cfft_instance_f32 arm_cfft_sR_f32_len512;
+   extern const arm_cfft_instance_f32 arm_cfft_sR_f32_len1024;
+   extern const arm_cfft_instance_f32 arm_cfft_sR_f32_len2048;
+   extern const arm_cfft_instance_f32 arm_cfft_sR_f32_len4096;
+
+   extern const arm_cfft_instance_q31 arm_cfft_sR_q31_len16;
+   extern const arm_cfft_instance_q31 arm_cfft_sR_q31_len32;
+   extern const arm_cfft_instance_q31 arm_cfft_sR_q31_len64;
+   extern const arm_cfft_instance_q31 arm_cfft_sR_q31_len128;
+   extern const arm_cfft_instance_q31 arm_cfft_sR_q31_len256;
+   extern const arm_cfft_instance_q31 arm_cfft_sR_q31_len512;
+   extern const arm_cfft_instance_q31 arm_cfft_sR_q31_len1024;
+   extern const arm_cfft_instance_q31 arm_cfft_sR_q31_len2048;
+   extern const arm_cfft_instance_q31 arm_cfft_sR_q31_len4096;
+
+   extern const arm_cfft_instance_q15 arm_cfft_sR_q15_len16;
+   extern const arm_cfft_instance_q15 arm_cfft_sR_q15_len32;
+   extern const arm_cfft_instance_q15 arm_cfft_sR_q15_len64;
+   extern const arm_cfft_instance_q15 arm_cfft_sR_q15_len128;
+   extern const arm_cfft_instance_q15 arm_cfft_sR_q15_len256;
+   extern const arm_cfft_instance_q15 arm_cfft_sR_q15_len512;
+   extern const arm_cfft_instance_q15 arm_cfft_sR_q15_len1024;
+   extern const arm_cfft_instance_q15 arm_cfft_sR_q15_len2048;
+   extern const arm_cfft_instance_q15 arm_cfft_sR_q15_len4096;
+
+#endif

--- a/common/arm/arm_math.h
+++ b/common/arm/arm_math.h
@@ -1,0 +1,7544 @@
+/* ----------------------------------------------------------------------
+* Copyright (C) 2010-2014 ARM Limited. All rights reserved.
+*
+* $Date:        12. March 2014
+* $Revision: 	V1.4.4
+*
+* Project: 	    CMSIS DSP Library
+* Title:	    arm_math.h
+*
+* Description:	Public header file for CMSIS DSP Library
+*
+* Target Processor: Cortex-M7/Cortex-M4/Cortex-M3/Cortex-M0
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*   - Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   - Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in
+*     the documentation and/or other materials provided with the
+*     distribution.
+*   - Neither the name of ARM LIMITED nor the names of its contributors
+*     may be used to endorse or promote products derived from this
+*     software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+ * -------------------------------------------------------------------- */
+
+/**
+   \mainpage CMSIS DSP Software Library
+   *
+   * Introduction
+   * ------------
+   *
+   * This user manual describes the CMSIS DSP software library,
+   * a suite of common signal processing functions for use on Cortex-M processor based devices.
+   *
+   * The library is divided into a number of functions each covering a specific category:
+   * - Basic math functions
+   * - Fast math functions
+   * - Complex math functions
+   * - Filters
+   * - Matrix functions
+   * - Transforms
+   * - Motor control functions
+   * - Statistical functions
+   * - Support functions
+   * - Interpolation functions
+   *
+   * The library has separate functions for operating on 8-bit integers, 16-bit integers,
+   * 32-bit integer and 32-bit floating-point values.
+   *
+   * Using the Library
+   * ------------
+   *
+   * The library installer contains prebuilt versions of the libraries in the <code>Lib</code> folder.
+   * - arm_cortexM7lfdp_math.lib (Little endian and Double Precision Floating Point Unit on Cortex-M7)
+   * - arm_cortexM7bfdp_math.lib (Big endian and Double Precision Floating Point Unit on Cortex-M7)
+   * - arm_cortexM7lfsp_math.lib (Little endian and Single Precision Floating Point Unit on Cortex-M7)
+   * - arm_cortexM7bfsp_math.lib (Big endian and Single Precision Floating Point Unit on Cortex-M7)
+   * - arm_cortexM7l_math.lib (Little endian on Cortex-M7)
+   * - arm_cortexM7b_math.lib (Big endian on Cortex-M7)
+   * - arm_cortexM4lf_math.lib (Little endian and Floating Point Unit on Cortex-M4)
+   * - arm_cortexM4bf_math.lib (Big endian and Floating Point Unit on Cortex-M4)
+   * - arm_cortexM4l_math.lib (Little endian on Cortex-M4)
+   * - arm_cortexM4b_math.lib (Big endian on Cortex-M4)
+   * - arm_cortexM3l_math.lib (Little endian on Cortex-M3)
+   * - arm_cortexM3b_math.lib (Big endian on Cortex-M3)
+   * - arm_cortexM0l_math.lib (Little endian on Cortex-M0 / CortexM0+)
+   * - arm_cortexM0b_math.lib (Big endian on Cortex-M0 / CortexM0+)
+   *
+   * The library functions are declared in the public file <code>arm_math.h</code> which is placed in the <code>Include</code> folder.
+   * Simply include this file and link the appropriate library in the application and begin calling the library functions. The Library supports single
+   * public header file <code> arm_math.h</code> for Cortex-M7/M4/M3/M0/M0+ with little endian and big endian. Same header file will be used for floating point unit(FPU) variants.
+   * Define the appropriate pre processor MACRO ARM_MATH_CM7 or ARM_MATH_CM4 or  ARM_MATH_CM3 or
+   * ARM_MATH_CM0 or ARM_MATH_CM0PLUS depending on the target processor in the application.
+   *
+   * Examples
+   * --------
+   *
+   * The library ships with a number of examples which demonstrate how to use the library functions.
+   *
+   * Toolchain Support
+   * ------------
+   *
+   * The library has been developed and tested with MDK-ARM version 4.60.
+   * The library is being tested in GCC and IAR toolchains and updates on this activity will be made available shortly.
+   *
+   * Building the Library
+   * ------------
+   *
+   * The library installer contains a project file to re build libraries on MDK-ARM Tool chain in the <code>CMSIS\\DSP_Lib\\Source\\ARM</code> folder.
+   * - arm_cortexM_math.uvproj
+   *
+   *
+   * The libraries can be built by opening the arm_cortexM_math.uvproj project in MDK-ARM, selecting a specific target, and defining the optional pre processor MACROs detailed above.
+   *
+   * Pre-processor Macros
+   * ------------
+   *
+   * Each library project have differant pre-processor macros.
+   *
+   * - UNALIGNED_SUPPORT_DISABLE:
+   *
+   * Define macro UNALIGNED_SUPPORT_DISABLE, If the silicon does not support unaligned memory access
+   *
+   * - ARM_MATH_BIG_ENDIAN:
+   *
+   * Define macro ARM_MATH_BIG_ENDIAN to build the library for big endian targets. By default library builds for little endian targets.
+   *
+   * - ARM_MATH_MATRIX_CHECK:
+   *
+   * Define macro ARM_MATH_MATRIX_CHECK for checking on the input and output sizes of matrices
+   *
+   * - ARM_MATH_ROUNDING:
+   *
+   * Define macro ARM_MATH_ROUNDING for rounding on support functions
+   *
+   * - ARM_MATH_CMx:
+   *
+   * Define macro ARM_MATH_CM4 for building the library on Cortex-M4 target, ARM_MATH_CM3 for building library on Cortex-M3 target
+   * and ARM_MATH_CM0 for building library on cortex-M0 target, ARM_MATH_CM0PLUS for building library on cortex-M0+ target.
+   *
+   * - __FPU_PRESENT:
+   *
+   * Initialize macro __FPU_PRESENT = 1 when building on FPU supported Targets. Enable this macro for M4bf and M4lf libraries
+   *
+   * <hr>
+   * CMSIS-DSP in ARM::CMSIS Pack
+   * -----------------------------
+   * 
+   * The following files relevant to CMSIS-DSP are present in the <b>ARM::CMSIS</b> Pack directories:
+   * |File/Folder                   |Content                                                                 |
+   * |------------------------------|------------------------------------------------------------------------|
+   * |\b CMSIS\\Documentation\\DSP  | This documentation                                                     |
+   * |\b CMSIS\\DSP_Lib             | Software license agreement (license.txt)                               |
+   * |\b CMSIS\\DSP_Lib\\Examples   | Example projects demonstrating the usage of the library functions      |
+   * |\b CMSIS\\DSP_Lib\\Source     | Source files for rebuilding the library                                |
+   * 
+   * <hr>
+   * Revision History of CMSIS-DSP
+   * ------------
+   * Please refer to \ref ChangeLog_pg.
+   *
+   * Copyright Notice
+   * ------------
+   *
+   * Copyright (C) 2010-2014 ARM Limited. All rights reserved.
+   */
+
+
+/**
+ * @defgroup groupMath Basic Math Functions
+ */
+
+/**
+ * @defgroup groupFastMath Fast Math Functions
+ * This set of functions provides a fast approximation to sine, cosine, and square root.
+ * As compared to most of the other functions in the CMSIS math library, the fast math functions
+ * operate on individual values and not arrays.
+ * There are separate functions for Q15, Q31, and floating-point data.
+ *
+ */
+
+/**
+ * @defgroup groupCmplxMath Complex Math Functions
+ * This set of functions operates on complex data vectors.
+ * The data in the complex arrays is stored in an interleaved fashion
+ * (real, imag, real, imag, ...).
+ * In the API functions, the number of samples in a complex array refers
+ * to the number of complex values; the array contains twice this number of
+ * real values.
+ */
+
+/**
+ * @defgroup groupFilters Filtering Functions
+ */
+
+/**
+ * @defgroup groupMatrix Matrix Functions
+ *
+ * This set of functions provides basic matrix math operations.
+ * The functions operate on matrix data structures.  For example,
+ * the type
+ * definition for the floating-point matrix structure is shown
+ * below:
+ * <pre>
+ *     typedef struct
+ *     {
+ *       uint16_t numRows;     // number of rows of the matrix.
+ *       uint16_t numCols;     // number of columns of the matrix.
+ *       float32_t *pData;     // points to the data of the matrix.
+ *     } arm_matrix_instance_f32;
+ * </pre>
+ * There are similar definitions for Q15 and Q31 data types.
+ *
+ * The structure specifies the size of the matrix and then points to
+ * an array of data.  The array is of size <code>numRows X numCols</code>
+ * and the values are arranged in row order.  That is, the
+ * matrix element (i, j) is stored at:
+ * <pre>
+ *     pData[i*numCols + j]
+ * </pre>
+ *
+ * \par Init Functions
+ * There is an associated initialization function for each type of matrix
+ * data structure.
+ * The initialization function sets the values of the internal structure fields.
+ * Refer to the function <code>arm_mat_init_f32()</code>, <code>arm_mat_init_q31()</code>
+ * and <code>arm_mat_init_q15()</code> for floating-point, Q31 and Q15 types,  respectively.
+ *
+ * \par
+ * Use of the initialization function is optional. However, if initialization function is used
+ * then the instance structure cannot be placed into a const data section.
+ * To place the instance structure in a const data
+ * section, manually initialize the data structure.  For example:
+ * <pre>
+ * <code>arm_matrix_instance_f32 S = {nRows, nColumns, pData};</code>
+ * <code>arm_matrix_instance_q31 S = {nRows, nColumns, pData};</code>
+ * <code>arm_matrix_instance_q15 S = {nRows, nColumns, pData};</code>
+ * </pre>
+ * where <code>nRows</code> specifies the number of rows, <code>nColumns</code>
+ * specifies the number of columns, and <code>pData</code> points to the
+ * data array.
+ *
+ * \par Size Checking
+ * By default all of the matrix functions perform size checking on the input and
+ * output matrices.  For example, the matrix addition function verifies that the
+ * two input matrices and the output matrix all have the same number of rows and
+ * columns.  If the size check fails the functions return:
+ * <pre>
+ *     ARM_MATH_SIZE_MISMATCH
+ * </pre>
+ * Otherwise the functions return
+ * <pre>
+ *     ARM_MATH_SUCCESS
+ * </pre>
+ * There is some overhead associated with this matrix size checking.
+ * The matrix size checking is enabled via the \#define
+ * <pre>
+ *     ARM_MATH_MATRIX_CHECK
+ * </pre>
+ * within the library project settings.  By default this macro is defined
+ * and size checking is enabled.  By changing the project settings and
+ * undefining this macro size checking is eliminated and the functions
+ * run a bit faster.  With size checking disabled the functions always
+ * return <code>ARM_MATH_SUCCESS</code>.
+ */
+
+/**
+ * @defgroup groupTransforms Transform Functions
+ */
+
+/**
+ * @defgroup groupController Controller Functions
+ */
+
+/**
+ * @defgroup groupStats Statistics Functions
+ */
+/**
+ * @defgroup groupSupport Support Functions
+ */
+
+/**
+ * @defgroup groupInterpolation Interpolation Functions
+ * These functions perform 1- and 2-dimensional interpolation of data.
+ * Linear interpolation is used for 1-dimensional data and
+ * bilinear interpolation is used for 2-dimensional data.
+ */
+
+/**
+ * @defgroup groupExamples Examples
+ */
+#ifndef _ARM_MATH_H
+#define _ARM_MATH_H
+
+#define __CMSIS_GENERIC         /* disable NVIC and Systick functions */
+
+#if defined(ARM_MATH_CM7)
+  #include "core_cm7.h"
+#elif defined (ARM_MATH_CM4)
+  #include "core_cm4.h"
+#elif defined (ARM_MATH_CM3)
+  #include "core_cm3.h"
+#elif defined (ARM_MATH_CM0)
+  #include "core_cm0.h"
+#define ARM_MATH_CM0_FAMILY
+  #elif defined (ARM_MATH_CM0PLUS)
+#include "core_cm0plus.h"
+  #define ARM_MATH_CM0_FAMILY
+#else
+  #error "Define according the used Cortex core ARM_MATH_CM7, ARM_MATH_CM4, ARM_MATH_CM3, ARM_MATH_CM0PLUS or ARM_MATH_CM0"
+#endif
+
+#undef  __CMSIS_GENERIC         /* enable NVIC and Systick functions */
+#include "string.h"
+#include "math.h"
+#ifdef	__cplusplus
+extern "C"
+{
+#endif
+
+
+  /**
+   * @brief Macros required for reciprocal calculation in Normalized LMS
+   */
+
+#define DELTA_Q31 			(0x100)
+#define DELTA_Q15 			0x5
+#define INDEX_MASK 			0x0000003F
+#ifndef PI
+#define PI					3.14159265358979f
+#endif
+
+  /**
+   * @brief Macros required for SINE and COSINE Fast math approximations
+   */
+
+#define FAST_MATH_TABLE_SIZE  512
+#define FAST_MATH_Q31_SHIFT   (32 - 10)
+#define FAST_MATH_Q15_SHIFT   (16 - 10)
+#define CONTROLLER_Q31_SHIFT  (32 - 9)
+#define TABLE_SIZE  256
+#define TABLE_SPACING_Q31	   0x400000
+#define TABLE_SPACING_Q15	   0x80
+
+  /**
+   * @brief Macros required for SINE and COSINE Controller functions
+   */
+  /* 1.31(q31) Fixed value of 2/360 */
+  /* -1 to +1 is divided into 360 values so total spacing is (2/360) */
+#define INPUT_SPACING			0xB60B61
+
+  /**
+   * @brief Macro for Unaligned Support
+   */
+#ifndef UNALIGNED_SUPPORT_DISABLE
+    #define ALIGN4
+#else
+  #if defined  (__GNUC__)
+    #define ALIGN4 __attribute__((aligned(4)))
+  #else
+    #define ALIGN4 __align(4)
+  #endif
+#endif	/*	#ifndef UNALIGNED_SUPPORT_DISABLE	*/
+
+  /**
+   * @brief Error status returned by some functions in the library.
+   */
+
+  typedef enum
+  {
+    ARM_MATH_SUCCESS = 0,                /**< No error */
+    ARM_MATH_ARGUMENT_ERROR = -1,        /**< One or more arguments are incorrect */
+    ARM_MATH_LENGTH_ERROR = -2,          /**< Length of data buffer is incorrect */
+    ARM_MATH_SIZE_MISMATCH = -3,         /**< Size of matrices is not compatible with the operation. */
+    ARM_MATH_NANINF = -4,                /**< Not-a-number (NaN) or infinity is generated */
+    ARM_MATH_SINGULAR = -5,              /**< Generated by matrix inversion if the input matrix is singular and cannot be inverted. */
+    ARM_MATH_TEST_FAILURE = -6           /**< Test Failed  */
+  } arm_status;
+
+  /**
+   * @brief 8-bit fractional data type in 1.7 format.
+   */
+  typedef int8_t q7_t;
+
+  /**
+   * @brief 16-bit fractional data type in 1.15 format.
+   */
+  typedef int16_t q15_t;
+
+  /**
+   * @brief 32-bit fractional data type in 1.31 format.
+   */
+  typedef int32_t q31_t;
+
+  /**
+   * @brief 64-bit fractional data type in 1.63 format.
+   */
+  typedef int64_t q63_t;
+
+  /**
+   * @brief 32-bit floating-point type definition.
+   */
+  typedef float float32_t;
+
+  /**
+   * @brief 64-bit floating-point type definition.
+   */
+  typedef double float64_t;
+
+  /**
+   * @brief definition to read/write two 16 bit values.
+   */
+#if defined __CC_ARM
+#define __SIMD32_TYPE int32_t __packed
+#define CMSIS_UNUSED __attribute__((unused))
+#elif defined __ICCARM__
+#define CMSIS_UNUSED
+#define __SIMD32_TYPE int32_t __packed
+#elif defined __GNUC__
+#define __SIMD32_TYPE int32_t
+#define CMSIS_UNUSED __attribute__((unused))
+#elif defined __CSMC__			/* Cosmic */
+#define CMSIS_UNUSED
+#define __SIMD32_TYPE int32_t
+#else
+#error Unknown compiler
+#endif
+
+#define __SIMD32(addr)  (*(__SIMD32_TYPE **) & (addr))
+#define __SIMD32_CONST(addr)  ((__SIMD32_TYPE *)(addr))
+
+#define _SIMD32_OFFSET(addr)  (*(__SIMD32_TYPE *)  (addr))
+
+#define __SIMD64(addr)  (*(int64_t **) & (addr))
+
+#if defined (ARM_MATH_CM3) || defined (ARM_MATH_CM0_FAMILY)
+  /**
+   * @brief definition to pack two 16 bit values.
+   */
+#define __PKHBT(ARG1, ARG2, ARG3)      ( (((int32_t)(ARG1) <<  0) & (int32_t)0x0000FFFF) | \
+                                         (((int32_t)(ARG2) << ARG3) & (int32_t)0xFFFF0000)  )
+#define __PKHTB(ARG1, ARG2, ARG3)      ( (((int32_t)(ARG1) <<  0) & (int32_t)0xFFFF0000) | \
+                                         (((int32_t)(ARG2) >> ARG3) & (int32_t)0x0000FFFF)  )
+
+#endif
+
+
+   /**
+   * @brief definition to pack four 8 bit values.
+   */
+#ifndef ARM_MATH_BIG_ENDIAN
+
+#define __PACKq7(v0,v1,v2,v3) ( (((int32_t)(v0) <<  0) & (int32_t)0x000000FF) |	\
+                                (((int32_t)(v1) <<  8) & (int32_t)0x0000FF00) |	\
+							    (((int32_t)(v2) << 16) & (int32_t)0x00FF0000) |	\
+							    (((int32_t)(v3) << 24) & (int32_t)0xFF000000)  )
+#else
+
+#define __PACKq7(v0,v1,v2,v3) ( (((int32_t)(v3) <<  0) & (int32_t)0x000000FF) |	\
+                                (((int32_t)(v2) <<  8) & (int32_t)0x0000FF00) |	\
+							    (((int32_t)(v1) << 16) & (int32_t)0x00FF0000) |	\
+							    (((int32_t)(v0) << 24) & (int32_t)0xFF000000)  )
+
+#endif
+
+
+  /**
+   * @brief Clips Q63 to Q31 values.
+   */
+  static __INLINE q31_t clip_q63_to_q31(
+  q63_t x)
+  {
+    return ((q31_t) (x >> 32) != ((q31_t) x >> 31)) ?
+      ((0x7FFFFFFF ^ ((q31_t) (x >> 63)))) : (q31_t) x;
+  }
+
+  /**
+   * @brief Clips Q63 to Q15 values.
+   */
+  static __INLINE q15_t clip_q63_to_q15(
+  q63_t x)
+  {
+    return ((q31_t) (x >> 32) != ((q31_t) x >> 31)) ?
+      ((0x7FFF ^ ((q15_t) (x >> 63)))) : (q15_t) (x >> 15);
+  }
+
+  /**
+   * @brief Clips Q31 to Q7 values.
+   */
+  static __INLINE q7_t clip_q31_to_q7(
+  q31_t x)
+  {
+    return ((q31_t) (x >> 24) != ((q31_t) x >> 23)) ?
+      ((0x7F ^ ((q7_t) (x >> 31)))) : (q7_t) x;
+  }
+
+  /**
+   * @brief Clips Q31 to Q15 values.
+   */
+  static __INLINE q15_t clip_q31_to_q15(
+  q31_t x)
+  {
+    return ((q31_t) (x >> 16) != ((q31_t) x >> 15)) ?
+      ((0x7FFF ^ ((q15_t) (x >> 31)))) : (q15_t) x;
+  }
+
+  /**
+   * @brief Multiplies 32 X 64 and returns 32 bit result in 2.30 format.
+   */
+
+  static __INLINE q63_t mult32x64(
+  q63_t x,
+  q31_t y)
+  {
+    return ((((q63_t) (x & 0x00000000FFFFFFFF) * y) >> 32) +
+            (((q63_t) (x >> 32) * y)));
+  }
+
+
+#if defined (ARM_MATH_CM0_FAMILY) && defined ( __CC_ARM   )
+#define __CLZ __clz
+#endif
+
+#if defined (ARM_MATH_CM0_FAMILY) && ((defined (__ICCARM__)) ||(defined (__GNUC__)) || defined (__TASKING__) )
+
+  static __INLINE uint32_t __CLZ(
+  q31_t data);
+
+
+  static __INLINE uint32_t __CLZ(
+  q31_t data)
+  {
+    uint32_t count = 0;
+    uint32_t mask = 0x80000000;
+
+    while((data & mask) == 0)
+    {
+      count += 1u;
+      mask = mask >> 1u;
+    }
+
+    return (count);
+
+  }
+
+#endif
+
+  /**
+   * @brief Function to Calculates 1/in (reciprocal) value of Q31 Data type.
+   */
+
+  static __INLINE uint32_t arm_recip_q31(
+  q31_t in,
+  q31_t * dst,
+  q31_t * pRecipTable)
+  {
+
+    uint32_t out, tempVal;
+    uint32_t index, i;
+    uint32_t signBits;
+
+    if(in > 0)
+    {
+      signBits = __CLZ(in) - 1;
+    }
+    else
+    {
+      signBits = __CLZ(-in) - 1;
+    }
+
+    /* Convert input sample to 1.31 format */
+    in = in << signBits;
+
+    /* calculation of index for initial approximated Val */
+    index = (uint32_t) (in >> 24u);
+    index = (index & INDEX_MASK);
+
+    /* 1.31 with exp 1 */
+    out = pRecipTable[index];
+
+    /* calculation of reciprocal value */
+    /* running approximation for two iterations */
+    for (i = 0u; i < 2u; i++)
+    {
+      tempVal = (q31_t) (((q63_t) in * out) >> 31u);
+      tempVal = 0x7FFFFFFF - tempVal;
+      /*      1.31 with exp 1 */
+      //out = (q31_t) (((q63_t) out * tempVal) >> 30u);
+      out = (q31_t) clip_q63_to_q31(((q63_t) out * tempVal) >> 30u);
+    }
+
+    /* write output */
+    *dst = out;
+
+    /* return num of signbits of out = 1/in value */
+    return (signBits + 1u);
+
+  }
+
+  /**
+   * @brief Function to Calculates 1/in (reciprocal) value of Q15 Data type.
+   */
+  static __INLINE uint32_t arm_recip_q15(
+  q15_t in,
+  q15_t * dst,
+  q15_t * pRecipTable)
+  {
+
+    uint32_t out = 0, tempVal = 0;
+    uint32_t index = 0, i = 0;
+    uint32_t signBits = 0;
+
+    if(in > 0)
+    {
+      signBits = __CLZ(in) - 17;
+    }
+    else
+    {
+      signBits = __CLZ(-in) - 17;
+    }
+
+    /* Convert input sample to 1.15 format */
+    in = in << signBits;
+
+    /* calculation of index for initial approximated Val */
+    index = in >> 8;
+    index = (index & INDEX_MASK);
+
+    /*      1.15 with exp 1  */
+    out = pRecipTable[index];
+
+    /* calculation of reciprocal value */
+    /* running approximation for two iterations */
+    for (i = 0; i < 2; i++)
+    {
+      tempVal = (q15_t) (((q31_t) in * out) >> 15);
+      tempVal = 0x7FFF - tempVal;
+      /*      1.15 with exp 1 */
+      out = (q15_t) (((q31_t) out * tempVal) >> 14);
+    }
+
+    /* write output */
+    *dst = out;
+
+    /* return num of signbits of out = 1/in value */
+    return (signBits + 1);
+
+  }
+
+
+  /*
+   * @brief C custom defined intrinisic function for only M0 processors
+   */
+#if defined(ARM_MATH_CM0_FAMILY)
+
+  static __INLINE q31_t __SSAT(
+  q31_t x,
+  uint32_t y)
+  {
+    int32_t posMax, negMin;
+    uint32_t i;
+
+    posMax = 1;
+    for (i = 0; i < (y - 1); i++)
+    {
+      posMax = posMax * 2;
+    }
+
+    if(x > 0)
+    {
+      posMax = (posMax - 1);
+
+      if(x > posMax)
+      {
+        x = posMax;
+      }
+    }
+    else
+    {
+      negMin = -posMax;
+
+      if(x < negMin)
+      {
+        x = negMin;
+      }
+    }
+    return (x);
+
+
+  }
+
+#endif /* end of ARM_MATH_CM0_FAMILY */
+
+
+
+  /*
+   * @brief C custom defined intrinsic function for M3 and M0 processors
+   */
+#if defined (ARM_MATH_CM3) || defined (ARM_MATH_CM0_FAMILY)
+
+  /*
+   * @brief C custom defined QADD8 for M3 and M0 processors
+   */
+  static __INLINE q31_t __QADD8(
+  q31_t x,
+  q31_t y)
+  {
+
+    q31_t sum;
+    q7_t r, s, t, u;
+
+    r = (q7_t) x;
+    s = (q7_t) y;
+
+    r = __SSAT((q31_t) (r + s), 8);
+    s = __SSAT(((q31_t) (((x << 16) >> 24) + ((y << 16) >> 24))), 8);
+    t = __SSAT(((q31_t) (((x << 8) >> 24) + ((y << 8) >> 24))), 8);
+    u = __SSAT(((q31_t) ((x >> 24) + (y >> 24))), 8);
+
+    sum =
+      (((q31_t) u << 24) & 0xFF000000) | (((q31_t) t << 16) & 0x00FF0000) |
+      (((q31_t) s << 8) & 0x0000FF00) | (r & 0x000000FF);
+
+    return sum;
+
+  }
+
+  /*
+   * @brief C custom defined QSUB8 for M3 and M0 processors
+   */
+  static __INLINE q31_t __QSUB8(
+  q31_t x,
+  q31_t y)
+  {
+
+    q31_t sum;
+    q31_t r, s, t, u;
+
+    r = (q7_t) x;
+    s = (q7_t) y;
+
+    r = __SSAT((r - s), 8);
+    s = __SSAT(((q31_t) (((x << 16) >> 24) - ((y << 16) >> 24))), 8) << 8;
+    t = __SSAT(((q31_t) (((x << 8) >> 24) - ((y << 8) >> 24))), 8) << 16;
+    u = __SSAT(((q31_t) ((x >> 24) - (y >> 24))), 8) << 24;
+
+    sum =
+      (u & 0xFF000000) | (t & 0x00FF0000) | (s & 0x0000FF00) | (r &
+                                                                0x000000FF);
+
+    return sum;
+  }
+
+  /*
+   * @brief C custom defined QADD16 for M3 and M0 processors
+   */
+
+  /*
+   * @brief C custom defined QADD16 for M3 and M0 processors
+   */
+  static __INLINE q31_t __QADD16(
+  q31_t x,
+  q31_t y)
+  {
+
+    q31_t sum;
+    q31_t r, s;
+
+    r = (q15_t) x;
+    s = (q15_t) y;
+
+    r = __SSAT(r + s, 16);
+    s = __SSAT(((q31_t) ((x >> 16) + (y >> 16))), 16) << 16;
+
+    sum = (s & 0xFFFF0000) | (r & 0x0000FFFF);
+
+    return sum;
+
+  }
+
+  /*
+   * @brief C custom defined SHADD16 for M3 and M0 processors
+   */
+  static __INLINE q31_t __SHADD16(
+  q31_t x,
+  q31_t y)
+  {
+
+    q31_t sum;
+    q31_t r, s;
+
+    r = (q15_t) x;
+    s = (q15_t) y;
+
+    r = ((r >> 1) + (s >> 1));
+    s = ((q31_t) ((x >> 17) + (y >> 17))) << 16;
+
+    sum = (s & 0xFFFF0000) | (r & 0x0000FFFF);
+
+    return sum;
+
+  }
+
+  /*
+   * @brief C custom defined QSUB16 for M3 and M0 processors
+   */
+  static __INLINE q31_t __QSUB16(
+  q31_t x,
+  q31_t y)
+  {
+
+    q31_t sum;
+    q31_t r, s;
+
+    r = (q15_t) x;
+    s = (q15_t) y;
+
+    r = __SSAT(r - s, 16);
+    s = __SSAT(((q31_t) ((x >> 16) - (y >> 16))), 16) << 16;
+
+    sum = (s & 0xFFFF0000) | (r & 0x0000FFFF);
+
+    return sum;
+  }
+
+  /*
+   * @brief C custom defined SHSUB16 for M3 and M0 processors
+   */
+  static __INLINE q31_t __SHSUB16(
+  q31_t x,
+  q31_t y)
+  {
+
+    q31_t diff;
+    q31_t r, s;
+
+    r = (q15_t) x;
+    s = (q15_t) y;
+
+    r = ((r >> 1) - (s >> 1));
+    s = (((x >> 17) - (y >> 17)) << 16);
+
+    diff = (s & 0xFFFF0000) | (r & 0x0000FFFF);
+
+    return diff;
+  }
+
+  /*
+   * @brief C custom defined QASX for M3 and M0 processors
+   */
+  static __INLINE q31_t __QASX(
+  q31_t x,
+  q31_t y)
+  {
+
+    q31_t sum = 0;
+
+    sum =
+      ((sum +
+        clip_q31_to_q15((q31_t) ((q15_t) (x >> 16) + (q15_t) y))) << 16) +
+      clip_q31_to_q15((q31_t) ((q15_t) x - (q15_t) (y >> 16)));
+
+    return sum;
+  }
+
+  /*
+   * @brief C custom defined SHASX for M3 and M0 processors
+   */
+  static __INLINE q31_t __SHASX(
+  q31_t x,
+  q31_t y)
+  {
+
+    q31_t sum;
+    q31_t r, s;
+
+    r = (q15_t) x;
+    s = (q15_t) y;
+
+    r = ((r >> 1) - (y >> 17));
+    s = (((x >> 17) + (s >> 1)) << 16);
+
+    sum = (s & 0xFFFF0000) | (r & 0x0000FFFF);
+
+    return sum;
+  }
+
+
+  /*
+   * @brief C custom defined QSAX for M3 and M0 processors
+   */
+  static __INLINE q31_t __QSAX(
+  q31_t x,
+  q31_t y)
+  {
+
+    q31_t sum = 0;
+
+    sum =
+      ((sum +
+        clip_q31_to_q15((q31_t) ((q15_t) (x >> 16) - (q15_t) y))) << 16) +
+      clip_q31_to_q15((q31_t) ((q15_t) x + (q15_t) (y >> 16)));
+
+    return sum;
+  }
+
+  /*
+   * @brief C custom defined SHSAX for M3 and M0 processors
+   */
+  static __INLINE q31_t __SHSAX(
+  q31_t x,
+  q31_t y)
+  {
+
+    q31_t sum;
+    q31_t r, s;
+
+    r = (q15_t) x;
+    s = (q15_t) y;
+
+    r = ((r >> 1) + (y >> 17));
+    s = (((x >> 17) - (s >> 1)) << 16);
+
+    sum = (s & 0xFFFF0000) | (r & 0x0000FFFF);
+
+    return sum;
+  }
+
+  /*
+   * @brief C custom defined SMUSDX for M3 and M0 processors
+   */
+  static __INLINE q31_t __SMUSDX(
+  q31_t x,
+  q31_t y)
+  {
+
+    return ((q31_t) (((q15_t) x * (q15_t) (y >> 16)) -
+                     ((q15_t) (x >> 16) * (q15_t) y)));
+  }
+
+  /*
+   * @brief C custom defined SMUADX for M3 and M0 processors
+   */
+  static __INLINE q31_t __SMUADX(
+  q31_t x,
+  q31_t y)
+  {
+
+    return ((q31_t) (((q15_t) x * (q15_t) (y >> 16)) +
+                     ((q15_t) (x >> 16) * (q15_t) y)));
+  }
+
+  /*
+   * @brief C custom defined QADD for M3 and M0 processors
+   */
+  static __INLINE q31_t __QADD(
+  q31_t x,
+  q31_t y)
+  {
+    return clip_q63_to_q31((q63_t) x + y);
+  }
+
+  /*
+   * @brief C custom defined QSUB for M3 and M0 processors
+   */
+  static __INLINE q31_t __QSUB(
+  q31_t x,
+  q31_t y)
+  {
+    return clip_q63_to_q31((q63_t) x - y);
+  }
+
+  /*
+   * @brief C custom defined SMLAD for M3 and M0 processors
+   */
+  static __INLINE q31_t __SMLAD(
+  q31_t x,
+  q31_t y,
+  q31_t sum)
+  {
+
+    return (sum + ((q15_t) (x >> 16) * (q15_t) (y >> 16)) +
+            ((q15_t) x * (q15_t) y));
+  }
+
+  /*
+   * @brief C custom defined SMLADX for M3 and M0 processors
+   */
+  static __INLINE q31_t __SMLADX(
+  q31_t x,
+  q31_t y,
+  q31_t sum)
+  {
+
+    return (sum + ((q15_t) (x >> 16) * (q15_t) (y)) +
+            ((q15_t) x * (q15_t) (y >> 16)));
+  }
+
+  /*
+   * @brief C custom defined SMLSDX for M3 and M0 processors
+   */
+  static __INLINE q31_t __SMLSDX(
+  q31_t x,
+  q31_t y,
+  q31_t sum)
+  {
+
+    return (sum - ((q15_t) (x >> 16) * (q15_t) (y)) +
+            ((q15_t) x * (q15_t) (y >> 16)));
+  }
+
+  /*
+   * @brief C custom defined SMLALD for M3 and M0 processors
+   */
+  static __INLINE q63_t __SMLALD(
+  q31_t x,
+  q31_t y,
+  q63_t sum)
+  {
+
+    return (sum + ((q15_t) (x >> 16) * (q15_t) (y >> 16)) +
+            ((q15_t) x * (q15_t) y));
+  }
+
+  /*
+   * @brief C custom defined SMLALDX for M3 and M0 processors
+   */
+  static __INLINE q63_t __SMLALDX(
+  q31_t x,
+  q31_t y,
+  q63_t sum)
+  {
+
+    return (sum + ((q15_t) (x >> 16) * (q15_t) y)) +
+      ((q15_t) x * (q15_t) (y >> 16));
+  }
+
+  /*
+   * @brief C custom defined SMUAD for M3 and M0 processors
+   */
+  static __INLINE q31_t __SMUAD(
+  q31_t x,
+  q31_t y)
+  {
+
+    return (((x >> 16) * (y >> 16)) +
+            (((x << 16) >> 16) * ((y << 16) >> 16)));
+  }
+
+  /*
+   * @brief C custom defined SMUSD for M3 and M0 processors
+   */
+  static __INLINE q31_t __SMUSD(
+  q31_t x,
+  q31_t y)
+  {
+
+    return (-((x >> 16) * (y >> 16)) +
+            (((x << 16) >> 16) * ((y << 16) >> 16)));
+  }
+
+
+  /*
+   * @brief C custom defined SXTB16 for M3 and M0 processors
+   */
+  static __INLINE q31_t __SXTB16(
+  q31_t x)
+  {
+
+    return ((((x << 24) >> 24) & 0x0000FFFF) |
+            (((x << 8) >> 8) & 0xFFFF0000));
+  }
+
+
+#endif /* defined (ARM_MATH_CM3) || defined (ARM_MATH_CM0_FAMILY) */
+
+
+  /**
+   * @brief Instance structure for the Q7 FIR filter.
+   */
+  typedef struct
+  {
+    uint16_t numTaps;        /**< number of filter coefficients in the filter. */
+    q7_t *pState;            /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q7_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
+  } arm_fir_instance_q7;
+
+  /**
+   * @brief Instance structure for the Q15 FIR filter.
+   */
+  typedef struct
+  {
+    uint16_t numTaps;         /**< number of filter coefficients in the filter. */
+    q15_t *pState;            /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q15_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
+  } arm_fir_instance_q15;
+
+  /**
+   * @brief Instance structure for the Q31 FIR filter.
+   */
+  typedef struct
+  {
+    uint16_t numTaps;         /**< number of filter coefficients in the filter. */
+    q31_t *pState;            /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q31_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps. */
+  } arm_fir_instance_q31;
+
+  /**
+   * @brief Instance structure for the floating-point FIR filter.
+   */
+  typedef struct
+  {
+    uint16_t numTaps;     /**< number of filter coefficients in the filter. */
+    float32_t *pState;    /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    float32_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps. */
+  } arm_fir_instance_f32;
+
+
+  /**
+   * @brief Processing function for the Q7 FIR filter.
+   * @param[in] *S points to an instance of the Q7 FIR filter structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+  void arm_fir_q7(
+  const arm_fir_instance_q7 * S,
+  q7_t * pSrc,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief  Initialization function for the Q7 FIR filter.
+   * @param[in,out] *S points to an instance of the Q7 FIR structure.
+   * @param[in] numTaps  Number of filter coefficients in the filter.
+   * @param[in] *pCoeffs points to the filter coefficients.
+   * @param[in] *pState points to the state buffer.
+   * @param[in] blockSize number of samples that are processed.
+   * @return none
+   */
+  void arm_fir_init_q7(
+  arm_fir_instance_q7 * S,
+  uint16_t numTaps,
+  q7_t * pCoeffs,
+  q7_t * pState,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Processing function for the Q15 FIR filter.
+   * @param[in] *S points to an instance of the Q15 FIR structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+  void arm_fir_q15(
+  const arm_fir_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the fast Q15 FIR filter for Cortex-M3 and Cortex-M4.
+   * @param[in] *S points to an instance of the Q15 FIR filter structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+  void arm_fir_fast_q15(
+  const arm_fir_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the Q15 FIR filter.
+   * @param[in,out] *S points to an instance of the Q15 FIR filter structure.
+   * @param[in] numTaps  Number of filter coefficients in the filter. Must be even and greater than or equal to 4.
+   * @param[in] *pCoeffs points to the filter coefficients.
+   * @param[in] *pState points to the state buffer.
+   * @param[in] blockSize number of samples that are processed at a time.
+   * @return The function returns ARM_MATH_SUCCESS if initialization was successful or ARM_MATH_ARGUMENT_ERROR if
+   * <code>numTaps</code> is not a supported value.
+   */
+
+  arm_status arm_fir_init_q15(
+  arm_fir_instance_q15 * S,
+  uint16_t numTaps,
+  q15_t * pCoeffs,
+  q15_t * pState,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the Q31 FIR filter.
+   * @param[in] *S points to an instance of the Q31 FIR filter structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+  void arm_fir_q31(
+  const arm_fir_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the fast Q31 FIR filter for Cortex-M3 and Cortex-M4.
+   * @param[in] *S points to an instance of the Q31 FIR structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+  void arm_fir_fast_q31(
+  const arm_fir_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the Q31 FIR filter.
+   * @param[in,out] *S points to an instance of the Q31 FIR structure.
+   * @param[in] 	numTaps  Number of filter coefficients in the filter.
+   * @param[in] 	*pCoeffs points to the filter coefficients.
+   * @param[in] 	*pState points to the state buffer.
+   * @param[in] 	blockSize number of samples that are processed at a time.
+   * @return 		none.
+   */
+  void arm_fir_init_q31(
+  arm_fir_instance_q31 * S,
+  uint16_t numTaps,
+  q31_t * pCoeffs,
+  q31_t * pState,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the floating-point FIR filter.
+   * @param[in] *S points to an instance of the floating-point FIR structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+  void arm_fir_f32(
+  const arm_fir_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the floating-point FIR filter.
+   * @param[in,out] *S points to an instance of the floating-point FIR filter structure.
+   * @param[in] 	numTaps  Number of filter coefficients in the filter.
+   * @param[in] 	*pCoeffs points to the filter coefficients.
+   * @param[in] 	*pState points to the state buffer.
+   * @param[in] 	blockSize number of samples that are processed at a time.
+   * @return    	none.
+   */
+  void arm_fir_init_f32(
+  arm_fir_instance_f32 * S,
+  uint16_t numTaps,
+  float32_t * pCoeffs,
+  float32_t * pState,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Instance structure for the Q15 Biquad cascade filter.
+   */
+  typedef struct
+  {
+    int8_t numStages;         /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    q15_t *pState;            /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
+    q15_t *pCoeffs;           /**< Points to the array of coefficients.  The array is of length 5*numStages. */
+    int8_t postShift;         /**< Additional shift, in bits, applied to each output sample. */
+
+  } arm_biquad_casd_df1_inst_q15;
+
+
+  /**
+   * @brief Instance structure for the Q31 Biquad cascade filter.
+   */
+  typedef struct
+  {
+    uint32_t numStages;      /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    q31_t *pState;           /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
+    q31_t *pCoeffs;          /**< Points to the array of coefficients.  The array is of length 5*numStages. */
+    uint8_t postShift;       /**< Additional shift, in bits, applied to each output sample. */
+
+  } arm_biquad_casd_df1_inst_q31;
+
+  /**
+   * @brief Instance structure for the floating-point Biquad cascade filter.
+   */
+  typedef struct
+  {
+    uint32_t numStages;         /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    float32_t *pState;          /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
+    float32_t *pCoeffs;         /**< Points to the array of coefficients.  The array is of length 5*numStages. */
+
+
+  } arm_biquad_casd_df1_inst_f32;
+
+
+
+  /**
+   * @brief Processing function for the Q15 Biquad cascade filter.
+   * @param[in]  *S points to an instance of the Q15 Biquad cascade structure.
+   * @param[in]  *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in]  blockSize number of samples to process.
+   * @return     none.
+   */
+
+  void arm_biquad_cascade_df1_q15(
+  const arm_biquad_casd_df1_inst_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the Q15 Biquad cascade filter.
+   * @param[in,out] *S           points to an instance of the Q15 Biquad cascade structure.
+   * @param[in]     numStages    number of 2nd order stages in the filter.
+   * @param[in]     *pCoeffs     points to the filter coefficients.
+   * @param[in]     *pState      points to the state buffer.
+   * @param[in]     postShift    Shift to be applied to the output. Varies according to the coefficients format
+   * @return        none
+   */
+
+  void arm_biquad_cascade_df1_init_q15(
+  arm_biquad_casd_df1_inst_q15 * S,
+  uint8_t numStages,
+  q15_t * pCoeffs,
+  q15_t * pState,
+  int8_t postShift);
+
+
+  /**
+   * @brief Fast but less precise processing function for the Q15 Biquad cascade filter for Cortex-M3 and Cortex-M4.
+   * @param[in]  *S points to an instance of the Q15 Biquad cascade structure.
+   * @param[in]  *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in]  blockSize number of samples to process.
+   * @return     none.
+   */
+
+  void arm_biquad_cascade_df1_fast_q15(
+  const arm_biquad_casd_df1_inst_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Processing function for the Q31 Biquad cascade filter
+   * @param[in]  *S         points to an instance of the Q31 Biquad cascade structure.
+   * @param[in]  *pSrc      points to the block of input data.
+   * @param[out] *pDst      points to the block of output data.
+   * @param[in]  blockSize  number of samples to process.
+   * @return     none.
+   */
+
+  void arm_biquad_cascade_df1_q31(
+  const arm_biquad_casd_df1_inst_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Fast but less precise processing function for the Q31 Biquad cascade filter for Cortex-M3 and Cortex-M4.
+   * @param[in]  *S         points to an instance of the Q31 Biquad cascade structure.
+   * @param[in]  *pSrc      points to the block of input data.
+   * @param[out] *pDst      points to the block of output data.
+   * @param[in]  blockSize  number of samples to process.
+   * @return     none.
+   */
+
+  void arm_biquad_cascade_df1_fast_q31(
+  const arm_biquad_casd_df1_inst_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the Q31 Biquad cascade filter.
+   * @param[in,out] *S           points to an instance of the Q31 Biquad cascade structure.
+   * @param[in]     numStages      number of 2nd order stages in the filter.
+   * @param[in]     *pCoeffs     points to the filter coefficients.
+   * @param[in]     *pState      points to the state buffer.
+   * @param[in]     postShift    Shift to be applied to the output. Varies according to the coefficients format
+   * @return        none
+   */
+
+  void arm_biquad_cascade_df1_init_q31(
+  arm_biquad_casd_df1_inst_q31 * S,
+  uint8_t numStages,
+  q31_t * pCoeffs,
+  q31_t * pState,
+  int8_t postShift);
+
+  /**
+   * @brief Processing function for the floating-point Biquad cascade filter.
+   * @param[in]  *S         points to an instance of the floating-point Biquad cascade structure.
+   * @param[in]  *pSrc      points to the block of input data.
+   * @param[out] *pDst      points to the block of output data.
+   * @param[in]  blockSize  number of samples to process.
+   * @return     none.
+   */
+
+  void arm_biquad_cascade_df1_f32(
+  const arm_biquad_casd_df1_inst_f32 * S,
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the floating-point Biquad cascade filter.
+   * @param[in,out] *S           points to an instance of the floating-point Biquad cascade structure.
+   * @param[in]     numStages    number of 2nd order stages in the filter.
+   * @param[in]     *pCoeffs     points to the filter coefficients.
+   * @param[in]     *pState      points to the state buffer.
+   * @return        none
+   */
+
+  void arm_biquad_cascade_df1_init_f32(
+  arm_biquad_casd_df1_inst_f32 * S,
+  uint8_t numStages,
+  float32_t * pCoeffs,
+  float32_t * pState);
+
+
+  /**
+   * @brief Instance structure for the floating-point matrix structure.
+   */
+
+  typedef struct
+  {
+    uint16_t numRows;     /**< number of rows of the matrix.     */
+    uint16_t numCols;     /**< number of columns of the matrix.  */
+    float32_t *pData;     /**< points to the data of the matrix. */
+  } arm_matrix_instance_f32;
+
+
+  /**
+   * @brief Instance structure for the floating-point matrix structure.
+   */
+
+  typedef struct
+  {
+    uint16_t numRows;     /**< number of rows of the matrix.     */
+    uint16_t numCols;     /**< number of columns of the matrix.  */
+    float64_t *pData;     /**< points to the data of the matrix. */
+  } arm_matrix_instance_f64;
+
+  /**
+   * @brief Instance structure for the Q15 matrix structure.
+   */
+
+  typedef struct
+  {
+    uint16_t numRows;     /**< number of rows of the matrix.     */
+    uint16_t numCols;     /**< number of columns of the matrix.  */
+    q15_t *pData;         /**< points to the data of the matrix. */
+
+  } arm_matrix_instance_q15;
+
+  /**
+   * @brief Instance structure for the Q31 matrix structure.
+   */
+
+  typedef struct
+  {
+    uint16_t numRows;     /**< number of rows of the matrix.     */
+    uint16_t numCols;     /**< number of columns of the matrix.  */
+    q31_t *pData;         /**< points to the data of the matrix. */
+
+  } arm_matrix_instance_q31;
+
+
+
+  /**
+   * @brief Floating-point matrix addition.
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_add_f32(
+  const arm_matrix_instance_f32 * pSrcA,
+  const arm_matrix_instance_f32 * pSrcB,
+  arm_matrix_instance_f32 * pDst);
+
+  /**
+   * @brief Q15 matrix addition.
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_add_q15(
+  const arm_matrix_instance_q15 * pSrcA,
+  const arm_matrix_instance_q15 * pSrcB,
+  arm_matrix_instance_q15 * pDst);
+
+  /**
+   * @brief Q31 matrix addition.
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_add_q31(
+  const arm_matrix_instance_q31 * pSrcA,
+  const arm_matrix_instance_q31 * pSrcB,
+  arm_matrix_instance_q31 * pDst);
+
+  /**
+   * @brief Floating-point, complex, matrix multiplication.
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_cmplx_mult_f32(
+  const arm_matrix_instance_f32 * pSrcA,
+  const arm_matrix_instance_f32 * pSrcB,
+  arm_matrix_instance_f32 * pDst);
+
+  /**
+   * @brief Q15, complex,  matrix multiplication.
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_cmplx_mult_q15(
+  const arm_matrix_instance_q15 * pSrcA,
+  const arm_matrix_instance_q15 * pSrcB,
+  arm_matrix_instance_q15 * pDst,
+  q15_t * pScratch);
+
+  /**
+   * @brief Q31, complex, matrix multiplication.
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_cmplx_mult_q31(
+  const arm_matrix_instance_q31 * pSrcA,
+  const arm_matrix_instance_q31 * pSrcB,
+  arm_matrix_instance_q31 * pDst);
+
+
+  /**
+   * @brief Floating-point matrix transpose.
+   * @param[in]  *pSrc points to the input matrix
+   * @param[out] *pDst points to the output matrix
+   * @return 	The function returns either  <code>ARM_MATH_SIZE_MISMATCH</code>
+   * or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_trans_f32(
+  const arm_matrix_instance_f32 * pSrc,
+  arm_matrix_instance_f32 * pDst);
+
+
+  /**
+   * @brief Q15 matrix transpose.
+   * @param[in]  *pSrc points to the input matrix
+   * @param[out] *pDst points to the output matrix
+   * @return 	The function returns either  <code>ARM_MATH_SIZE_MISMATCH</code>
+   * or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_trans_q15(
+  const arm_matrix_instance_q15 * pSrc,
+  arm_matrix_instance_q15 * pDst);
+
+  /**
+   * @brief Q31 matrix transpose.
+   * @param[in]  *pSrc points to the input matrix
+   * @param[out] *pDst points to the output matrix
+   * @return 	The function returns either  <code>ARM_MATH_SIZE_MISMATCH</code>
+   * or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_trans_q31(
+  const arm_matrix_instance_q31 * pSrc,
+  arm_matrix_instance_q31 * pDst);
+
+
+  /**
+   * @brief Floating-point matrix multiplication
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_mult_f32(
+  const arm_matrix_instance_f32 * pSrcA,
+  const arm_matrix_instance_f32 * pSrcB,
+  arm_matrix_instance_f32 * pDst);
+
+  /**
+   * @brief Q15 matrix multiplication
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @param[in]		 *pState points to the array for storing intermediate results
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_mult_q15(
+  const arm_matrix_instance_q15 * pSrcA,
+  const arm_matrix_instance_q15 * pSrcB,
+  arm_matrix_instance_q15 * pDst,
+  q15_t * pState);
+
+  /**
+   * @brief Q15 matrix multiplication (fast variant) for Cortex-M3 and Cortex-M4
+   * @param[in]       *pSrcA  points to the first input matrix structure
+   * @param[in]       *pSrcB  points to the second input matrix structure
+   * @param[out]      *pDst   points to output matrix structure
+   * @param[in]		  *pState points to the array for storing intermediate results
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_mult_fast_q15(
+  const arm_matrix_instance_q15 * pSrcA,
+  const arm_matrix_instance_q15 * pSrcB,
+  arm_matrix_instance_q15 * pDst,
+  q15_t * pState);
+
+  /**
+   * @brief Q31 matrix multiplication
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_mult_q31(
+  const arm_matrix_instance_q31 * pSrcA,
+  const arm_matrix_instance_q31 * pSrcB,
+  arm_matrix_instance_q31 * pDst);
+
+  /**
+   * @brief Q31 matrix multiplication (fast variant) for Cortex-M3 and Cortex-M4
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_mult_fast_q31(
+  const arm_matrix_instance_q31 * pSrcA,
+  const arm_matrix_instance_q31 * pSrcB,
+  arm_matrix_instance_q31 * pDst);
+
+
+  /**
+   * @brief Floating-point matrix subtraction
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_sub_f32(
+  const arm_matrix_instance_f32 * pSrcA,
+  const arm_matrix_instance_f32 * pSrcB,
+  arm_matrix_instance_f32 * pDst);
+
+  /**
+   * @brief Q15 matrix subtraction
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_sub_q15(
+  const arm_matrix_instance_q15 * pSrcA,
+  const arm_matrix_instance_q15 * pSrcB,
+  arm_matrix_instance_q15 * pDst);
+
+  /**
+   * @brief Q31 matrix subtraction
+   * @param[in]       *pSrcA points to the first input matrix structure
+   * @param[in]       *pSrcB points to the second input matrix structure
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_sub_q31(
+  const arm_matrix_instance_q31 * pSrcA,
+  const arm_matrix_instance_q31 * pSrcB,
+  arm_matrix_instance_q31 * pDst);
+
+  /**
+   * @brief Floating-point matrix scaling.
+   * @param[in]  *pSrc points to the input matrix
+   * @param[in]  scale scale factor
+   * @param[out] *pDst points to the output matrix
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_scale_f32(
+  const arm_matrix_instance_f32 * pSrc,
+  float32_t scale,
+  arm_matrix_instance_f32 * pDst);
+
+  /**
+   * @brief Q15 matrix scaling.
+   * @param[in]       *pSrc points to input matrix
+   * @param[in]       scaleFract fractional portion of the scale factor
+   * @param[in]       shift number of bits to shift the result by
+   * @param[out]      *pDst points to output matrix
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_scale_q15(
+  const arm_matrix_instance_q15 * pSrc,
+  q15_t scaleFract,
+  int32_t shift,
+  arm_matrix_instance_q15 * pDst);
+
+  /**
+   * @brief Q31 matrix scaling.
+   * @param[in]       *pSrc points to input matrix
+   * @param[in]       scaleFract fractional portion of the scale factor
+   * @param[in]       shift number of bits to shift the result by
+   * @param[out]      *pDst points to output matrix structure
+   * @return     The function returns either
+   * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
+   */
+
+  arm_status arm_mat_scale_q31(
+  const arm_matrix_instance_q31 * pSrc,
+  q31_t scaleFract,
+  int32_t shift,
+  arm_matrix_instance_q31 * pDst);
+
+
+  /**
+   * @brief  Q31 matrix initialization.
+   * @param[in,out] *S             points to an instance of the floating-point matrix structure.
+   * @param[in]     nRows          number of rows in the matrix.
+   * @param[in]     nColumns       number of columns in the matrix.
+   * @param[in]     *pData	       points to the matrix data array.
+   * @return        none
+   */
+
+  void arm_mat_init_q31(
+  arm_matrix_instance_q31 * S,
+  uint16_t nRows,
+  uint16_t nColumns,
+  q31_t * pData);
+
+  /**
+   * @brief  Q15 matrix initialization.
+   * @param[in,out] *S             points to an instance of the floating-point matrix structure.
+   * @param[in]     nRows          number of rows in the matrix.
+   * @param[in]     nColumns       number of columns in the matrix.
+   * @param[in]     *pData	       points to the matrix data array.
+   * @return        none
+   */
+
+  void arm_mat_init_q15(
+  arm_matrix_instance_q15 * S,
+  uint16_t nRows,
+  uint16_t nColumns,
+  q15_t * pData);
+
+  /**
+   * @brief  Floating-point matrix initialization.
+   * @param[in,out] *S             points to an instance of the floating-point matrix structure.
+   * @param[in]     nRows          number of rows in the matrix.
+   * @param[in]     nColumns       number of columns in the matrix.
+   * @param[in]     *pData	       points to the matrix data array.
+   * @return        none
+   */
+
+  void arm_mat_init_f32(
+  arm_matrix_instance_f32 * S,
+  uint16_t nRows,
+  uint16_t nColumns,
+  float32_t * pData);
+
+
+
+  /**
+   * @brief Instance structure for the Q15 PID Control.
+   */
+  typedef struct
+  {
+    q15_t A0;    /**< The derived gain, A0 = Kp + Ki + Kd . */
+#ifdef ARM_MATH_CM0_FAMILY
+    q15_t A1;
+    q15_t A2;
+#else
+    q31_t A1;           /**< The derived gain A1 = -Kp - 2Kd | Kd.*/
+#endif
+    q15_t state[3];       /**< The state array of length 3. */
+    q15_t Kp;           /**< The proportional gain. */
+    q15_t Ki;           /**< The integral gain. */
+    q15_t Kd;           /**< The derivative gain. */
+  } arm_pid_instance_q15;
+
+  /**
+   * @brief Instance structure for the Q31 PID Control.
+   */
+  typedef struct
+  {
+    q31_t A0;            /**< The derived gain, A0 = Kp + Ki + Kd . */
+    q31_t A1;            /**< The derived gain, A1 = -Kp - 2Kd. */
+    q31_t A2;            /**< The derived gain, A2 = Kd . */
+    q31_t state[3];      /**< The state array of length 3. */
+    q31_t Kp;            /**< The proportional gain. */
+    q31_t Ki;            /**< The integral gain. */
+    q31_t Kd;            /**< The derivative gain. */
+
+  } arm_pid_instance_q31;
+
+  /**
+   * @brief Instance structure for the floating-point PID Control.
+   */
+  typedef struct
+  {
+    float32_t A0;          /**< The derived gain, A0 = Kp + Ki + Kd . */
+    float32_t A1;          /**< The derived gain, A1 = -Kp - 2Kd. */
+    float32_t A2;          /**< The derived gain, A2 = Kd . */
+    float32_t state[3];    /**< The state array of length 3. */
+    float32_t Kp;               /**< The proportional gain. */
+    float32_t Ki;               /**< The integral gain. */
+    float32_t Kd;               /**< The derivative gain. */
+  } arm_pid_instance_f32;
+
+
+
+  /**
+   * @brief  Initialization function for the floating-point PID Control.
+   * @param[in,out] *S      points to an instance of the PID structure.
+   * @param[in]     resetStateFlag  flag to reset the state. 0 = no change in state 1 = reset the state.
+   * @return none.
+   */
+  void arm_pid_init_f32(
+  arm_pid_instance_f32 * S,
+  int32_t resetStateFlag);
+
+  /**
+   * @brief  Reset function for the floating-point PID Control.
+   * @param[in,out] *S is an instance of the floating-point PID Control structure
+   * @return none
+   */
+  void arm_pid_reset_f32(
+  arm_pid_instance_f32 * S);
+
+
+  /**
+   * @brief  Initialization function for the Q31 PID Control.
+   * @param[in,out] *S points to an instance of the Q15 PID structure.
+   * @param[in]     resetStateFlag  flag to reset the state. 0 = no change in state 1 = reset the state.
+   * @return none.
+   */
+  void arm_pid_init_q31(
+  arm_pid_instance_q31 * S,
+  int32_t resetStateFlag);
+
+
+  /**
+   * @brief  Reset function for the Q31 PID Control.
+   * @param[in,out] *S points to an instance of the Q31 PID Control structure
+   * @return none
+   */
+
+  void arm_pid_reset_q31(
+  arm_pid_instance_q31 * S);
+
+  /**
+   * @brief  Initialization function for the Q15 PID Control.
+   * @param[in,out] *S points to an instance of the Q15 PID structure.
+   * @param[in] resetStateFlag  flag to reset the state. 0 = no change in state 1 = reset the state.
+   * @return none.
+   */
+  void arm_pid_init_q15(
+  arm_pid_instance_q15 * S,
+  int32_t resetStateFlag);
+
+  /**
+   * @brief  Reset function for the Q15 PID Control.
+   * @param[in,out] *S points to an instance of the q15 PID Control structure
+   * @return none
+   */
+  void arm_pid_reset_q15(
+  arm_pid_instance_q15 * S);
+
+
+  /**
+   * @brief Instance structure for the floating-point Linear Interpolate function.
+   */
+  typedef struct
+  {
+    uint32_t nValues;           /**< nValues */
+    float32_t x1;               /**< x1 */
+    float32_t xSpacing;         /**< xSpacing */
+    float32_t *pYData;          /**< pointer to the table of Y values */
+  } arm_linear_interp_instance_f32;
+
+  /**
+   * @brief Instance structure for the floating-point bilinear interpolation function.
+   */
+
+  typedef struct
+  {
+    uint16_t numRows;   /**< number of rows in the data table. */
+    uint16_t numCols;   /**< number of columns in the data table. */
+    float32_t *pData;   /**< points to the data table. */
+  } arm_bilinear_interp_instance_f32;
+
+   /**
+   * @brief Instance structure for the Q31 bilinear interpolation function.
+   */
+
+  typedef struct
+  {
+    uint16_t numRows;   /**< number of rows in the data table. */
+    uint16_t numCols;   /**< number of columns in the data table. */
+    q31_t *pData;       /**< points to the data table. */
+  } arm_bilinear_interp_instance_q31;
+
+   /**
+   * @brief Instance structure for the Q15 bilinear interpolation function.
+   */
+
+  typedef struct
+  {
+    uint16_t numRows;   /**< number of rows in the data table. */
+    uint16_t numCols;   /**< number of columns in the data table. */
+    q15_t *pData;       /**< points to the data table. */
+  } arm_bilinear_interp_instance_q15;
+
+   /**
+   * @brief Instance structure for the Q15 bilinear interpolation function.
+   */
+
+  typedef struct
+  {
+    uint16_t numRows;   /**< number of rows in the data table. */
+    uint16_t numCols;   /**< number of columns in the data table. */
+    q7_t *pData;                /**< points to the data table. */
+  } arm_bilinear_interp_instance_q7;
+
+
+  /**
+   * @brief Q7 vector multiplication.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst  points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_mult_q7(
+  q7_t * pSrcA,
+  q7_t * pSrcB,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q15 vector multiplication.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst  points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_mult_q15(
+  q15_t * pSrcA,
+  q15_t * pSrcB,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q31 vector multiplication.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_mult_q31(
+  q31_t * pSrcA,
+  q31_t * pSrcB,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Floating-point vector multiplication.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_mult_f32(
+  float32_t * pSrcA,
+  float32_t * pSrcB,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+
+
+
+
+
+  /**
+   * @brief Instance structure for the Q15 CFFT/CIFFT function.
+   */
+
+  typedef struct
+  {
+    uint16_t fftLen;                 /**< length of the FFT. */
+    uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    q15_t *pTwiddle;                     /**< points to the Sin twiddle factor table. */
+    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+  } arm_cfft_radix2_instance_q15;
+
+/* Deprecated */
+  arm_status arm_cfft_radix2_init_q15(
+  arm_cfft_radix2_instance_q15 * S,
+  uint16_t fftLen,
+  uint8_t ifftFlag,
+  uint8_t bitReverseFlag);
+
+/* Deprecated */
+  void arm_cfft_radix2_q15(
+  const arm_cfft_radix2_instance_q15 * S,
+  q15_t * pSrc);
+
+
+
+  /**
+   * @brief Instance structure for the Q15 CFFT/CIFFT function.
+   */
+
+  typedef struct
+  {
+    uint16_t fftLen;                 /**< length of the FFT. */
+    uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    q15_t *pTwiddle;                 /**< points to the twiddle factor table. */
+    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+  } arm_cfft_radix4_instance_q15;
+
+/* Deprecated */
+  arm_status arm_cfft_radix4_init_q15(
+  arm_cfft_radix4_instance_q15 * S,
+  uint16_t fftLen,
+  uint8_t ifftFlag,
+  uint8_t bitReverseFlag);
+
+/* Deprecated */
+  void arm_cfft_radix4_q15(
+  const arm_cfft_radix4_instance_q15 * S,
+  q15_t * pSrc);
+
+  /**
+   * @brief Instance structure for the Radix-2 Q31 CFFT/CIFFT function.
+   */
+
+  typedef struct
+  {
+    uint16_t fftLen;                 /**< length of the FFT. */
+    uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    q31_t *pTwiddle;                     /**< points to the Twiddle factor table. */
+    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+  } arm_cfft_radix2_instance_q31;
+
+/* Deprecated */
+  arm_status arm_cfft_radix2_init_q31(
+  arm_cfft_radix2_instance_q31 * S,
+  uint16_t fftLen,
+  uint8_t ifftFlag,
+  uint8_t bitReverseFlag);
+
+/* Deprecated */
+  void arm_cfft_radix2_q31(
+  const arm_cfft_radix2_instance_q31 * S,
+  q31_t * pSrc);
+
+  /**
+   * @brief Instance structure for the Q31 CFFT/CIFFT function.
+   */
+
+  typedef struct
+  {
+    uint16_t fftLen;                 /**< length of the FFT. */
+    uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    q31_t *pTwiddle;                 /**< points to the twiddle factor table. */
+    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+  } arm_cfft_radix4_instance_q31;
+
+/* Deprecated */
+  void arm_cfft_radix4_q31(
+  const arm_cfft_radix4_instance_q31 * S,
+  q31_t * pSrc);
+
+/* Deprecated */
+  arm_status arm_cfft_radix4_init_q31(
+  arm_cfft_radix4_instance_q31 * S,
+  uint16_t fftLen,
+  uint8_t ifftFlag,
+  uint8_t bitReverseFlag);
+
+  /**
+   * @brief Instance structure for the floating-point CFFT/CIFFT function.
+   */
+
+  typedef struct
+  {
+    uint16_t fftLen;                   /**< length of the FFT. */
+    uint8_t ifftFlag;                  /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;            /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    float32_t *pTwiddle;               /**< points to the Twiddle factor table. */
+    uint16_t *pBitRevTable;            /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier;         /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;             /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+    float32_t onebyfftLen;                 /**< value of 1/fftLen. */
+  } arm_cfft_radix2_instance_f32;
+
+/* Deprecated */
+  arm_status arm_cfft_radix2_init_f32(
+  arm_cfft_radix2_instance_f32 * S,
+  uint16_t fftLen,
+  uint8_t ifftFlag,
+  uint8_t bitReverseFlag);
+
+/* Deprecated */
+  void arm_cfft_radix2_f32(
+  const arm_cfft_radix2_instance_f32 * S,
+  float32_t * pSrc);
+
+  /**
+   * @brief Instance structure for the floating-point CFFT/CIFFT function.
+   */
+
+  typedef struct
+  {
+    uint16_t fftLen;                   /**< length of the FFT. */
+    uint8_t ifftFlag;                  /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;            /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    float32_t *pTwiddle;               /**< points to the Twiddle factor table. */
+    uint16_t *pBitRevTable;            /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier;         /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;             /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+    float32_t onebyfftLen;                 /**< value of 1/fftLen. */
+  } arm_cfft_radix4_instance_f32;
+
+/* Deprecated */
+  arm_status arm_cfft_radix4_init_f32(
+  arm_cfft_radix4_instance_f32 * S,
+  uint16_t fftLen,
+  uint8_t ifftFlag,
+  uint8_t bitReverseFlag);
+
+/* Deprecated */
+  void arm_cfft_radix4_f32(
+  const arm_cfft_radix4_instance_f32 * S,
+  float32_t * pSrc);
+
+  /**
+   * @brief Instance structure for the fixed-point CFFT/CIFFT function.
+   */
+
+  typedef struct
+  {
+    uint16_t fftLen;                   /**< length of the FFT. */
+    const q15_t *pTwiddle;             /**< points to the Twiddle factor table. */
+    const uint16_t *pBitRevTable;      /**< points to the bit reversal table. */
+    uint16_t bitRevLength;             /**< bit reversal table length. */
+  } arm_cfft_instance_q15;
+
+void arm_cfft_q15( 
+    const arm_cfft_instance_q15 * S, 
+    q15_t * p1,
+    uint8_t ifftFlag,
+    uint8_t bitReverseFlag);  
+
+  /**
+   * @brief Instance structure for the fixed-point CFFT/CIFFT function.
+   */
+
+  typedef struct
+  {
+    uint16_t fftLen;                   /**< length of the FFT. */
+    const q31_t *pTwiddle;             /**< points to the Twiddle factor table. */
+    const uint16_t *pBitRevTable;      /**< points to the bit reversal table. */
+    uint16_t bitRevLength;             /**< bit reversal table length. */
+  } arm_cfft_instance_q31;
+
+void arm_cfft_q31( 
+    const arm_cfft_instance_q31 * S, 
+    q31_t * p1,
+    uint8_t ifftFlag,
+    uint8_t bitReverseFlag);  
+  
+  /**
+   * @brief Instance structure for the floating-point CFFT/CIFFT function.
+   */
+
+  typedef struct
+  {
+    uint16_t fftLen;                   /**< length of the FFT. */
+    const float32_t *pTwiddle;         /**< points to the Twiddle factor table. */
+    const uint16_t *pBitRevTable;      /**< points to the bit reversal table. */
+    uint16_t bitRevLength;             /**< bit reversal table length. */
+  } arm_cfft_instance_f32;
+
+  void arm_cfft_f32(
+  const arm_cfft_instance_f32 * S,
+  float32_t * p1,
+  uint8_t ifftFlag,
+  uint8_t bitReverseFlag);
+
+  /**
+   * @brief Instance structure for the Q15 RFFT/RIFFT function.
+   */
+
+  typedef struct
+  {
+    uint32_t fftLenReal;                      /**< length of the real FFT. */
+    uint8_t ifftFlagR;                        /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
+    uint8_t bitReverseFlagR;                  /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
+    uint32_t twidCoefRModifier;               /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    q15_t *pTwiddleAReal;                     /**< points to the real twiddle factor table. */
+    q15_t *pTwiddleBReal;                     /**< points to the imag twiddle factor table. */
+    const arm_cfft_instance_q15 *pCfft;       /**< points to the complex FFT instance. */
+  } arm_rfft_instance_q15;
+
+  arm_status arm_rfft_init_q15(
+  arm_rfft_instance_q15 * S,
+  uint32_t fftLenReal,
+  uint32_t ifftFlagR,
+  uint32_t bitReverseFlag);
+
+  void arm_rfft_q15(
+  const arm_rfft_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst);
+
+  /**
+   * @brief Instance structure for the Q31 RFFT/RIFFT function.
+   */
+
+  typedef struct
+  {
+    uint32_t fftLenReal;                        /**< length of the real FFT. */
+    uint8_t ifftFlagR;                          /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
+    uint8_t bitReverseFlagR;                    /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
+    uint32_t twidCoefRModifier;                 /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    q31_t *pTwiddleAReal;                       /**< points to the real twiddle factor table. */
+    q31_t *pTwiddleBReal;                       /**< points to the imag twiddle factor table. */
+    const arm_cfft_instance_q31 *pCfft;         /**< points to the complex FFT instance. */
+  } arm_rfft_instance_q31;
+
+  arm_status arm_rfft_init_q31(
+  arm_rfft_instance_q31 * S,
+  uint32_t fftLenReal,
+  uint32_t ifftFlagR,
+  uint32_t bitReverseFlag);
+
+  void arm_rfft_q31(
+  const arm_rfft_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst);
+
+  /**
+   * @brief Instance structure for the floating-point RFFT/RIFFT function.
+   */
+
+  typedef struct
+  {
+    uint32_t fftLenReal;                        /**< length of the real FFT. */
+    uint16_t fftLenBy2;                         /**< length of the complex FFT. */
+    uint8_t ifftFlagR;                          /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
+    uint8_t bitReverseFlagR;                    /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
+    uint32_t twidCoefRModifier;                     /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    float32_t *pTwiddleAReal;                   /**< points to the real twiddle factor table. */
+    float32_t *pTwiddleBReal;                   /**< points to the imag twiddle factor table. */
+    arm_cfft_radix4_instance_f32 *pCfft;        /**< points to the complex FFT instance. */
+  } arm_rfft_instance_f32;
+
+  arm_status arm_rfft_init_f32(
+  arm_rfft_instance_f32 * S,
+  arm_cfft_radix4_instance_f32 * S_CFFT,
+  uint32_t fftLenReal,
+  uint32_t ifftFlagR,
+  uint32_t bitReverseFlag);
+
+  void arm_rfft_f32(
+  const arm_rfft_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pDst);
+
+  /**
+   * @brief Instance structure for the floating-point RFFT/RIFFT function.
+   */
+
+typedef struct
+  {
+    arm_cfft_instance_f32 Sint;      /**< Internal CFFT structure. */
+    uint16_t fftLenRFFT;                        /**< length of the real sequence */
+	float32_t * pTwiddleRFFT;					/**< Twiddle factors real stage  */
+  } arm_rfft_fast_instance_f32 ;
+
+arm_status arm_rfft_fast_init_f32 (
+	arm_rfft_fast_instance_f32 * S,
+	uint16_t fftLen);
+
+void arm_rfft_fast_f32(
+  arm_rfft_fast_instance_f32 * S,
+  float32_t * p, float32_t * pOut,
+  uint8_t ifftFlag);
+
+  /**
+   * @brief Instance structure for the floating-point DCT4/IDCT4 function.
+   */
+
+  typedef struct
+  {
+    uint16_t N;                         /**< length of the DCT4. */
+    uint16_t Nby2;                      /**< half of the length of the DCT4. */
+    float32_t normalize;                /**< normalizing factor. */
+    float32_t *pTwiddle;                /**< points to the twiddle factor table. */
+    float32_t *pCosFactor;              /**< points to the cosFactor table. */
+    arm_rfft_instance_f32 *pRfft;        /**< points to the real FFT instance. */
+    arm_cfft_radix4_instance_f32 *pCfft; /**< points to the complex FFT instance. */
+  } arm_dct4_instance_f32;
+
+  /**
+   * @brief  Initialization function for the floating-point DCT4/IDCT4.
+   * @param[in,out] *S         points to an instance of floating-point DCT4/IDCT4 structure.
+   * @param[in]     *S_RFFT    points to an instance of floating-point RFFT/RIFFT structure.
+   * @param[in]     *S_CFFT    points to an instance of floating-point CFFT/CIFFT structure.
+   * @param[in]     N          length of the DCT4.
+   * @param[in]     Nby2       half of the length of the DCT4.
+   * @param[in]     normalize  normalizing factor.
+   * @return		arm_status function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if <code>fftLenReal</code> is not a supported transform length.
+   */
+
+  arm_status arm_dct4_init_f32(
+  arm_dct4_instance_f32 * S,
+  arm_rfft_instance_f32 * S_RFFT,
+  arm_cfft_radix4_instance_f32 * S_CFFT,
+  uint16_t N,
+  uint16_t Nby2,
+  float32_t normalize);
+
+  /**
+   * @brief Processing function for the floating-point DCT4/IDCT4.
+   * @param[in]       *S             points to an instance of the floating-point DCT4/IDCT4 structure.
+   * @param[in]       *pState        points to state buffer.
+   * @param[in,out]   *pInlineBuffer points to the in-place input and output buffer.
+   * @return none.
+   */
+
+  void arm_dct4_f32(
+  const arm_dct4_instance_f32 * S,
+  float32_t * pState,
+  float32_t * pInlineBuffer);
+
+  /**
+   * @brief Instance structure for the Q31 DCT4/IDCT4 function.
+   */
+
+  typedef struct
+  {
+    uint16_t N;                         /**< length of the DCT4. */
+    uint16_t Nby2;                      /**< half of the length of the DCT4. */
+    q31_t normalize;                    /**< normalizing factor. */
+    q31_t *pTwiddle;                    /**< points to the twiddle factor table. */
+    q31_t *pCosFactor;                  /**< points to the cosFactor table. */
+    arm_rfft_instance_q31 *pRfft;        /**< points to the real FFT instance. */
+    arm_cfft_radix4_instance_q31 *pCfft; /**< points to the complex FFT instance. */
+  } arm_dct4_instance_q31;
+
+  /**
+   * @brief  Initialization function for the Q31 DCT4/IDCT4.
+   * @param[in,out] *S         points to an instance of Q31 DCT4/IDCT4 structure.
+   * @param[in]     *S_RFFT    points to an instance of Q31 RFFT/RIFFT structure
+   * @param[in]     *S_CFFT    points to an instance of Q31 CFFT/CIFFT structure
+   * @param[in]     N          length of the DCT4.
+   * @param[in]     Nby2       half of the length of the DCT4.
+   * @param[in]     normalize  normalizing factor.
+   * @return		arm_status function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if <code>N</code> is not a supported transform length.
+   */
+
+  arm_status arm_dct4_init_q31(
+  arm_dct4_instance_q31 * S,
+  arm_rfft_instance_q31 * S_RFFT,
+  arm_cfft_radix4_instance_q31 * S_CFFT,
+  uint16_t N,
+  uint16_t Nby2,
+  q31_t normalize);
+
+  /**
+   * @brief Processing function for the Q31 DCT4/IDCT4.
+   * @param[in]       *S             points to an instance of the Q31 DCT4 structure.
+   * @param[in]       *pState        points to state buffer.
+   * @param[in,out]   *pInlineBuffer points to the in-place input and output buffer.
+   * @return none.
+   */
+
+  void arm_dct4_q31(
+  const arm_dct4_instance_q31 * S,
+  q31_t * pState,
+  q31_t * pInlineBuffer);
+
+  /**
+   * @brief Instance structure for the Q15 DCT4/IDCT4 function.
+   */
+
+  typedef struct
+  {
+    uint16_t N;                         /**< length of the DCT4. */
+    uint16_t Nby2;                      /**< half of the length of the DCT4. */
+    q15_t normalize;                    /**< normalizing factor. */
+    q15_t *pTwiddle;                    /**< points to the twiddle factor table. */
+    q15_t *pCosFactor;                  /**< points to the cosFactor table. */
+    arm_rfft_instance_q15 *pRfft;        /**< points to the real FFT instance. */
+    arm_cfft_radix4_instance_q15 *pCfft; /**< points to the complex FFT instance. */
+  } arm_dct4_instance_q15;
+
+  /**
+   * @brief  Initialization function for the Q15 DCT4/IDCT4.
+   * @param[in,out] *S         points to an instance of Q15 DCT4/IDCT4 structure.
+   * @param[in]     *S_RFFT    points to an instance of Q15 RFFT/RIFFT structure.
+   * @param[in]     *S_CFFT    points to an instance of Q15 CFFT/CIFFT structure.
+   * @param[in]     N          length of the DCT4.
+   * @param[in]     Nby2       half of the length of the DCT4.
+   * @param[in]     normalize  normalizing factor.
+   * @return		arm_status function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if <code>N</code> is not a supported transform length.
+   */
+
+  arm_status arm_dct4_init_q15(
+  arm_dct4_instance_q15 * S,
+  arm_rfft_instance_q15 * S_RFFT,
+  arm_cfft_radix4_instance_q15 * S_CFFT,
+  uint16_t N,
+  uint16_t Nby2,
+  q15_t normalize);
+
+  /**
+   * @brief Processing function for the Q15 DCT4/IDCT4.
+   * @param[in]       *S             points to an instance of the Q15 DCT4 structure.
+   * @param[in]       *pState        points to state buffer.
+   * @param[in,out]   *pInlineBuffer points to the in-place input and output buffer.
+   * @return none.
+   */
+
+  void arm_dct4_q15(
+  const arm_dct4_instance_q15 * S,
+  q15_t * pState,
+  q15_t * pInlineBuffer);
+
+  /**
+   * @brief Floating-point vector addition.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_add_f32(
+  float32_t * pSrcA,
+  float32_t * pSrcB,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q7 vector addition.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_add_q7(
+  q7_t * pSrcA,
+  q7_t * pSrcB,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q15 vector addition.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_add_q15(
+  q15_t * pSrcA,
+  q15_t * pSrcB,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q31 vector addition.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_add_q31(
+  q31_t * pSrcA,
+  q31_t * pSrcB,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Floating-point vector subtraction.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_sub_f32(
+  float32_t * pSrcA,
+  float32_t * pSrcB,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q7 vector subtraction.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_sub_q7(
+  q7_t * pSrcA,
+  q7_t * pSrcB,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q15 vector subtraction.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_sub_q15(
+  q15_t * pSrcA,
+  q15_t * pSrcB,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q31 vector subtraction.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_sub_q31(
+  q31_t * pSrcA,
+  q31_t * pSrcB,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Multiplies a floating-point vector by a scalar.
+   * @param[in]       *pSrc points to the input vector
+   * @param[in]       scale scale factor to be applied
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_scale_f32(
+  float32_t * pSrc,
+  float32_t scale,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Multiplies a Q7 vector by a scalar.
+   * @param[in]       *pSrc points to the input vector
+   * @param[in]       scaleFract fractional portion of the scale value
+   * @param[in]       shift number of bits to shift the result by
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_scale_q7(
+  q7_t * pSrc,
+  q7_t scaleFract,
+  int8_t shift,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Multiplies a Q15 vector by a scalar.
+   * @param[in]       *pSrc points to the input vector
+   * @param[in]       scaleFract fractional portion of the scale value
+   * @param[in]       shift number of bits to shift the result by
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_scale_q15(
+  q15_t * pSrc,
+  q15_t scaleFract,
+  int8_t shift,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Multiplies a Q31 vector by a scalar.
+   * @param[in]       *pSrc points to the input vector
+   * @param[in]       scaleFract fractional portion of the scale value
+   * @param[in]       shift number of bits to shift the result by
+   * @param[out]      *pDst points to the output vector
+   * @param[in]       blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_scale_q31(
+  q31_t * pSrc,
+  q31_t scaleFract,
+  int8_t shift,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q7 vector absolute value.
+   * @param[in]       *pSrc points to the input buffer
+   * @param[out]      *pDst points to the output buffer
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_abs_q7(
+  q7_t * pSrc,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Floating-point vector absolute value.
+   * @param[in]       *pSrc points to the input buffer
+   * @param[out]      *pDst points to the output buffer
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_abs_f32(
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q15 vector absolute value.
+   * @param[in]       *pSrc points to the input buffer
+   * @param[out]      *pDst points to the output buffer
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_abs_q15(
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Q31 vector absolute value.
+   * @param[in]       *pSrc points to the input buffer
+   * @param[out]      *pDst points to the output buffer
+   * @param[in]       blockSize number of samples in each vector
+   * @return none.
+   */
+
+  void arm_abs_q31(
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Dot product of floating-point vectors.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[in]       blockSize number of samples in each vector
+   * @param[out]      *result output result returned here
+   * @return none.
+   */
+
+  void arm_dot_prod_f32(
+  float32_t * pSrcA,
+  float32_t * pSrcB,
+  uint32_t blockSize,
+  float32_t * result);
+
+  /**
+   * @brief Dot product of Q7 vectors.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[in]       blockSize number of samples in each vector
+   * @param[out]      *result output result returned here
+   * @return none.
+   */
+
+  void arm_dot_prod_q7(
+  q7_t * pSrcA,
+  q7_t * pSrcB,
+  uint32_t blockSize,
+  q31_t * result);
+
+  /**
+   * @brief Dot product of Q15 vectors.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[in]       blockSize number of samples in each vector
+   * @param[out]      *result output result returned here
+   * @return none.
+   */
+
+  void arm_dot_prod_q15(
+  q15_t * pSrcA,
+  q15_t * pSrcB,
+  uint32_t blockSize,
+  q63_t * result);
+
+  /**
+   * @brief Dot product of Q31 vectors.
+   * @param[in]       *pSrcA points to the first input vector
+   * @param[in]       *pSrcB points to the second input vector
+   * @param[in]       blockSize number of samples in each vector
+   * @param[out]      *result output result returned here
+   * @return none.
+   */
+
+  void arm_dot_prod_q31(
+  q31_t * pSrcA,
+  q31_t * pSrcB,
+  uint32_t blockSize,
+  q63_t * result);
+
+  /**
+   * @brief  Shifts the elements of a Q7 vector a specified number of bits.
+   * @param[in]  *pSrc points to the input vector
+   * @param[in]  shiftBits number of bits to shift.  A positive value shifts left; a negative value shifts right.
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_shift_q7(
+  q7_t * pSrc,
+  int8_t shiftBits,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Shifts the elements of a Q15 vector a specified number of bits.
+   * @param[in]  *pSrc points to the input vector
+   * @param[in]  shiftBits number of bits to shift.  A positive value shifts left; a negative value shifts right.
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_shift_q15(
+  q15_t * pSrc,
+  int8_t shiftBits,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Shifts the elements of a Q31 vector a specified number of bits.
+   * @param[in]  *pSrc points to the input vector
+   * @param[in]  shiftBits number of bits to shift.  A positive value shifts left; a negative value shifts right.
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_shift_q31(
+  q31_t * pSrc,
+  int8_t shiftBits,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Adds a constant offset to a floating-point vector.
+   * @param[in]  *pSrc points to the input vector
+   * @param[in]  offset is the offset to be added
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_offset_f32(
+  float32_t * pSrc,
+  float32_t offset,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Adds a constant offset to a Q7 vector.
+   * @param[in]  *pSrc points to the input vector
+   * @param[in]  offset is the offset to be added
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_offset_q7(
+  q7_t * pSrc,
+  q7_t offset,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Adds a constant offset to a Q15 vector.
+   * @param[in]  *pSrc points to the input vector
+   * @param[in]  offset is the offset to be added
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_offset_q15(
+  q15_t * pSrc,
+  q15_t offset,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Adds a constant offset to a Q31 vector.
+   * @param[in]  *pSrc points to the input vector
+   * @param[in]  offset is the offset to be added
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_offset_q31(
+  q31_t * pSrc,
+  q31_t offset,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Negates the elements of a floating-point vector.
+   * @param[in]  *pSrc points to the input vector
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_negate_f32(
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Negates the elements of a Q7 vector.
+   * @param[in]  *pSrc points to the input vector
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_negate_q7(
+  q7_t * pSrc,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Negates the elements of a Q15 vector.
+   * @param[in]  *pSrc points to the input vector
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_negate_q15(
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Negates the elements of a Q31 vector.
+   * @param[in]  *pSrc points to the input vector
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  blockSize number of samples in the vector
+   * @return none.
+   */
+
+  void arm_negate_q31(
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+  /**
+   * @brief  Copies the elements of a floating-point vector.
+   * @param[in]  *pSrc input pointer
+   * @param[out]  *pDst output pointer
+   * @param[in]  blockSize number of samples to process
+   * @return none.
+   */
+  void arm_copy_f32(
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Copies the elements of a Q7 vector.
+   * @param[in]  *pSrc input pointer
+   * @param[out]  *pDst output pointer
+   * @param[in]  blockSize number of samples to process
+   * @return none.
+   */
+  void arm_copy_q7(
+  q7_t * pSrc,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Copies the elements of a Q15 vector.
+   * @param[in]  *pSrc input pointer
+   * @param[out]  *pDst output pointer
+   * @param[in]  blockSize number of samples to process
+   * @return none.
+   */
+  void arm_copy_q15(
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Copies the elements of a Q31 vector.
+   * @param[in]  *pSrc input pointer
+   * @param[out]  *pDst output pointer
+   * @param[in]  blockSize number of samples to process
+   * @return none.
+   */
+  void arm_copy_q31(
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+  /**
+   * @brief  Fills a constant value into a floating-point vector.
+   * @param[in]  value input value to be filled
+   * @param[out]  *pDst output pointer
+   * @param[in]  blockSize number of samples to process
+   * @return none.
+   */
+  void arm_fill_f32(
+  float32_t value,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Fills a constant value into a Q7 vector.
+   * @param[in]  value input value to be filled
+   * @param[out]  *pDst output pointer
+   * @param[in]  blockSize number of samples to process
+   * @return none.
+   */
+  void arm_fill_q7(
+  q7_t value,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Fills a constant value into a Q15 vector.
+   * @param[in]  value input value to be filled
+   * @param[out]  *pDst output pointer
+   * @param[in]  blockSize number of samples to process
+   * @return none.
+   */
+  void arm_fill_q15(
+  q15_t value,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Fills a constant value into a Q31 vector.
+   * @param[in]  value input value to be filled
+   * @param[out]  *pDst output pointer
+   * @param[in]  blockSize number of samples to process
+   * @return none.
+   */
+  void arm_fill_q31(
+  q31_t value,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+/**
+ * @brief Convolution of floating-point sequences.
+ * @param[in] *pSrcA points to the first input sequence.
+ * @param[in] srcALen length of the first input sequence.
+ * @param[in] *pSrcB points to the second input sequence.
+ * @param[in] srcBLen length of the second input sequence.
+ * @param[out] *pDst points to the location where the output result is written.  Length srcALen+srcBLen-1.
+ * @return none.
+ */
+
+  void arm_conv_f32(
+  float32_t * pSrcA,
+  uint32_t srcALen,
+  float32_t * pSrcB,
+  uint32_t srcBLen,
+  float32_t * pDst);
+
+
+  /**
+   * @brief Convolution of Q15 sequences.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length srcALen+srcBLen-1.
+   * @param[in]  *pScratch1 points to scratch buffer of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
+   * @param[in]  *pScratch2 points to scratch buffer of size min(srcALen, srcBLen).
+   * @return none.
+   */
+
+
+  void arm_conv_opt_q15(
+  q15_t * pSrcA,
+  uint32_t srcALen,
+  q15_t * pSrcB,
+  uint32_t srcBLen,
+  q15_t * pDst,
+  q15_t * pScratch1,
+  q15_t * pScratch2);
+
+
+/**
+ * @brief Convolution of Q15 sequences.
+ * @param[in] *pSrcA points to the first input sequence.
+ * @param[in] srcALen length of the first input sequence.
+ * @param[in] *pSrcB points to the second input sequence.
+ * @param[in] srcBLen length of the second input sequence.
+ * @param[out] *pDst points to the location where the output result is written.  Length srcALen+srcBLen-1.
+ * @return none.
+ */
+
+  void arm_conv_q15(
+  q15_t * pSrcA,
+  uint32_t srcALen,
+  q15_t * pSrcB,
+  uint32_t srcBLen,
+  q15_t * pDst);
+
+  /**
+   * @brief Convolution of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length srcALen+srcBLen-1.
+   * @return none.
+   */
+
+  void arm_conv_fast_q15(
+			  q15_t * pSrcA,
+			 uint32_t srcALen,
+			  q15_t * pSrcB,
+			 uint32_t srcBLen,
+			 q15_t * pDst);
+
+  /**
+   * @brief Convolution of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length srcALen+srcBLen-1.
+   * @param[in]  *pScratch1 points to scratch buffer of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
+   * @param[in]  *pScratch2 points to scratch buffer of size min(srcALen, srcBLen).
+   * @return none.
+   */
+
+  void arm_conv_fast_opt_q15(
+  q15_t * pSrcA,
+  uint32_t srcALen,
+  q15_t * pSrcB,
+  uint32_t srcBLen,
+  q15_t * pDst,
+  q15_t * pScratch1,
+  q15_t * pScratch2);
+
+
+
+  /**
+   * @brief Convolution of Q31 sequences.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length srcALen+srcBLen-1.
+   * @return none.
+   */
+
+  void arm_conv_q31(
+  q31_t * pSrcA,
+  uint32_t srcALen,
+  q31_t * pSrcB,
+  uint32_t srcBLen,
+  q31_t * pDst);
+
+  /**
+   * @brief Convolution of Q31 sequences (fast version) for Cortex-M3 and Cortex-M4
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length srcALen+srcBLen-1.
+   * @return none.
+   */
+
+  void arm_conv_fast_q31(
+  q31_t * pSrcA,
+  uint32_t srcALen,
+  q31_t * pSrcB,
+  uint32_t srcBLen,
+  q31_t * pDst);
+
+
+    /**
+   * @brief Convolution of Q7 sequences.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length srcALen+srcBLen-1.
+   * @param[in]  *pScratch1 points to scratch buffer(of type q15_t) of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
+   * @param[in]  *pScratch2 points to scratch buffer (of type q15_t) of size min(srcALen, srcBLen).
+   * @return none.
+   */
+
+  void arm_conv_opt_q7(
+  q7_t * pSrcA,
+  uint32_t srcALen,
+  q7_t * pSrcB,
+  uint32_t srcBLen,
+  q7_t * pDst,
+  q15_t * pScratch1,
+  q15_t * pScratch2);
+
+
+
+  /**
+   * @brief Convolution of Q7 sequences.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length srcALen+srcBLen-1.
+   * @return none.
+   */
+
+  void arm_conv_q7(
+  q7_t * pSrcA,
+  uint32_t srcALen,
+  q7_t * pSrcB,
+  uint32_t srcBLen,
+  q7_t * pDst);
+
+
+  /**
+   * @brief Partial convolution of floating-point sequences.
+   * @param[in]       *pSrcA points to the first input sequence.
+   * @param[in]       srcALen length of the first input sequence.
+   * @param[in]       *pSrcB points to the second input sequence.
+   * @param[in]       srcBLen length of the second input sequence.
+   * @param[out]      *pDst points to the block of output data
+   * @param[in]       firstIndex is the first output sample to start with.
+   * @param[in]       numPoints is the number of output points to be computed.
+   * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
+   */
+
+  arm_status arm_conv_partial_f32(
+  float32_t * pSrcA,
+  uint32_t srcALen,
+  float32_t * pSrcB,
+  uint32_t srcBLen,
+  float32_t * pDst,
+  uint32_t firstIndex,
+  uint32_t numPoints);
+
+    /**
+   * @brief Partial convolution of Q15 sequences.
+   * @param[in]       *pSrcA points to the first input sequence.
+   * @param[in]       srcALen length of the first input sequence.
+   * @param[in]       *pSrcB points to the second input sequence.
+   * @param[in]       srcBLen length of the second input sequence.
+   * @param[out]      *pDst points to the block of output data
+   * @param[in]       firstIndex is the first output sample to start with.
+   * @param[in]       numPoints is the number of output points to be computed.
+   * @param[in]       * pScratch1 points to scratch buffer of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
+   * @param[in]       * pScratch2 points to scratch buffer of size min(srcALen, srcBLen).
+   * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
+   */
+
+  arm_status arm_conv_partial_opt_q15(
+  q15_t * pSrcA,
+  uint32_t srcALen,
+  q15_t * pSrcB,
+  uint32_t srcBLen,
+  q15_t * pDst,
+  uint32_t firstIndex,
+  uint32_t numPoints,
+  q15_t * pScratch1,
+  q15_t * pScratch2);
+
+
+/**
+   * @brief Partial convolution of Q15 sequences.
+   * @param[in]       *pSrcA points to the first input sequence.
+   * @param[in]       srcALen length of the first input sequence.
+   * @param[in]       *pSrcB points to the second input sequence.
+   * @param[in]       srcBLen length of the second input sequence.
+   * @param[out]      *pDst points to the block of output data
+   * @param[in]       firstIndex is the first output sample to start with.
+   * @param[in]       numPoints is the number of output points to be computed.
+   * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
+   */
+
+  arm_status arm_conv_partial_q15(
+  q15_t * pSrcA,
+  uint32_t srcALen,
+  q15_t * pSrcB,
+  uint32_t srcBLen,
+  q15_t * pDst,
+  uint32_t firstIndex,
+  uint32_t numPoints);
+
+  /**
+   * @brief Partial convolution of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4
+   * @param[in]       *pSrcA points to the first input sequence.
+   * @param[in]       srcALen length of the first input sequence.
+   * @param[in]       *pSrcB points to the second input sequence.
+   * @param[in]       srcBLen length of the second input sequence.
+   * @param[out]      *pDst points to the block of output data
+   * @param[in]       firstIndex is the first output sample to start with.
+   * @param[in]       numPoints is the number of output points to be computed.
+   * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
+   */
+
+  arm_status arm_conv_partial_fast_q15(
+				        q15_t * pSrcA,
+				       uint32_t srcALen,
+				        q15_t * pSrcB,
+				       uint32_t srcBLen,
+				       q15_t * pDst,
+				       uint32_t firstIndex,
+				       uint32_t numPoints);
+
+
+  /**
+   * @brief Partial convolution of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4
+   * @param[in]       *pSrcA points to the first input sequence.
+   * @param[in]       srcALen length of the first input sequence.
+   * @param[in]       *pSrcB points to the second input sequence.
+   * @param[in]       srcBLen length of the second input sequence.
+   * @param[out]      *pDst points to the block of output data
+   * @param[in]       firstIndex is the first output sample to start with.
+   * @param[in]       numPoints is the number of output points to be computed.
+   * @param[in]       * pScratch1 points to scratch buffer of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
+   * @param[in]       * pScratch2 points to scratch buffer of size min(srcALen, srcBLen).
+   * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
+   */
+
+  arm_status arm_conv_partial_fast_opt_q15(
+  q15_t * pSrcA,
+  uint32_t srcALen,
+  q15_t * pSrcB,
+  uint32_t srcBLen,
+  q15_t * pDst,
+  uint32_t firstIndex,
+  uint32_t numPoints,
+  q15_t * pScratch1,
+  q15_t * pScratch2);
+
+
+  /**
+   * @brief Partial convolution of Q31 sequences.
+   * @param[in]       *pSrcA points to the first input sequence.
+   * @param[in]       srcALen length of the first input sequence.
+   * @param[in]       *pSrcB points to the second input sequence.
+   * @param[in]       srcBLen length of the second input sequence.
+   * @param[out]      *pDst points to the block of output data
+   * @param[in]       firstIndex is the first output sample to start with.
+   * @param[in]       numPoints is the number of output points to be computed.
+   * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
+   */
+
+  arm_status arm_conv_partial_q31(
+  q31_t * pSrcA,
+  uint32_t srcALen,
+  q31_t * pSrcB,
+  uint32_t srcBLen,
+  q31_t * pDst,
+  uint32_t firstIndex,
+  uint32_t numPoints);
+
+
+  /**
+   * @brief Partial convolution of Q31 sequences (fast version) for Cortex-M3 and Cortex-M4
+   * @param[in]       *pSrcA points to the first input sequence.
+   * @param[in]       srcALen length of the first input sequence.
+   * @param[in]       *pSrcB points to the second input sequence.
+   * @param[in]       srcBLen length of the second input sequence.
+   * @param[out]      *pDst points to the block of output data
+   * @param[in]       firstIndex is the first output sample to start with.
+   * @param[in]       numPoints is the number of output points to be computed.
+   * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
+   */
+
+  arm_status arm_conv_partial_fast_q31(
+  q31_t * pSrcA,
+  uint32_t srcALen,
+  q31_t * pSrcB,
+  uint32_t srcBLen,
+  q31_t * pDst,
+  uint32_t firstIndex,
+  uint32_t numPoints);
+
+
+  /**
+   * @brief Partial convolution of Q7 sequences
+   * @param[in]       *pSrcA points to the first input sequence.
+   * @param[in]       srcALen length of the first input sequence.
+   * @param[in]       *pSrcB points to the second input sequence.
+   * @param[in]       srcBLen length of the second input sequence.
+   * @param[out]      *pDst points to the block of output data
+   * @param[in]       firstIndex is the first output sample to start with.
+   * @param[in]       numPoints is the number of output points to be computed.
+   * @param[in]  *pScratch1 points to scratch buffer(of type q15_t) of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
+   * @param[in]  *pScratch2 points to scratch buffer (of type q15_t) of size min(srcALen, srcBLen).
+   * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
+   */
+
+  arm_status arm_conv_partial_opt_q7(
+  q7_t * pSrcA,
+  uint32_t srcALen,
+  q7_t * pSrcB,
+  uint32_t srcBLen,
+  q7_t * pDst,
+  uint32_t firstIndex,
+  uint32_t numPoints,
+  q15_t * pScratch1,
+  q15_t * pScratch2);
+
+
+/**
+   * @brief Partial convolution of Q7 sequences.
+   * @param[in]       *pSrcA points to the first input sequence.
+   * @param[in]       srcALen length of the first input sequence.
+   * @param[in]       *pSrcB points to the second input sequence.
+   * @param[in]       srcBLen length of the second input sequence.
+   * @param[out]      *pDst points to the block of output data
+   * @param[in]       firstIndex is the first output sample to start with.
+   * @param[in]       numPoints is the number of output points to be computed.
+   * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
+   */
+
+  arm_status arm_conv_partial_q7(
+  q7_t * pSrcA,
+  uint32_t srcALen,
+  q7_t * pSrcB,
+  uint32_t srcBLen,
+  q7_t * pDst,
+  uint32_t firstIndex,
+  uint32_t numPoints);
+
+
+
+  /**
+   * @brief Instance structure for the Q15 FIR decimator.
+   */
+
+  typedef struct
+  {
+    uint8_t M;                      /**< decimation factor. */
+    uint16_t numTaps;               /**< number of coefficients in the filter. */
+    q15_t *pCoeffs;                  /**< points to the coefficient array. The array is of length numTaps.*/
+    q15_t *pState;                   /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+  } arm_fir_decimate_instance_q15;
+
+  /**
+   * @brief Instance structure for the Q31 FIR decimator.
+   */
+
+  typedef struct
+  {
+    uint8_t M;                  /**< decimation factor. */
+    uint16_t numTaps;           /**< number of coefficients in the filter. */
+    q31_t *pCoeffs;              /**< points to the coefficient array. The array is of length numTaps.*/
+    q31_t *pState;               /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+
+  } arm_fir_decimate_instance_q31;
+
+  /**
+   * @brief Instance structure for the floating-point FIR decimator.
+   */
+
+  typedef struct
+  {
+    uint8_t M;                          /**< decimation factor. */
+    uint16_t numTaps;                   /**< number of coefficients in the filter. */
+    float32_t *pCoeffs;                  /**< points to the coefficient array. The array is of length numTaps.*/
+    float32_t *pState;                   /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+
+  } arm_fir_decimate_instance_f32;
+
+
+
+  /**
+   * @brief Processing function for the floating-point FIR decimator.
+   * @param[in] *S points to an instance of the floating-point FIR decimator structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data
+   * @param[in] blockSize number of input samples to process per call.
+   * @return none
+   */
+
+  void arm_fir_decimate_f32(
+  const arm_fir_decimate_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief  Initialization function for the floating-point FIR decimator.
+   * @param[in,out] *S points to an instance of the floating-point FIR decimator structure.
+   * @param[in] numTaps  number of coefficients in the filter.
+   * @param[in] M  decimation factor.
+   * @param[in] *pCoeffs points to the filter coefficients.
+   * @param[in] *pState points to the state buffer.
+   * @param[in] blockSize number of input samples to process per call.
+   * @return    The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_LENGTH_ERROR if
+   * <code>blockSize</code> is not a multiple of <code>M</code>.
+   */
+
+  arm_status arm_fir_decimate_init_f32(
+  arm_fir_decimate_instance_f32 * S,
+  uint16_t numTaps,
+  uint8_t M,
+  float32_t * pCoeffs,
+  float32_t * pState,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the Q15 FIR decimator.
+   * @param[in] *S points to an instance of the Q15 FIR decimator structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data
+   * @param[in] blockSize number of input samples to process per call.
+   * @return none
+   */
+
+  void arm_fir_decimate_q15(
+  const arm_fir_decimate_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the Q15 FIR decimator (fast variant) for Cortex-M3 and Cortex-M4.
+   * @param[in] *S points to an instance of the Q15 FIR decimator structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data
+   * @param[in] blockSize number of input samples to process per call.
+   * @return none
+   */
+
+  void arm_fir_decimate_fast_q15(
+  const arm_fir_decimate_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+
+
+  /**
+   * @brief  Initialization function for the Q15 FIR decimator.
+   * @param[in,out] *S points to an instance of the Q15 FIR decimator structure.
+   * @param[in] numTaps  number of coefficients in the filter.
+   * @param[in] M  decimation factor.
+   * @param[in] *pCoeffs points to the filter coefficients.
+   * @param[in] *pState points to the state buffer.
+   * @param[in] blockSize number of input samples to process per call.
+   * @return    The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_LENGTH_ERROR if
+   * <code>blockSize</code> is not a multiple of <code>M</code>.
+   */
+
+  arm_status arm_fir_decimate_init_q15(
+  arm_fir_decimate_instance_q15 * S,
+  uint16_t numTaps,
+  uint8_t M,
+  q15_t * pCoeffs,
+  q15_t * pState,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the Q31 FIR decimator.
+   * @param[in] *S points to an instance of the Q31 FIR decimator structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data
+   * @param[in] blockSize number of input samples to process per call.
+   * @return none
+   */
+
+  void arm_fir_decimate_q31(
+  const arm_fir_decimate_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the Q31 FIR decimator (fast variant) for Cortex-M3 and Cortex-M4.
+   * @param[in] *S points to an instance of the Q31 FIR decimator structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data
+   * @param[in] blockSize number of input samples to process per call.
+   * @return none
+   */
+
+  void arm_fir_decimate_fast_q31(
+  arm_fir_decimate_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief  Initialization function for the Q31 FIR decimator.
+   * @param[in,out] *S points to an instance of the Q31 FIR decimator structure.
+   * @param[in] numTaps  number of coefficients in the filter.
+   * @param[in] M  decimation factor.
+   * @param[in] *pCoeffs points to the filter coefficients.
+   * @param[in] *pState points to the state buffer.
+   * @param[in] blockSize number of input samples to process per call.
+   * @return    The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_LENGTH_ERROR if
+   * <code>blockSize</code> is not a multiple of <code>M</code>.
+   */
+
+  arm_status arm_fir_decimate_init_q31(
+  arm_fir_decimate_instance_q31 * S,
+  uint16_t numTaps,
+  uint8_t M,
+  q31_t * pCoeffs,
+  q31_t * pState,
+  uint32_t blockSize);
+
+
+
+  /**
+   * @brief Instance structure for the Q15 FIR interpolator.
+   */
+
+  typedef struct
+  {
+    uint8_t L;                      /**< upsample factor. */
+    uint16_t phaseLength;           /**< length of each polyphase filter component. */
+    q15_t *pCoeffs;                 /**< points to the coefficient array. The array is of length L*phaseLength. */
+    q15_t *pState;                  /**< points to the state variable array. The array is of length blockSize+phaseLength-1. */
+  } arm_fir_interpolate_instance_q15;
+
+  /**
+   * @brief Instance structure for the Q31 FIR interpolator.
+   */
+
+  typedef struct
+  {
+    uint8_t L;                      /**< upsample factor. */
+    uint16_t phaseLength;           /**< length of each polyphase filter component. */
+    q31_t *pCoeffs;                  /**< points to the coefficient array. The array is of length L*phaseLength. */
+    q31_t *pState;                   /**< points to the state variable array. The array is of length blockSize+phaseLength-1. */
+  } arm_fir_interpolate_instance_q31;
+
+  /**
+   * @brief Instance structure for the floating-point FIR interpolator.
+   */
+
+  typedef struct
+  {
+    uint8_t L;                     /**< upsample factor. */
+    uint16_t phaseLength;          /**< length of each polyphase filter component. */
+    float32_t *pCoeffs;             /**< points to the coefficient array. The array is of length L*phaseLength. */
+    float32_t *pState;              /**< points to the state variable array. The array is of length phaseLength+numTaps-1. */
+  } arm_fir_interpolate_instance_f32;
+
+
+  /**
+   * @brief Processing function for the Q15 FIR interpolator.
+   * @param[in] *S        points to an instance of the Q15 FIR interpolator structure.
+   * @param[in] *pSrc     points to the block of input data.
+   * @param[out] *pDst    points to the block of output data.
+   * @param[in] blockSize number of input samples to process per call.
+   * @return none.
+   */
+
+  void arm_fir_interpolate_q15(
+  const arm_fir_interpolate_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief  Initialization function for the Q15 FIR interpolator.
+   * @param[in,out] *S        points to an instance of the Q15 FIR interpolator structure.
+   * @param[in]     L         upsample factor.
+   * @param[in]     numTaps   number of filter coefficients in the filter.
+   * @param[in]     *pCoeffs  points to the filter coefficient buffer.
+   * @param[in]     *pState   points to the state buffer.
+   * @param[in]     blockSize number of input samples to process per call.
+   * @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_LENGTH_ERROR if
+   * the filter length <code>numTaps</code> is not a multiple of the interpolation factor <code>L</code>.
+   */
+
+  arm_status arm_fir_interpolate_init_q15(
+  arm_fir_interpolate_instance_q15 * S,
+  uint8_t L,
+  uint16_t numTaps,
+  q15_t * pCoeffs,
+  q15_t * pState,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the Q31 FIR interpolator.
+   * @param[in] *S        points to an instance of the Q15 FIR interpolator structure.
+   * @param[in] *pSrc     points to the block of input data.
+   * @param[out] *pDst    points to the block of output data.
+   * @param[in] blockSize number of input samples to process per call.
+   * @return none.
+   */
+
+  void arm_fir_interpolate_q31(
+  const arm_fir_interpolate_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the Q31 FIR interpolator.
+   * @param[in,out] *S        points to an instance of the Q31 FIR interpolator structure.
+   * @param[in]     L         upsample factor.
+   * @param[in]     numTaps   number of filter coefficients in the filter.
+   * @param[in]     *pCoeffs  points to the filter coefficient buffer.
+   * @param[in]     *pState   points to the state buffer.
+   * @param[in]     blockSize number of input samples to process per call.
+   * @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_LENGTH_ERROR if
+   * the filter length <code>numTaps</code> is not a multiple of the interpolation factor <code>L</code>.
+   */
+
+  arm_status arm_fir_interpolate_init_q31(
+  arm_fir_interpolate_instance_q31 * S,
+  uint8_t L,
+  uint16_t numTaps,
+  q31_t * pCoeffs,
+  q31_t * pState,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Processing function for the floating-point FIR interpolator.
+   * @param[in] *S        points to an instance of the floating-point FIR interpolator structure.
+   * @param[in] *pSrc     points to the block of input data.
+   * @param[out] *pDst    points to the block of output data.
+   * @param[in] blockSize number of input samples to process per call.
+   * @return none.
+   */
+
+  void arm_fir_interpolate_f32(
+  const arm_fir_interpolate_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the floating-point FIR interpolator.
+   * @param[in,out] *S        points to an instance of the floating-point FIR interpolator structure.
+   * @param[in]     L         upsample factor.
+   * @param[in]     numTaps   number of filter coefficients in the filter.
+   * @param[in]     *pCoeffs  points to the filter coefficient buffer.
+   * @param[in]     *pState   points to the state buffer.
+   * @param[in]     blockSize number of input samples to process per call.
+   * @return        The function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_LENGTH_ERROR if
+   * the filter length <code>numTaps</code> is not a multiple of the interpolation factor <code>L</code>.
+   */
+
+  arm_status arm_fir_interpolate_init_f32(
+  arm_fir_interpolate_instance_f32 * S,
+  uint8_t L,
+  uint16_t numTaps,
+  float32_t * pCoeffs,
+  float32_t * pState,
+  uint32_t blockSize);
+
+  /**
+   * @brief Instance structure for the high precision Q31 Biquad cascade filter.
+   */
+
+  typedef struct
+  {
+    uint8_t numStages;       /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    q63_t *pState;           /**< points to the array of state coefficients.  The array is of length 4*numStages. */
+    q31_t *pCoeffs;          /**< points to the array of coefficients.  The array is of length 5*numStages. */
+    uint8_t postShift;       /**< additional shift, in bits, applied to each output sample. */
+
+  } arm_biquad_cas_df1_32x64_ins_q31;
+
+
+  /**
+   * @param[in]  *S        points to an instance of the high precision Q31 Biquad cascade filter structure.
+   * @param[in]  *pSrc     points to the block of input data.
+   * @param[out] *pDst     points to the block of output data
+   * @param[in]  blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_biquad_cas_df1_32x64_q31(
+  const arm_biquad_cas_df1_32x64_ins_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @param[in,out] *S           points to an instance of the high precision Q31 Biquad cascade filter structure.
+   * @param[in]     numStages    number of 2nd order stages in the filter.
+   * @param[in]     *pCoeffs     points to the filter coefficients.
+   * @param[in]     *pState      points to the state buffer.
+   * @param[in]     postShift    shift to be applied to the output. Varies according to the coefficients format
+   * @return        none
+   */
+
+  void arm_biquad_cas_df1_32x64_init_q31(
+  arm_biquad_cas_df1_32x64_ins_q31 * S,
+  uint8_t numStages,
+  q31_t * pCoeffs,
+  q63_t * pState,
+  uint8_t postShift);
+
+
+
+  /**
+   * @brief Instance structure for the floating-point transposed direct form II Biquad cascade filter.
+   */
+
+  typedef struct
+  {
+    uint8_t numStages;         /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    float32_t *pState;         /**< points to the array of state coefficients.  The array is of length 2*numStages. */
+    float32_t *pCoeffs;        /**< points to the array of coefficients.  The array is of length 5*numStages. */
+  } arm_biquad_cascade_df2T_instance_f32;
+
+
+
+  /**
+   * @brief Instance structure for the floating-point transposed direct form II Biquad cascade filter.
+   */
+
+  typedef struct
+  {
+    uint8_t numStages;         /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    float32_t *pState;         /**< points to the array of state coefficients.  The array is of length 4*numStages. */
+    float32_t *pCoeffs;        /**< points to the array of coefficients.  The array is of length 5*numStages. */
+  } arm_biquad_cascade_stereo_df2T_instance_f32;
+
+
+
+  /**
+   * @brief Instance structure for the floating-point transposed direct form II Biquad cascade filter.
+   */
+
+  typedef struct
+  {
+    uint8_t numStages;         /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    float64_t *pState;         /**< points to the array of state coefficients.  The array is of length 2*numStages. */
+    float64_t *pCoeffs;        /**< points to the array of coefficients.  The array is of length 5*numStages. */
+  } arm_biquad_cascade_df2T_instance_f64;
+
+
+  /**
+   * @brief Processing function for the floating-point transposed direct form II Biquad cascade filter.
+   * @param[in]  *S        points to an instance of the filter data structure.
+   * @param[in]  *pSrc     points to the block of input data.
+   * @param[out] *pDst     points to the block of output data
+   * @param[in]  blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_biquad_cascade_df2T_f32(
+  const arm_biquad_cascade_df2T_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Processing function for the floating-point transposed direct form II Biquad cascade filter. 2 channels
+   * @param[in]  *S        points to an instance of the filter data structure.
+   * @param[in]  *pSrc     points to the block of input data.
+   * @param[out] *pDst     points to the block of output data
+   * @param[in]  blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_biquad_cascade_stereo_df2T_f32(
+  const arm_biquad_cascade_stereo_df2T_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the floating-point transposed direct form II Biquad cascade filter.
+   * @param[in]  *S        points to an instance of the filter data structure.
+   * @param[in]  *pSrc     points to the block of input data.
+   * @param[out] *pDst     points to the block of output data
+   * @param[in]  blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_biquad_cascade_df2T_f64(
+  const arm_biquad_cascade_df2T_instance_f64 * S,
+  float64_t * pSrc,
+  float64_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief  Initialization function for the floating-point transposed direct form II Biquad cascade filter.
+   * @param[in,out] *S           points to an instance of the filter data structure.
+   * @param[in]     numStages    number of 2nd order stages in the filter.
+   * @param[in]     *pCoeffs     points to the filter coefficients.
+   * @param[in]     *pState      points to the state buffer.
+   * @return        none
+   */
+
+  void arm_biquad_cascade_df2T_init_f32(
+  arm_biquad_cascade_df2T_instance_f32 * S,
+  uint8_t numStages,
+  float32_t * pCoeffs,
+  float32_t * pState);
+
+
+  /**
+   * @brief  Initialization function for the floating-point transposed direct form II Biquad cascade filter.
+   * @param[in,out] *S           points to an instance of the filter data structure.
+   * @param[in]     numStages    number of 2nd order stages in the filter.
+   * @param[in]     *pCoeffs     points to the filter coefficients.
+   * @param[in]     *pState      points to the state buffer.
+   * @return        none
+   */
+
+  void arm_biquad_cascade_stereo_df2T_init_f32(
+  arm_biquad_cascade_stereo_df2T_instance_f32 * S,
+  uint8_t numStages,
+  float32_t * pCoeffs,
+  float32_t * pState);
+
+
+  /**
+   * @brief  Initialization function for the floating-point transposed direct form II Biquad cascade filter.
+   * @param[in,out] *S           points to an instance of the filter data structure.
+   * @param[in]     numStages    number of 2nd order stages in the filter.
+   * @param[in]     *pCoeffs     points to the filter coefficients.
+   * @param[in]     *pState      points to the state buffer.
+   * @return        none
+   */
+
+  void arm_biquad_cascade_df2T_init_f64(
+  arm_biquad_cascade_df2T_instance_f64 * S,
+  uint8_t numStages,
+  float64_t * pCoeffs,
+  float64_t * pState);
+
+
+
+  /**
+   * @brief Instance structure for the Q15 FIR lattice filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numStages;                          /**< number of filter stages. */
+    q15_t *pState;                               /**< points to the state variable array. The array is of length numStages. */
+    q15_t *pCoeffs;                              /**< points to the coefficient array. The array is of length numStages. */
+  } arm_fir_lattice_instance_q15;
+
+  /**
+   * @brief Instance structure for the Q31 FIR lattice filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numStages;                          /**< number of filter stages. */
+    q31_t *pState;                               /**< points to the state variable array. The array is of length numStages. */
+    q31_t *pCoeffs;                              /**< points to the coefficient array. The array is of length numStages. */
+  } arm_fir_lattice_instance_q31;
+
+  /**
+   * @brief Instance structure for the floating-point FIR lattice filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numStages;                  /**< number of filter stages. */
+    float32_t *pState;                   /**< points to the state variable array. The array is of length numStages. */
+    float32_t *pCoeffs;                  /**< points to the coefficient array. The array is of length numStages. */
+  } arm_fir_lattice_instance_f32;
+
+  /**
+   * @brief Initialization function for the Q15 FIR lattice filter.
+   * @param[in] *S points to an instance of the Q15 FIR lattice structure.
+   * @param[in] numStages  number of filter stages.
+   * @param[in] *pCoeffs points to the coefficient buffer.  The array is of length numStages.
+   * @param[in] *pState points to the state buffer.  The array is of length numStages.
+   * @return none.
+   */
+
+  void arm_fir_lattice_init_q15(
+  arm_fir_lattice_instance_q15 * S,
+  uint16_t numStages,
+  q15_t * pCoeffs,
+  q15_t * pState);
+
+
+  /**
+   * @brief Processing function for the Q15 FIR lattice filter.
+   * @param[in] *S points to an instance of the Q15 FIR lattice structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+  void arm_fir_lattice_q15(
+  const arm_fir_lattice_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Initialization function for the Q31 FIR lattice filter.
+   * @param[in] *S points to an instance of the Q31 FIR lattice structure.
+   * @param[in] numStages  number of filter stages.
+   * @param[in] *pCoeffs points to the coefficient buffer.  The array is of length numStages.
+   * @param[in] *pState points to the state buffer.   The array is of length numStages.
+   * @return none.
+   */
+
+  void arm_fir_lattice_init_q31(
+  arm_fir_lattice_instance_q31 * S,
+  uint16_t numStages,
+  q31_t * pCoeffs,
+  q31_t * pState);
+
+
+  /**
+   * @brief Processing function for the Q31 FIR lattice filter.
+   * @param[in]  *S        points to an instance of the Q31 FIR lattice structure.
+   * @param[in]  *pSrc     points to the block of input data.
+   * @param[out] *pDst     points to the block of output data
+   * @param[in]  blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_fir_lattice_q31(
+  const arm_fir_lattice_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+/**
+ * @brief Initialization function for the floating-point FIR lattice filter.
+ * @param[in] *S points to an instance of the floating-point FIR lattice structure.
+ * @param[in] numStages  number of filter stages.
+ * @param[in] *pCoeffs points to the coefficient buffer.  The array is of length numStages.
+ * @param[in] *pState points to the state buffer.  The array is of length numStages.
+ * @return none.
+ */
+
+  void arm_fir_lattice_init_f32(
+  arm_fir_lattice_instance_f32 * S,
+  uint16_t numStages,
+  float32_t * pCoeffs,
+  float32_t * pState);
+
+  /**
+   * @brief Processing function for the floating-point FIR lattice filter.
+   * @param[in]  *S        points to an instance of the floating-point FIR lattice structure.
+   * @param[in]  *pSrc     points to the block of input data.
+   * @param[out] *pDst     points to the block of output data
+   * @param[in]  blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_fir_lattice_f32(
+  const arm_fir_lattice_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Instance structure for the Q15 IIR lattice filter.
+   */
+  typedef struct
+  {
+    uint16_t numStages;                         /**< number of stages in the filter. */
+    q15_t *pState;                              /**< points to the state variable array. The array is of length numStages+blockSize. */
+    q15_t *pkCoeffs;                            /**< points to the reflection coefficient array. The array is of length numStages. */
+    q15_t *pvCoeffs;                            /**< points to the ladder coefficient array. The array is of length numStages+1. */
+  } arm_iir_lattice_instance_q15;
+
+  /**
+   * @brief Instance structure for the Q31 IIR lattice filter.
+   */
+  typedef struct
+  {
+    uint16_t numStages;                         /**< number of stages in the filter. */
+    q31_t *pState;                              /**< points to the state variable array. The array is of length numStages+blockSize. */
+    q31_t *pkCoeffs;                            /**< points to the reflection coefficient array. The array is of length numStages. */
+    q31_t *pvCoeffs;                            /**< points to the ladder coefficient array. The array is of length numStages+1. */
+  } arm_iir_lattice_instance_q31;
+
+  /**
+   * @brief Instance structure for the floating-point IIR lattice filter.
+   */
+  typedef struct
+  {
+    uint16_t numStages;                         /**< number of stages in the filter. */
+    float32_t *pState;                          /**< points to the state variable array. The array is of length numStages+blockSize. */
+    float32_t *pkCoeffs;                        /**< points to the reflection coefficient array. The array is of length numStages. */
+    float32_t *pvCoeffs;                        /**< points to the ladder coefficient array. The array is of length numStages+1. */
+  } arm_iir_lattice_instance_f32;
+
+  /**
+   * @brief Processing function for the floating-point IIR lattice filter.
+   * @param[in] *S points to an instance of the floating-point IIR lattice structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_iir_lattice_f32(
+  const arm_iir_lattice_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Initialization function for the floating-point IIR lattice filter.
+   * @param[in] *S points to an instance of the floating-point IIR lattice structure.
+   * @param[in] numStages number of stages in the filter.
+   * @param[in] *pkCoeffs points to the reflection coefficient buffer.  The array is of length numStages.
+   * @param[in] *pvCoeffs points to the ladder coefficient buffer.  The array is of length numStages+1.
+   * @param[in] *pState points to the state buffer.  The array is of length numStages+blockSize-1.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_iir_lattice_init_f32(
+  arm_iir_lattice_instance_f32 * S,
+  uint16_t numStages,
+  float32_t * pkCoeffs,
+  float32_t * pvCoeffs,
+  float32_t * pState,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Processing function for the Q31 IIR lattice filter.
+   * @param[in] *S points to an instance of the Q31 IIR lattice structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_iir_lattice_q31(
+  const arm_iir_lattice_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Initialization function for the Q31 IIR lattice filter.
+   * @param[in] *S points to an instance of the Q31 IIR lattice structure.
+   * @param[in] numStages number of stages in the filter.
+   * @param[in] *pkCoeffs points to the reflection coefficient buffer.  The array is of length numStages.
+   * @param[in] *pvCoeffs points to the ladder coefficient buffer.  The array is of length numStages+1.
+   * @param[in] *pState points to the state buffer.  The array is of length numStages+blockSize.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_iir_lattice_init_q31(
+  arm_iir_lattice_instance_q31 * S,
+  uint16_t numStages,
+  q31_t * pkCoeffs,
+  q31_t * pvCoeffs,
+  q31_t * pState,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Processing function for the Q15 IIR lattice filter.
+   * @param[in] *S points to an instance of the Q15 IIR lattice structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[out] *pDst points to the block of output data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_iir_lattice_q15(
+  const arm_iir_lattice_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+
+/**
+ * @brief Initialization function for the Q15 IIR lattice filter.
+ * @param[in] *S points to an instance of the fixed-point Q15 IIR lattice structure.
+ * @param[in] numStages  number of stages in the filter.
+ * @param[in] *pkCoeffs points to reflection coefficient buffer.  The array is of length numStages.
+ * @param[in] *pvCoeffs points to ladder coefficient buffer.  The array is of length numStages+1.
+ * @param[in] *pState points to state buffer.  The array is of length numStages+blockSize.
+ * @param[in] blockSize number of samples to process per call.
+ * @return none.
+ */
+
+  void arm_iir_lattice_init_q15(
+  arm_iir_lattice_instance_q15 * S,
+  uint16_t numStages,
+  q15_t * pkCoeffs,
+  q15_t * pvCoeffs,
+  q15_t * pState,
+  uint32_t blockSize);
+
+  /**
+   * @brief Instance structure for the floating-point LMS filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numTaps;    /**< number of coefficients in the filter. */
+    float32_t *pState;   /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    float32_t *pCoeffs;  /**< points to the coefficient array. The array is of length numTaps. */
+    float32_t mu;        /**< step size that controls filter coefficient updates. */
+  } arm_lms_instance_f32;
+
+  /**
+   * @brief Processing function for floating-point LMS filter.
+   * @param[in]  *S points to an instance of the floating-point LMS filter structure.
+   * @param[in]  *pSrc points to the block of input data.
+   * @param[in]  *pRef points to the block of reference data.
+   * @param[out] *pOut points to the block of output data.
+   * @param[out] *pErr points to the block of error data.
+   * @param[in]  blockSize number of samples to process.
+   * @return     none.
+   */
+
+  void arm_lms_f32(
+  const arm_lms_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pRef,
+  float32_t * pOut,
+  float32_t * pErr,
+  uint32_t blockSize);
+
+  /**
+   * @brief Initialization function for floating-point LMS filter.
+   * @param[in] *S points to an instance of the floating-point LMS filter structure.
+   * @param[in] numTaps  number of filter coefficients.
+   * @param[in] *pCoeffs points to the coefficient buffer.
+   * @param[in] *pState points to state buffer.
+   * @param[in] mu step size that controls filter coefficient updates.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_lms_init_f32(
+  arm_lms_instance_f32 * S,
+  uint16_t numTaps,
+  float32_t * pCoeffs,
+  float32_t * pState,
+  float32_t mu,
+  uint32_t blockSize);
+
+  /**
+   * @brief Instance structure for the Q15 LMS filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numTaps;    /**< number of coefficients in the filter. */
+    q15_t *pState;       /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q15_t *pCoeffs;      /**< points to the coefficient array. The array is of length numTaps. */
+    q15_t mu;            /**< step size that controls filter coefficient updates. */
+    uint32_t postShift;  /**< bit shift applied to coefficients. */
+  } arm_lms_instance_q15;
+
+
+  /**
+   * @brief Initialization function for the Q15 LMS filter.
+   * @param[in] *S points to an instance of the Q15 LMS filter structure.
+   * @param[in] numTaps  number of filter coefficients.
+   * @param[in] *pCoeffs points to the coefficient buffer.
+   * @param[in] *pState points to the state buffer.
+   * @param[in] mu step size that controls filter coefficient updates.
+   * @param[in] blockSize number of samples to process.
+   * @param[in] postShift bit shift applied to coefficients.
+   * @return    none.
+   */
+
+  void arm_lms_init_q15(
+  arm_lms_instance_q15 * S,
+  uint16_t numTaps,
+  q15_t * pCoeffs,
+  q15_t * pState,
+  q15_t mu,
+  uint32_t blockSize,
+  uint32_t postShift);
+
+  /**
+   * @brief Processing function for Q15 LMS filter.
+   * @param[in] *S points to an instance of the Q15 LMS filter structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[in] *pRef points to the block of reference data.
+   * @param[out] *pOut points to the block of output data.
+   * @param[out] *pErr points to the block of error data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_lms_q15(
+  const arm_lms_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pRef,
+  q15_t * pOut,
+  q15_t * pErr,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Instance structure for the Q31 LMS filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numTaps;    /**< number of coefficients in the filter. */
+    q31_t *pState;       /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q31_t *pCoeffs;      /**< points to the coefficient array. The array is of length numTaps. */
+    q31_t mu;            /**< step size that controls filter coefficient updates. */
+    uint32_t postShift;  /**< bit shift applied to coefficients. */
+
+  } arm_lms_instance_q31;
+
+  /**
+   * @brief Processing function for Q31 LMS filter.
+   * @param[in]  *S points to an instance of the Q15 LMS filter structure.
+   * @param[in]  *pSrc points to the block of input data.
+   * @param[in]  *pRef points to the block of reference data.
+   * @param[out] *pOut points to the block of output data.
+   * @param[out] *pErr points to the block of error data.
+   * @param[in]  blockSize number of samples to process.
+   * @return     none.
+   */
+
+  void arm_lms_q31(
+  const arm_lms_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pRef,
+  q31_t * pOut,
+  q31_t * pErr,
+  uint32_t blockSize);
+
+  /**
+   * @brief Initialization function for Q31 LMS filter.
+   * @param[in] *S points to an instance of the Q31 LMS filter structure.
+   * @param[in] numTaps  number of filter coefficients.
+   * @param[in] *pCoeffs points to coefficient buffer.
+   * @param[in] *pState points to state buffer.
+   * @param[in] mu step size that controls filter coefficient updates.
+   * @param[in] blockSize number of samples to process.
+   * @param[in] postShift bit shift applied to coefficients.
+   * @return none.
+   */
+
+  void arm_lms_init_q31(
+  arm_lms_instance_q31 * S,
+  uint16_t numTaps,
+  q31_t * pCoeffs,
+  q31_t * pState,
+  q31_t mu,
+  uint32_t blockSize,
+  uint32_t postShift);
+
+  /**
+   * @brief Instance structure for the floating-point normalized LMS filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numTaps;     /**< number of coefficients in the filter. */
+    float32_t *pState;    /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    float32_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps. */
+    float32_t mu;        /**< step size that control filter coefficient updates. */
+    float32_t energy;    /**< saves previous frame energy. */
+    float32_t x0;        /**< saves previous input sample. */
+  } arm_lms_norm_instance_f32;
+
+  /**
+   * @brief Processing function for floating-point normalized LMS filter.
+   * @param[in] *S points to an instance of the floating-point normalized LMS filter structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[in] *pRef points to the block of reference data.
+   * @param[out] *pOut points to the block of output data.
+   * @param[out] *pErr points to the block of error data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_lms_norm_f32(
+  arm_lms_norm_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pRef,
+  float32_t * pOut,
+  float32_t * pErr,
+  uint32_t blockSize);
+
+  /**
+   * @brief Initialization function for floating-point normalized LMS filter.
+   * @param[in] *S points to an instance of the floating-point LMS filter structure.
+   * @param[in] numTaps  number of filter coefficients.
+   * @param[in] *pCoeffs points to coefficient buffer.
+   * @param[in] *pState points to state buffer.
+   * @param[in] mu step size that controls filter coefficient updates.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_lms_norm_init_f32(
+  arm_lms_norm_instance_f32 * S,
+  uint16_t numTaps,
+  float32_t * pCoeffs,
+  float32_t * pState,
+  float32_t mu,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Instance structure for the Q31 normalized LMS filter.
+   */
+  typedef struct
+  {
+    uint16_t numTaps;     /**< number of coefficients in the filter. */
+    q31_t *pState;        /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q31_t *pCoeffs;       /**< points to the coefficient array. The array is of length numTaps. */
+    q31_t mu;             /**< step size that controls filter coefficient updates. */
+    uint8_t postShift;    /**< bit shift applied to coefficients. */
+    q31_t *recipTable;    /**< points to the reciprocal initial value table. */
+    q31_t energy;         /**< saves previous frame energy. */
+    q31_t x0;             /**< saves previous input sample. */
+  } arm_lms_norm_instance_q31;
+
+  /**
+   * @brief Processing function for Q31 normalized LMS filter.
+   * @param[in] *S points to an instance of the Q31 normalized LMS filter structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[in] *pRef points to the block of reference data.
+   * @param[out] *pOut points to the block of output data.
+   * @param[out] *pErr points to the block of error data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_lms_norm_q31(
+  arm_lms_norm_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pRef,
+  q31_t * pOut,
+  q31_t * pErr,
+  uint32_t blockSize);
+
+  /**
+   * @brief Initialization function for Q31 normalized LMS filter.
+   * @param[in] *S points to an instance of the Q31 normalized LMS filter structure.
+   * @param[in] numTaps  number of filter coefficients.
+   * @param[in] *pCoeffs points to coefficient buffer.
+   * @param[in] *pState points to state buffer.
+   * @param[in] mu step size that controls filter coefficient updates.
+   * @param[in] blockSize number of samples to process.
+   * @param[in] postShift bit shift applied to coefficients.
+   * @return none.
+   */
+
+  void arm_lms_norm_init_q31(
+  arm_lms_norm_instance_q31 * S,
+  uint16_t numTaps,
+  q31_t * pCoeffs,
+  q31_t * pState,
+  q31_t mu,
+  uint32_t blockSize,
+  uint8_t postShift);
+
+  /**
+   * @brief Instance structure for the Q15 normalized LMS filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numTaps;    /**< Number of coefficients in the filter. */
+    q15_t *pState;        /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q15_t *pCoeffs;       /**< points to the coefficient array. The array is of length numTaps. */
+    q15_t mu;            /**< step size that controls filter coefficient updates. */
+    uint8_t postShift;   /**< bit shift applied to coefficients. */
+    q15_t *recipTable;   /**< Points to the reciprocal initial value table. */
+    q15_t energy;        /**< saves previous frame energy. */
+    q15_t x0;            /**< saves previous input sample. */
+  } arm_lms_norm_instance_q15;
+
+  /**
+   * @brief Processing function for Q15 normalized LMS filter.
+   * @param[in] *S points to an instance of the Q15 normalized LMS filter structure.
+   * @param[in] *pSrc points to the block of input data.
+   * @param[in] *pRef points to the block of reference data.
+   * @param[out] *pOut points to the block of output data.
+   * @param[out] *pErr points to the block of error data.
+   * @param[in] blockSize number of samples to process.
+   * @return none.
+   */
+
+  void arm_lms_norm_q15(
+  arm_lms_norm_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pRef,
+  q15_t * pOut,
+  q15_t * pErr,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief Initialization function for Q15 normalized LMS filter.
+   * @param[in] *S points to an instance of the Q15 normalized LMS filter structure.
+   * @param[in] numTaps  number of filter coefficients.
+   * @param[in] *pCoeffs points to coefficient buffer.
+   * @param[in] *pState points to state buffer.
+   * @param[in] mu step size that controls filter coefficient updates.
+   * @param[in] blockSize number of samples to process.
+   * @param[in] postShift bit shift applied to coefficients.
+   * @return none.
+   */
+
+  void arm_lms_norm_init_q15(
+  arm_lms_norm_instance_q15 * S,
+  uint16_t numTaps,
+  q15_t * pCoeffs,
+  q15_t * pState,
+  q15_t mu,
+  uint32_t blockSize,
+  uint8_t postShift);
+
+  /**
+   * @brief Correlation of floating-point sequences.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
+   * @return none.
+   */
+
+  void arm_correlate_f32(
+  float32_t * pSrcA,
+  uint32_t srcALen,
+  float32_t * pSrcB,
+  uint32_t srcBLen,
+  float32_t * pDst);
+
+
+   /**
+   * @brief Correlation of Q15 sequences
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
+   * @param[in]  *pScratch points to scratch buffer of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
+   * @return none.
+   */
+  void arm_correlate_opt_q15(
+  q15_t * pSrcA,
+  uint32_t srcALen,
+  q15_t * pSrcB,
+  uint32_t srcBLen,
+  q15_t * pDst,
+  q15_t * pScratch);
+
+
+  /**
+   * @brief Correlation of Q15 sequences.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
+   * @return none.
+   */
+
+  void arm_correlate_q15(
+  q15_t * pSrcA,
+  uint32_t srcALen,
+  q15_t * pSrcB,
+  uint32_t srcBLen,
+  q15_t * pDst);
+
+  /**
+   * @brief Correlation of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
+   * @return none.
+   */
+
+  void arm_correlate_fast_q15(
+			       q15_t * pSrcA,
+			      uint32_t srcALen,
+			       q15_t * pSrcB,
+			      uint32_t srcBLen,
+			      q15_t * pDst);
+
+
+
+  /**
+   * @brief Correlation of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
+   * @param[in]  *pScratch points to scratch buffer of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
+   * @return none.
+   */
+
+  void arm_correlate_fast_opt_q15(
+  q15_t * pSrcA,
+  uint32_t srcALen,
+  q15_t * pSrcB,
+  uint32_t srcBLen,
+  q15_t * pDst,
+  q15_t * pScratch);
+
+  /**
+   * @brief Correlation of Q31 sequences.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
+   * @return none.
+   */
+
+  void arm_correlate_q31(
+  q31_t * pSrcA,
+  uint32_t srcALen,
+  q31_t * pSrcB,
+  uint32_t srcBLen,
+  q31_t * pDst);
+
+  /**
+   * @brief Correlation of Q31 sequences (fast version) for Cortex-M3 and Cortex-M4
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
+   * @return none.
+   */
+
+  void arm_correlate_fast_q31(
+  q31_t * pSrcA,
+  uint32_t srcALen,
+  q31_t * pSrcB,
+  uint32_t srcBLen,
+  q31_t * pDst);
+
+
+
+ /**
+   * @brief Correlation of Q7 sequences.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
+   * @param[in]  *pScratch1 points to scratch buffer(of type q15_t) of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
+   * @param[in]  *pScratch2 points to scratch buffer (of type q15_t) of size min(srcALen, srcBLen).
+   * @return none.
+   */
+
+  void arm_correlate_opt_q7(
+  q7_t * pSrcA,
+  uint32_t srcALen,
+  q7_t * pSrcB,
+  uint32_t srcBLen,
+  q7_t * pDst,
+  q15_t * pScratch1,
+  q15_t * pScratch2);
+
+
+  /**
+   * @brief Correlation of Q7 sequences.
+   * @param[in] *pSrcA points to the first input sequence.
+   * @param[in] srcALen length of the first input sequence.
+   * @param[in] *pSrcB points to the second input sequence.
+   * @param[in] srcBLen length of the second input sequence.
+   * @param[out] *pDst points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
+   * @return none.
+   */
+
+  void arm_correlate_q7(
+  q7_t * pSrcA,
+  uint32_t srcALen,
+  q7_t * pSrcB,
+  uint32_t srcBLen,
+  q7_t * pDst);
+
+
+  /**
+   * @brief Instance structure for the floating-point sparse FIR filter.
+   */
+  typedef struct
+  {
+    uint16_t numTaps;             /**< number of coefficients in the filter. */
+    uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
+    float32_t *pState;            /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
+    float32_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
+    uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
+    int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
+  } arm_fir_sparse_instance_f32;
+
+  /**
+   * @brief Instance structure for the Q31 sparse FIR filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numTaps;             /**< number of coefficients in the filter. */
+    uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
+    q31_t *pState;                /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
+    q31_t *pCoeffs;               /**< points to the coefficient array. The array is of length numTaps.*/
+    uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
+    int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
+  } arm_fir_sparse_instance_q31;
+
+  /**
+   * @brief Instance structure for the Q15 sparse FIR filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numTaps;             /**< number of coefficients in the filter. */
+    uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
+    q15_t *pState;                /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
+    q15_t *pCoeffs;               /**< points to the coefficient array. The array is of length numTaps.*/
+    uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
+    int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
+  } arm_fir_sparse_instance_q15;
+
+  /**
+   * @brief Instance structure for the Q7 sparse FIR filter.
+   */
+
+  typedef struct
+  {
+    uint16_t numTaps;             /**< number of coefficients in the filter. */
+    uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
+    q7_t *pState;                 /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
+    q7_t *pCoeffs;                /**< points to the coefficient array. The array is of length numTaps.*/
+    uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
+    int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
+  } arm_fir_sparse_instance_q7;
+
+  /**
+   * @brief Processing function for the floating-point sparse FIR filter.
+   * @param[in]  *S          points to an instance of the floating-point sparse FIR structure.
+   * @param[in]  *pSrc       points to the block of input data.
+   * @param[out] *pDst       points to the block of output data
+   * @param[in]  *pScratchIn points to a temporary buffer of size blockSize.
+   * @param[in]  blockSize   number of input samples to process per call.
+   * @return none.
+   */
+
+  void arm_fir_sparse_f32(
+  arm_fir_sparse_instance_f32 * S,
+  float32_t * pSrc,
+  float32_t * pDst,
+  float32_t * pScratchIn,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the floating-point sparse FIR filter.
+   * @param[in,out] *S         points to an instance of the floating-point sparse FIR structure.
+   * @param[in]     numTaps    number of nonzero coefficients in the filter.
+   * @param[in]     *pCoeffs   points to the array of filter coefficients.
+   * @param[in]     *pState    points to the state buffer.
+   * @param[in]     *pTapDelay points to the array of offset times.
+   * @param[in]     maxDelay   maximum offset time supported.
+   * @param[in]     blockSize  number of samples that will be processed per block.
+   * @return none
+   */
+
+  void arm_fir_sparse_init_f32(
+  arm_fir_sparse_instance_f32 * S,
+  uint16_t numTaps,
+  float32_t * pCoeffs,
+  float32_t * pState,
+  int32_t * pTapDelay,
+  uint16_t maxDelay,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the Q31 sparse FIR filter.
+   * @param[in]  *S          points to an instance of the Q31 sparse FIR structure.
+   * @param[in]  *pSrc       points to the block of input data.
+   * @param[out] *pDst       points to the block of output data
+   * @param[in]  *pScratchIn points to a temporary buffer of size blockSize.
+   * @param[in]  blockSize   number of input samples to process per call.
+   * @return none.
+   */
+
+  void arm_fir_sparse_q31(
+  arm_fir_sparse_instance_q31 * S,
+  q31_t * pSrc,
+  q31_t * pDst,
+  q31_t * pScratchIn,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the Q31 sparse FIR filter.
+   * @param[in,out] *S         points to an instance of the Q31 sparse FIR structure.
+   * @param[in]     numTaps    number of nonzero coefficients in the filter.
+   * @param[in]     *pCoeffs   points to the array of filter coefficients.
+   * @param[in]     *pState    points to the state buffer.
+   * @param[in]     *pTapDelay points to the array of offset times.
+   * @param[in]     maxDelay   maximum offset time supported.
+   * @param[in]     blockSize  number of samples that will be processed per block.
+   * @return none
+   */
+
+  void arm_fir_sparse_init_q31(
+  arm_fir_sparse_instance_q31 * S,
+  uint16_t numTaps,
+  q31_t * pCoeffs,
+  q31_t * pState,
+  int32_t * pTapDelay,
+  uint16_t maxDelay,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the Q15 sparse FIR filter.
+   * @param[in]  *S           points to an instance of the Q15 sparse FIR structure.
+   * @param[in]  *pSrc        points to the block of input data.
+   * @param[out] *pDst        points to the block of output data
+   * @param[in]  *pScratchIn  points to a temporary buffer of size blockSize.
+   * @param[in]  *pScratchOut points to a temporary buffer of size blockSize.
+   * @param[in]  blockSize    number of input samples to process per call.
+   * @return none.
+   */
+
+  void arm_fir_sparse_q15(
+  arm_fir_sparse_instance_q15 * S,
+  q15_t * pSrc,
+  q15_t * pDst,
+  q15_t * pScratchIn,
+  q31_t * pScratchOut,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief  Initialization function for the Q15 sparse FIR filter.
+   * @param[in,out] *S         points to an instance of the Q15 sparse FIR structure.
+   * @param[in]     numTaps    number of nonzero coefficients in the filter.
+   * @param[in]     *pCoeffs   points to the array of filter coefficients.
+   * @param[in]     *pState    points to the state buffer.
+   * @param[in]     *pTapDelay points to the array of offset times.
+   * @param[in]     maxDelay   maximum offset time supported.
+   * @param[in]     blockSize  number of samples that will be processed per block.
+   * @return none
+   */
+
+  void arm_fir_sparse_init_q15(
+  arm_fir_sparse_instance_q15 * S,
+  uint16_t numTaps,
+  q15_t * pCoeffs,
+  q15_t * pState,
+  int32_t * pTapDelay,
+  uint16_t maxDelay,
+  uint32_t blockSize);
+
+  /**
+   * @brief Processing function for the Q7 sparse FIR filter.
+   * @param[in]  *S           points to an instance of the Q7 sparse FIR structure.
+   * @param[in]  *pSrc        points to the block of input data.
+   * @param[out] *pDst        points to the block of output data
+   * @param[in]  *pScratchIn  points to a temporary buffer of size blockSize.
+   * @param[in]  *pScratchOut points to a temporary buffer of size blockSize.
+   * @param[in]  blockSize    number of input samples to process per call.
+   * @return none.
+   */
+
+  void arm_fir_sparse_q7(
+  arm_fir_sparse_instance_q7 * S,
+  q7_t * pSrc,
+  q7_t * pDst,
+  q7_t * pScratchIn,
+  q31_t * pScratchOut,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Initialization function for the Q7 sparse FIR filter.
+   * @param[in,out] *S         points to an instance of the Q7 sparse FIR structure.
+   * @param[in]     numTaps    number of nonzero coefficients in the filter.
+   * @param[in]     *pCoeffs   points to the array of filter coefficients.
+   * @param[in]     *pState    points to the state buffer.
+   * @param[in]     *pTapDelay points to the array of offset times.
+   * @param[in]     maxDelay   maximum offset time supported.
+   * @param[in]     blockSize  number of samples that will be processed per block.
+   * @return none
+   */
+
+  void arm_fir_sparse_init_q7(
+  arm_fir_sparse_instance_q7 * S,
+  uint16_t numTaps,
+  q7_t * pCoeffs,
+  q7_t * pState,
+  int32_t * pTapDelay,
+  uint16_t maxDelay,
+  uint32_t blockSize);
+
+
+  /*
+   * @brief  Floating-point sin_cos function.
+   * @param[in]  theta    input value in degrees
+   * @param[out] *pSinVal points to the processed sine output.
+   * @param[out] *pCosVal points to the processed cos output.
+   * @return none.
+   */
+
+  void arm_sin_cos_f32(
+  float32_t theta,
+  float32_t * pSinVal,
+  float32_t * pCcosVal);
+
+  /*
+   * @brief  Q31 sin_cos function.
+   * @param[in]  theta    scaled input value in degrees
+   * @param[out] *pSinVal points to the processed sine output.
+   * @param[out] *pCosVal points to the processed cosine output.
+   * @return none.
+   */
+
+  void arm_sin_cos_q31(
+  q31_t theta,
+  q31_t * pSinVal,
+  q31_t * pCosVal);
+
+
+  /**
+   * @brief  Floating-point complex conjugate.
+   * @param[in]  *pSrc points to the input vector
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  numSamples number of complex samples in each vector
+   * @return none.
+   */
+
+  void arm_cmplx_conj_f32(
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Q31 complex conjugate.
+   * @param[in]  *pSrc points to the input vector
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  numSamples number of complex samples in each vector
+   * @return none.
+   */
+
+  void arm_cmplx_conj_q31(
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Q15 complex conjugate.
+   * @param[in]  *pSrc points to the input vector
+   * @param[out]  *pDst points to the output vector
+   * @param[in]  numSamples number of complex samples in each vector
+   * @return none.
+   */
+
+  void arm_cmplx_conj_q15(
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t numSamples);
+
+
+
+  /**
+   * @brief  Floating-point complex magnitude squared
+   * @param[in]  *pSrc points to the complex input vector
+   * @param[out]  *pDst points to the real output vector
+   * @param[in]  numSamples number of complex samples in the input vector
+   * @return none.
+   */
+
+  void arm_cmplx_mag_squared_f32(
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Q31 complex magnitude squared
+   * @param[in]  *pSrc points to the complex input vector
+   * @param[out]  *pDst points to the real output vector
+   * @param[in]  numSamples number of complex samples in the input vector
+   * @return none.
+   */
+
+  void arm_cmplx_mag_squared_q31(
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Q15 complex magnitude squared
+   * @param[in]  *pSrc points to the complex input vector
+   * @param[out]  *pDst points to the real output vector
+   * @param[in]  numSamples number of complex samples in the input vector
+   * @return none.
+   */
+
+  void arm_cmplx_mag_squared_q15(
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t numSamples);
+
+
+ /**
+   * @ingroup groupController
+   */
+
+  /**
+   * @defgroup PID PID Motor Control
+   *
+   * A Proportional Integral Derivative (PID) controller is a generic feedback control
+   * loop mechanism widely used in industrial control systems.
+   * A PID controller is the most commonly used type of feedback controller.
+   *
+   * This set of functions implements (PID) controllers
+   * for Q15, Q31, and floating-point data types.  The functions operate on a single sample
+   * of data and each call to the function returns a single processed value.
+   * <code>S</code> points to an instance of the PID control data structure.  <code>in</code>
+   * is the input sample value. The functions return the output value.
+   *
+   * \par Algorithm:
+   * <pre>
+   *    y[n] = y[n-1] + A0 * x[n] + A1 * x[n-1] + A2 * x[n-2]
+   *    A0 = Kp + Ki + Kd
+   *    A1 = (-Kp ) - (2 * Kd )
+   *    A2 = Kd  </pre>
+   *
+   * \par
+   * where \c Kp is proportional constant, \c Ki is Integral constant and \c Kd is Derivative constant
+   *
+   * \par
+   * \image html PID.gif "Proportional Integral Derivative Controller"
+   *
+   * \par
+   * The PID controller calculates an "error" value as the difference between
+   * the measured output and the reference input.
+   * The controller attempts to minimize the error by adjusting the process control inputs.
+   * The proportional value determines the reaction to the current error,
+   * the integral value determines the reaction based on the sum of recent errors,
+   * and the derivative value determines the reaction based on the rate at which the error has been changing.
+   *
+   * \par Instance Structure
+   * The Gains A0, A1, A2 and state variables for a PID controller are stored together in an instance data structure.
+   * A separate instance structure must be defined for each PID Controller.
+   * There are separate instance structure declarations for each of the 3 supported data types.
+   *
+   * \par Reset Functions
+   * There is also an associated reset function for each data type which clears the state array.
+   *
+   * \par Initialization Functions
+   * There is also an associated initialization function for each data type.
+   * The initialization function performs the following operations:
+   * - Initializes the Gains A0, A1, A2 from Kp,Ki, Kd gains.
+   * - Zeros out the values in the state buffer.
+   *
+   * \par
+   * Instance structure cannot be placed into a const data section and it is recommended to use the initialization function.
+   *
+   * \par Fixed-Point Behavior
+   * Care must be taken when using the fixed-point versions of the PID Controller functions.
+   * In particular, the overflow and saturation behavior of the accumulator used in each function must be considered.
+   * Refer to the function specific documentation below for usage guidelines.
+   */
+
+  /**
+   * @addtogroup PID
+   * @{
+   */
+
+  /**
+   * @brief  Process function for the floating-point PID Control.
+   * @param[in,out] *S is an instance of the floating-point PID Control structure
+   * @param[in] in input sample to process
+   * @return out processed output sample.
+   */
+
+
+  static __INLINE float32_t arm_pid_f32(
+  arm_pid_instance_f32 * S,
+  float32_t in)
+  {
+    float32_t out;
+
+    /* y[n] = y[n-1] + A0 * x[n] + A1 * x[n-1] + A2 * x[n-2]  */
+    out = (S->A0 * in) +
+      (S->A1 * S->state[0]) + (S->A2 * S->state[1]) + (S->state[2]);
+
+    /* Update state */
+    S->state[1] = S->state[0];
+    S->state[0] = in;
+    S->state[2] = out;
+
+    /* return to application */
+    return (out);
+
+  }
+
+  /**
+   * @brief  Process function for the Q31 PID Control.
+   * @param[in,out] *S points to an instance of the Q31 PID Control structure
+   * @param[in] in input sample to process
+   * @return out processed output sample.
+   *
+   * <b>Scaling and Overflow Behavior:</b>
+   * \par
+   * The function is implemented using an internal 64-bit accumulator.
+   * The accumulator has a 2.62 format and maintains full precision of the intermediate multiplication results but provides only a single guard bit.
+   * Thus, if the accumulator result overflows it wraps around rather than clip.
+   * In order to avoid overflows completely the input signal must be scaled down by 2 bits as there are four additions.
+   * After all multiply-accumulates are performed, the 2.62 accumulator is truncated to 1.32 format and then saturated to 1.31 format.
+   */
+
+  static __INLINE q31_t arm_pid_q31(
+  arm_pid_instance_q31 * S,
+  q31_t in)
+  {
+    q63_t acc;
+    q31_t out;
+
+    /* acc = A0 * x[n]  */
+    acc = (q63_t) S->A0 * in;
+
+    /* acc += A1 * x[n-1] */
+    acc += (q63_t) S->A1 * S->state[0];
+
+    /* acc += A2 * x[n-2]  */
+    acc += (q63_t) S->A2 * S->state[1];
+
+    /* convert output to 1.31 format to add y[n-1] */
+    out = (q31_t) (acc >> 31u);
+
+    /* out += y[n-1] */
+    out += S->state[2];
+
+    /* Update state */
+    S->state[1] = S->state[0];
+    S->state[0] = in;
+    S->state[2] = out;
+
+    /* return to application */
+    return (out);
+
+  }
+
+  /**
+   * @brief  Process function for the Q15 PID Control.
+   * @param[in,out] *S points to an instance of the Q15 PID Control structure
+   * @param[in] in input sample to process
+   * @return out processed output sample.
+   *
+   * <b>Scaling and Overflow Behavior:</b>
+   * \par
+   * The function is implemented using a 64-bit internal accumulator.
+   * Both Gains and state variables are represented in 1.15 format and multiplications yield a 2.30 result.
+   * The 2.30 intermediate results are accumulated in a 64-bit accumulator in 34.30 format.
+   * There is no risk of internal overflow with this approach and the full precision of intermediate multiplications is preserved.
+   * After all additions have been performed, the accumulator is truncated to 34.15 format by discarding low 15 bits.
+   * Lastly, the accumulator is saturated to yield a result in 1.15 format.
+   */
+
+  static __INLINE q15_t arm_pid_q15(
+  arm_pid_instance_q15 * S,
+  q15_t in)
+  {
+    q63_t acc;
+    q15_t out;
+
+#ifndef ARM_MATH_CM0_FAMILY
+    __SIMD32_TYPE *vstate;
+
+    /* Implementation of PID controller */
+
+    /* acc = A0 * x[n]  */
+    acc = (q31_t) __SMUAD(S->A0, in);
+
+    /* acc += A1 * x[n-1] + A2 * x[n-2]  */
+    vstate = __SIMD32_CONST(S->state);
+    acc = __SMLALD(S->A1, (q31_t) *vstate, acc);
+
+#else
+    /* acc = A0 * x[n]  */
+    acc = ((q31_t) S->A0) * in;
+
+    /* acc += A1 * x[n-1] + A2 * x[n-2]  */
+    acc += (q31_t) S->A1 * S->state[0];
+    acc += (q31_t) S->A2 * S->state[1];
+
+#endif
+
+    /* acc += y[n-1] */
+    acc += (q31_t) S->state[2] << 15;
+
+    /* saturate the output */
+    out = (q15_t) (__SSAT((acc >> 15), 16));
+
+    /* Update state */
+    S->state[1] = S->state[0];
+    S->state[0] = in;
+    S->state[2] = out;
+
+    /* return to application */
+    return (out);
+
+  }
+
+  /**
+   * @} end of PID group
+   */
+
+
+  /**
+   * @brief Floating-point matrix inverse.
+   * @param[in]  *src points to the instance of the input floating-point matrix structure.
+   * @param[out] *dst points to the instance of the output floating-point matrix structure.
+   * @return The function returns ARM_MATH_SIZE_MISMATCH, if the dimensions do not match.
+   * If the input matrix is singular (does not have an inverse), then the algorithm terminates and returns error status ARM_MATH_SINGULAR.
+   */
+
+  arm_status arm_mat_inverse_f32(
+  const arm_matrix_instance_f32 * src,
+  arm_matrix_instance_f32 * dst);
+
+
+  /**
+   * @brief Floating-point matrix inverse.
+   * @param[in]  *src points to the instance of the input floating-point matrix structure.
+   * @param[out] *dst points to the instance of the output floating-point matrix structure.
+   * @return The function returns ARM_MATH_SIZE_MISMATCH, if the dimensions do not match.
+   * If the input matrix is singular (does not have an inverse), then the algorithm terminates and returns error status ARM_MATH_SINGULAR.
+   */
+
+  arm_status arm_mat_inverse_f64(
+  const arm_matrix_instance_f64 * src,
+  arm_matrix_instance_f64 * dst);
+
+
+
+  /**
+   * @ingroup groupController
+   */
+
+
+  /**
+   * @defgroup clarke Vector Clarke Transform
+   * Forward Clarke transform converts the instantaneous stator phases into a two-coordinate time invariant vector.
+   * Generally the Clarke transform uses three-phase currents <code>Ia, Ib and Ic</code> to calculate currents
+   * in the two-phase orthogonal stator axis <code>Ialpha</code> and <code>Ibeta</code>.
+   * When <code>Ialpha</code> is superposed with <code>Ia</code> as shown in the figure below
+   * \image html clarke.gif Stator current space vector and its components in (a,b).
+   * and <code>Ia + Ib + Ic = 0</code>, in this condition <code>Ialpha</code> and <code>Ibeta</code>
+   * can be calculated using only <code>Ia</code> and <code>Ib</code>.
+   *
+   * The function operates on a single sample of data and each call to the function returns the processed output.
+   * The library provides separate functions for Q31 and floating-point data types.
+   * \par Algorithm
+   * \image html clarkeFormula.gif
+   * where <code>Ia</code> and <code>Ib</code> are the instantaneous stator phases and
+   * <code>pIalpha</code> and <code>pIbeta</code> are the two coordinates of time invariant vector.
+   * \par Fixed-Point Behavior
+   * Care must be taken when using the Q31 version of the Clarke transform.
+   * In particular, the overflow and saturation behavior of the accumulator used must be considered.
+   * Refer to the function specific documentation below for usage guidelines.
+   */
+
+  /**
+   * @addtogroup clarke
+   * @{
+   */
+
+  /**
+   *
+   * @brief  Floating-point Clarke transform
+   * @param[in]       Ia       input three-phase coordinate <code>a</code>
+   * @param[in]       Ib       input three-phase coordinate <code>b</code>
+   * @param[out]      *pIalpha points to output two-phase orthogonal vector axis alpha
+   * @param[out]      *pIbeta  points to output two-phase orthogonal vector axis beta
+   * @return none.
+   */
+
+  static __INLINE void arm_clarke_f32(
+  float32_t Ia,
+  float32_t Ib,
+  float32_t * pIalpha,
+  float32_t * pIbeta)
+  {
+    /* Calculate pIalpha using the equation, pIalpha = Ia */
+    *pIalpha = Ia;
+
+    /* Calculate pIbeta using the equation, pIbeta = (1/sqrt(3)) * Ia + (2/sqrt(3)) * Ib */
+    *pIbeta =
+      ((float32_t) 0.57735026919 * Ia + (float32_t) 1.15470053838 * Ib);
+
+  }
+
+  /**
+   * @brief  Clarke transform for Q31 version
+   * @param[in]       Ia       input three-phase coordinate <code>a</code>
+   * @param[in]       Ib       input three-phase coordinate <code>b</code>
+   * @param[out]      *pIalpha points to output two-phase orthogonal vector axis alpha
+   * @param[out]      *pIbeta  points to output two-phase orthogonal vector axis beta
+   * @return none.
+   *
+   * <b>Scaling and Overflow Behavior:</b>
+   * \par
+   * The function is implemented using an internal 32-bit accumulator.
+   * The accumulator maintains 1.31 format by truncating lower 31 bits of the intermediate multiplication in 2.62 format.
+   * There is saturation on the addition, hence there is no risk of overflow.
+   */
+
+  static __INLINE void arm_clarke_q31(
+  q31_t Ia,
+  q31_t Ib,
+  q31_t * pIalpha,
+  q31_t * pIbeta)
+  {
+    q31_t product1, product2;                    /* Temporary variables used to store intermediate results */
+
+    /* Calculating pIalpha from Ia by equation pIalpha = Ia */
+    *pIalpha = Ia;
+
+    /* Intermediate product is calculated by (1/(sqrt(3)) * Ia) */
+    product1 = (q31_t) (((q63_t) Ia * 0x24F34E8B) >> 30);
+
+    /* Intermediate product is calculated by (2/sqrt(3) * Ib) */
+    product2 = (q31_t) (((q63_t) Ib * 0x49E69D16) >> 30);
+
+    /* pIbeta is calculated by adding the intermediate products */
+    *pIbeta = __QADD(product1, product2);
+  }
+
+  /**
+   * @} end of clarke group
+   */
+
+  /**
+   * @brief  Converts the elements of the Q7 vector to Q31 vector.
+   * @param[in]  *pSrc     input pointer
+   * @param[out]  *pDst    output pointer
+   * @param[in]  blockSize number of samples to process
+   * @return none.
+   */
+  void arm_q7_to_q31(
+  q7_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+
+
+
+  /**
+   * @ingroup groupController
+   */
+
+  /**
+   * @defgroup inv_clarke Vector Inverse Clarke Transform
+   * Inverse Clarke transform converts the two-coordinate time invariant vector into instantaneous stator phases.
+   *
+   * The function operates on a single sample of data and each call to the function returns the processed output.
+   * The library provides separate functions for Q31 and floating-point data types.
+   * \par Algorithm
+   * \image html clarkeInvFormula.gif
+   * where <code>pIa</code> and <code>pIb</code> are the instantaneous stator phases and
+   * <code>Ialpha</code> and <code>Ibeta</code> are the two coordinates of time invariant vector.
+   * \par Fixed-Point Behavior
+   * Care must be taken when using the Q31 version of the Clarke transform.
+   * In particular, the overflow and saturation behavior of the accumulator used must be considered.
+   * Refer to the function specific documentation below for usage guidelines.
+   */
+
+  /**
+   * @addtogroup inv_clarke
+   * @{
+   */
+
+   /**
+   * @brief  Floating-point Inverse Clarke transform
+   * @param[in]       Ialpha  input two-phase orthogonal vector axis alpha
+   * @param[in]       Ibeta   input two-phase orthogonal vector axis beta
+   * @param[out]      *pIa    points to output three-phase coordinate <code>a</code>
+   * @param[out]      *pIb    points to output three-phase coordinate <code>b</code>
+   * @return none.
+   */
+
+
+  static __INLINE void arm_inv_clarke_f32(
+  float32_t Ialpha,
+  float32_t Ibeta,
+  float32_t * pIa,
+  float32_t * pIb)
+  {
+    /* Calculating pIa from Ialpha by equation pIa = Ialpha */
+    *pIa = Ialpha;
+
+    /* Calculating pIb from Ialpha and Ibeta by equation pIb = -(1/2) * Ialpha + (sqrt(3)/2) * Ibeta */
+    *pIb = -0.5 * Ialpha + (float32_t) 0.8660254039 *Ibeta;
+
+  }
+
+  /**
+   * @brief  Inverse Clarke transform for Q31 version
+   * @param[in]       Ialpha  input two-phase orthogonal vector axis alpha
+   * @param[in]       Ibeta   input two-phase orthogonal vector axis beta
+   * @param[out]      *pIa    points to output three-phase coordinate <code>a</code>
+   * @param[out]      *pIb    points to output three-phase coordinate <code>b</code>
+   * @return none.
+   *
+   * <b>Scaling and Overflow Behavior:</b>
+   * \par
+   * The function is implemented using an internal 32-bit accumulator.
+   * The accumulator maintains 1.31 format by truncating lower 31 bits of the intermediate multiplication in 2.62 format.
+   * There is saturation on the subtraction, hence there is no risk of overflow.
+   */
+
+  static __INLINE void arm_inv_clarke_q31(
+  q31_t Ialpha,
+  q31_t Ibeta,
+  q31_t * pIa,
+  q31_t * pIb)
+  {
+    q31_t product1, product2;                    /* Temporary variables used to store intermediate results */
+
+    /* Calculating pIa from Ialpha by equation pIa = Ialpha */
+    *pIa = Ialpha;
+
+    /* Intermediate product is calculated by (1/(2*sqrt(3)) * Ia) */
+    product1 = (q31_t) (((q63_t) (Ialpha) * (0x40000000)) >> 31);
+
+    /* Intermediate product is calculated by (1/sqrt(3) * pIb) */
+    product2 = (q31_t) (((q63_t) (Ibeta) * (0x6ED9EBA1)) >> 31);
+
+    /* pIb is calculated by subtracting the products */
+    *pIb = __QSUB(product2, product1);
+
+  }
+
+  /**
+   * @} end of inv_clarke group
+   */
+
+  /**
+   * @brief  Converts the elements of the Q7 vector to Q15 vector.
+   * @param[in]  *pSrc     input pointer
+   * @param[out] *pDst     output pointer
+   * @param[in]  blockSize number of samples to process
+   * @return none.
+   */
+  void arm_q7_to_q15(
+  q7_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+
+
+  /**
+   * @ingroup groupController
+   */
+
+  /**
+   * @defgroup park Vector Park Transform
+   *
+   * Forward Park transform converts the input two-coordinate vector to flux and torque components.
+   * The Park transform can be used to realize the transformation of the <code>Ialpha</code> and the <code>Ibeta</code> currents
+   * from the stationary to the moving reference frame and control the spatial relationship between
+   * the stator vector current and rotor flux vector.
+   * If we consider the d axis aligned with the rotor flux, the diagram below shows the
+   * current vector and the relationship from the two reference frames:
+   * \image html park.gif "Stator current space vector and its component in (a,b) and in the d,q rotating reference frame"
+   *
+   * The function operates on a single sample of data and each call to the function returns the processed output.
+   * The library provides separate functions for Q31 and floating-point data types.
+   * \par Algorithm
+   * \image html parkFormula.gif
+   * where <code>Ialpha</code> and <code>Ibeta</code> are the stator vector components,
+   * <code>pId</code> and <code>pIq</code> are rotor vector components and <code>cosVal</code> and <code>sinVal</code> are the
+   * cosine and sine values of theta (rotor flux position).
+   * \par Fixed-Point Behavior
+   * Care must be taken when using the Q31 version of the Park transform.
+   * In particular, the overflow and saturation behavior of the accumulator used must be considered.
+   * Refer to the function specific documentation below for usage guidelines.
+   */
+
+  /**
+   * @addtogroup park
+   * @{
+   */
+
+  /**
+   * @brief Floating-point Park transform
+   * @param[in]       Ialpha input two-phase vector coordinate alpha
+   * @param[in]       Ibeta  input two-phase vector coordinate beta
+   * @param[out]      *pId   points to output	rotor reference frame d
+   * @param[out]      *pIq   points to output	rotor reference frame q
+   * @param[in]       sinVal sine value of rotation angle theta
+   * @param[in]       cosVal cosine value of rotation angle theta
+   * @return none.
+   *
+   * The function implements the forward Park transform.
+   *
+   */
+
+  static __INLINE void arm_park_f32(
+  float32_t Ialpha,
+  float32_t Ibeta,
+  float32_t * pId,
+  float32_t * pIq,
+  float32_t sinVal,
+  float32_t cosVal)
+  {
+    /* Calculate pId using the equation, pId = Ialpha * cosVal + Ibeta * sinVal */
+    *pId = Ialpha * cosVal + Ibeta * sinVal;
+
+    /* Calculate pIq using the equation, pIq = - Ialpha * sinVal + Ibeta * cosVal */
+    *pIq = -Ialpha * sinVal + Ibeta * cosVal;
+
+  }
+
+  /**
+   * @brief  Park transform for Q31 version
+   * @param[in]       Ialpha input two-phase vector coordinate alpha
+   * @param[in]       Ibeta  input two-phase vector coordinate beta
+   * @param[out]      *pId   points to output rotor reference frame d
+   * @param[out]      *pIq   points to output rotor reference frame q
+   * @param[in]       sinVal sine value of rotation angle theta
+   * @param[in]       cosVal cosine value of rotation angle theta
+   * @return none.
+   *
+   * <b>Scaling and Overflow Behavior:</b>
+   * \par
+   * The function is implemented using an internal 32-bit accumulator.
+   * The accumulator maintains 1.31 format by truncating lower 31 bits of the intermediate multiplication in 2.62 format.
+   * There is saturation on the addition and subtraction, hence there is no risk of overflow.
+   */
+
+
+  static __INLINE void arm_park_q31(
+  q31_t Ialpha,
+  q31_t Ibeta,
+  q31_t * pId,
+  q31_t * pIq,
+  q31_t sinVal,
+  q31_t cosVal)
+  {
+    q31_t product1, product2;                    /* Temporary variables used to store intermediate results */
+    q31_t product3, product4;                    /* Temporary variables used to store intermediate results */
+
+    /* Intermediate product is calculated by (Ialpha * cosVal) */
+    product1 = (q31_t) (((q63_t) (Ialpha) * (cosVal)) >> 31);
+
+    /* Intermediate product is calculated by (Ibeta * sinVal) */
+    product2 = (q31_t) (((q63_t) (Ibeta) * (sinVal)) >> 31);
+
+
+    /* Intermediate product is calculated by (Ialpha * sinVal) */
+    product3 = (q31_t) (((q63_t) (Ialpha) * (sinVal)) >> 31);
+
+    /* Intermediate product is calculated by (Ibeta * cosVal) */
+    product4 = (q31_t) (((q63_t) (Ibeta) * (cosVal)) >> 31);
+
+    /* Calculate pId by adding the two intermediate products 1 and 2 */
+    *pId = __QADD(product1, product2);
+
+    /* Calculate pIq by subtracting the two intermediate products 3 from 4 */
+    *pIq = __QSUB(product4, product3);
+  }
+
+  /**
+   * @} end of park group
+   */
+
+  /**
+   * @brief  Converts the elements of the Q7 vector to floating-point vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[out]  *pDst is output pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @return none.
+   */
+  void arm_q7_to_float(
+  q7_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @ingroup groupController
+   */
+
+  /**
+   * @defgroup inv_park Vector Inverse Park transform
+   * Inverse Park transform converts the input flux and torque components to two-coordinate vector.
+   *
+   * The function operates on a single sample of data and each call to the function returns the processed output.
+   * The library provides separate functions for Q31 and floating-point data types.
+   * \par Algorithm
+   * \image html parkInvFormula.gif
+   * where <code>pIalpha</code> and <code>pIbeta</code> are the stator vector components,
+   * <code>Id</code> and <code>Iq</code> are rotor vector components and <code>cosVal</code> and <code>sinVal</code> are the
+   * cosine and sine values of theta (rotor flux position).
+   * \par Fixed-Point Behavior
+   * Care must be taken when using the Q31 version of the Park transform.
+   * In particular, the overflow and saturation behavior of the accumulator used must be considered.
+   * Refer to the function specific documentation below for usage guidelines.
+   */
+
+  /**
+   * @addtogroup inv_park
+   * @{
+   */
+
+   /**
+   * @brief  Floating-point Inverse Park transform
+   * @param[in]       Id        input coordinate of rotor reference frame d
+   * @param[in]       Iq        input coordinate of rotor reference frame q
+   * @param[out]      *pIalpha  points to output two-phase orthogonal vector axis alpha
+   * @param[out]      *pIbeta   points to output two-phase orthogonal vector axis beta
+   * @param[in]       sinVal    sine value of rotation angle theta
+   * @param[in]       cosVal    cosine value of rotation angle theta
+   * @return none.
+   */
+
+  static __INLINE void arm_inv_park_f32(
+  float32_t Id,
+  float32_t Iq,
+  float32_t * pIalpha,
+  float32_t * pIbeta,
+  float32_t sinVal,
+  float32_t cosVal)
+  {
+    /* Calculate pIalpha using the equation, pIalpha = Id * cosVal - Iq * sinVal */
+    *pIalpha = Id * cosVal - Iq * sinVal;
+
+    /* Calculate pIbeta using the equation, pIbeta = Id * sinVal + Iq * cosVal */
+    *pIbeta = Id * sinVal + Iq * cosVal;
+
+  }
+
+
+  /**
+   * @brief  Inverse Park transform for	Q31 version
+   * @param[in]       Id        input coordinate of rotor reference frame d
+   * @param[in]       Iq        input coordinate of rotor reference frame q
+   * @param[out]      *pIalpha  points to output two-phase orthogonal vector axis alpha
+   * @param[out]      *pIbeta   points to output two-phase orthogonal vector axis beta
+   * @param[in]       sinVal    sine value of rotation angle theta
+   * @param[in]       cosVal    cosine value of rotation angle theta
+   * @return none.
+   *
+   * <b>Scaling and Overflow Behavior:</b>
+   * \par
+   * The function is implemented using an internal 32-bit accumulator.
+   * The accumulator maintains 1.31 format by truncating lower 31 bits of the intermediate multiplication in 2.62 format.
+   * There is saturation on the addition, hence there is no risk of overflow.
+   */
+
+
+  static __INLINE void arm_inv_park_q31(
+  q31_t Id,
+  q31_t Iq,
+  q31_t * pIalpha,
+  q31_t * pIbeta,
+  q31_t sinVal,
+  q31_t cosVal)
+  {
+    q31_t product1, product2;                    /* Temporary variables used to store intermediate results */
+    q31_t product3, product4;                    /* Temporary variables used to store intermediate results */
+
+    /* Intermediate product is calculated by (Id * cosVal) */
+    product1 = (q31_t) (((q63_t) (Id) * (cosVal)) >> 31);
+
+    /* Intermediate product is calculated by (Iq * sinVal) */
+    product2 = (q31_t) (((q63_t) (Iq) * (sinVal)) >> 31);
+
+
+    /* Intermediate product is calculated by (Id * sinVal) */
+    product3 = (q31_t) (((q63_t) (Id) * (sinVal)) >> 31);
+
+    /* Intermediate product is calculated by (Iq * cosVal) */
+    product4 = (q31_t) (((q63_t) (Iq) * (cosVal)) >> 31);
+
+    /* Calculate pIalpha by using the two intermediate products 1 and 2 */
+    *pIalpha = __QSUB(product1, product2);
+
+    /* Calculate pIbeta by using the two intermediate products 3 and 4 */
+    *pIbeta = __QADD(product4, product3);
+
+  }
+
+  /**
+   * @} end of Inverse park group
+   */
+
+
+  /**
+   * @brief  Converts the elements of the Q31 vector to floating-point vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[out]  *pDst is output pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @return none.
+   */
+  void arm_q31_to_float(
+  q31_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @ingroup groupInterpolation
+   */
+
+  /**
+   * @defgroup LinearInterpolate Linear Interpolation
+   *
+   * Linear interpolation is a method of curve fitting using linear polynomials.
+   * Linear interpolation works by effectively drawing a straight line between two neighboring samples and returning the appropriate point along that line
+   *
+   * \par
+   * \image html LinearInterp.gif "Linear interpolation"
+   *
+   * \par
+   * A  Linear Interpolate function calculates an output value(y), for the input(x)
+   * using linear interpolation of the input values x0, x1( nearest input values) and the output values y0 and y1(nearest output values)
+   *
+   * \par Algorithm:
+   * <pre>
+   *       y = y0 + (x - x0) * ((y1 - y0)/(x1-x0))
+   *       where x0, x1 are nearest values of input x
+   *             y0, y1 are nearest values to output y
+   * </pre>
+   *
+   * \par
+   * This set of functions implements Linear interpolation process
+   * for Q7, Q15, Q31, and floating-point data types.  The functions operate on a single
+   * sample of data and each call to the function returns a single processed value.
+   * <code>S</code> points to an instance of the Linear Interpolate function data structure.
+   * <code>x</code> is the input sample value. The functions returns the output value.
+   *
+   * \par
+   * if x is outside of the table boundary, Linear interpolation returns first value of the table
+   * if x is below input range and returns last value of table if x is above range.
+   */
+
+  /**
+   * @addtogroup LinearInterpolate
+   * @{
+   */
+
+  /**
+   * @brief  Process function for the floating-point Linear Interpolation Function.
+   * @param[in,out] *S is an instance of the floating-point Linear Interpolation structure
+   * @param[in] x input sample to process
+   * @return y processed output sample.
+   *
+   */
+
+  static __INLINE float32_t arm_linear_interp_f32(
+  arm_linear_interp_instance_f32 * S,
+  float32_t x)
+  {
+
+    float32_t y;
+    float32_t x0, x1;                            /* Nearest input values */
+    float32_t y0, y1;                            /* Nearest output values */
+    float32_t xSpacing = S->xSpacing;            /* spacing between input values */
+    int32_t i;                                   /* Index variable */
+    float32_t *pYData = S->pYData;               /* pointer to output table */
+
+    /* Calculation of index */
+    i = (int32_t) ((x - S->x1) / xSpacing);
+
+    if(i < 0)
+    {
+      /* Iniatilize output for below specified range as least output value of table */
+      y = pYData[0];
+    }
+    else if((uint32_t)i >= S->nValues)
+    {
+      /* Iniatilize output for above specified range as last output value of table */
+      y = pYData[S->nValues - 1];
+    }
+    else
+    {
+      /* Calculation of nearest input values */
+      x0 = S->x1 + i * xSpacing;
+      x1 = S->x1 + (i + 1) * xSpacing;
+
+      /* Read of nearest output values */
+      y0 = pYData[i];
+      y1 = pYData[i + 1];
+
+      /* Calculation of output */
+      y = y0 + (x - x0) * ((y1 - y0) / (x1 - x0));
+
+    }
+
+    /* returns output value */
+    return (y);
+  }
+
+   /**
+   *
+   * @brief  Process function for the Q31 Linear Interpolation Function.
+   * @param[in] *pYData  pointer to Q31 Linear Interpolation table
+   * @param[in] x input sample to process
+   * @param[in] nValues number of table values
+   * @return y processed output sample.
+   *
+   * \par
+   * Input sample <code>x</code> is in 12.20 format which contains 12 bits for table index and 20 bits for fractional part.
+   * This function can support maximum of table size 2^12.
+   *
+   */
+
+
+  static __INLINE q31_t arm_linear_interp_q31(
+  q31_t * pYData,
+  q31_t x,
+  uint32_t nValues)
+  {
+    q31_t y;                                     /* output */
+    q31_t y0, y1;                                /* Nearest output values */
+    q31_t fract;                                 /* fractional part */
+    int32_t index;                               /* Index to read nearest output values */
+
+    /* Input is in 12.20 format */
+    /* 12 bits for the table index */
+    /* Index value calculation */
+    index = ((x & 0xFFF00000) >> 20);
+
+    if(index >= (int32_t)(nValues - 1))
+    {
+      return (pYData[nValues - 1]);
+    }
+    else if(index < 0)
+    {
+      return (pYData[0]);
+    }
+    else
+    {
+
+      /* 20 bits for the fractional part */
+      /* shift left by 11 to keep fract in 1.31 format */
+      fract = (x & 0x000FFFFF) << 11;
+
+      /* Read two nearest output values from the index in 1.31(q31) format */
+      y0 = pYData[index];
+      y1 = pYData[index + 1u];
+
+      /* Calculation of y0 * (1-fract) and y is in 2.30 format */
+      y = ((q31_t) ((q63_t) y0 * (0x7FFFFFFF - fract) >> 32));
+
+      /* Calculation of y0 * (1-fract) + y1 *fract and y is in 2.30 format */
+      y += ((q31_t) (((q63_t) y1 * fract) >> 32));
+
+      /* Convert y to 1.31 format */
+      return (y << 1u);
+
+    }
+
+  }
+
+  /**
+   *
+   * @brief  Process function for the Q15 Linear Interpolation Function.
+   * @param[in] *pYData  pointer to Q15 Linear Interpolation table
+   * @param[in] x input sample to process
+   * @param[in] nValues number of table values
+   * @return y processed output sample.
+   *
+   * \par
+   * Input sample <code>x</code> is in 12.20 format which contains 12 bits for table index and 20 bits for fractional part.
+   * This function can support maximum of table size 2^12.
+   *
+   */
+
+
+  static __INLINE q15_t arm_linear_interp_q15(
+  q15_t * pYData,
+  q31_t x,
+  uint32_t nValues)
+  {
+    q63_t y;                                     /* output */
+    q15_t y0, y1;                                /* Nearest output values */
+    q31_t fract;                                 /* fractional part */
+    int32_t index;                               /* Index to read nearest output values */
+
+    /* Input is in 12.20 format */
+    /* 12 bits for the table index */
+    /* Index value calculation */
+    index = ((x & 0xFFF00000) >> 20u);
+
+    if(index >= (int32_t)(nValues - 1))
+    {
+      return (pYData[nValues - 1]);
+    }
+    else if(index < 0)
+    {
+      return (pYData[0]);
+    }
+    else
+    {
+      /* 20 bits for the fractional part */
+      /* fract is in 12.20 format */
+      fract = (x & 0x000FFFFF);
+
+      /* Read two nearest output values from the index */
+      y0 = pYData[index];
+      y1 = pYData[index + 1u];
+
+      /* Calculation of y0 * (1-fract) and y is in 13.35 format */
+      y = ((q63_t) y0 * (0xFFFFF - fract));
+
+      /* Calculation of (y0 * (1-fract) + y1 * fract) and y is in 13.35 format */
+      y += ((q63_t) y1 * (fract));
+
+      /* convert y to 1.15 format */
+      return (y >> 20);
+    }
+
+
+  }
+
+  /**
+   *
+   * @brief  Process function for the Q7 Linear Interpolation Function.
+   * @param[in] *pYData  pointer to Q7 Linear Interpolation table
+   * @param[in] x input sample to process
+   * @param[in] nValues number of table values
+   * @return y processed output sample.
+   *
+   * \par
+   * Input sample <code>x</code> is in 12.20 format which contains 12 bits for table index and 20 bits for fractional part.
+   * This function can support maximum of table size 2^12.
+   */
+
+
+  static __INLINE q7_t arm_linear_interp_q7(
+  q7_t * pYData,
+  q31_t x,
+  uint32_t nValues)
+  {
+    q31_t y;                                     /* output */
+    q7_t y0, y1;                                 /* Nearest output values */
+    q31_t fract;                                 /* fractional part */
+    uint32_t index;                              /* Index to read nearest output values */
+
+    /* Input is in 12.20 format */
+    /* 12 bits for the table index */
+    /* Index value calculation */
+    if (x < 0)
+    {
+      return (pYData[0]);
+    }
+    index = (x >> 20) & 0xfff;
+
+
+    if(index >= (nValues - 1))
+    {
+      return (pYData[nValues - 1]);
+    }
+    else
+    {
+
+      /* 20 bits for the fractional part */
+      /* fract is in 12.20 format */
+      fract = (x & 0x000FFFFF);
+
+      /* Read two nearest output values from the index and are in 1.7(q7) format */
+      y0 = pYData[index];
+      y1 = pYData[index + 1u];
+
+      /* Calculation of y0 * (1-fract ) and y is in 13.27(q27) format */
+      y = ((y0 * (0xFFFFF - fract)));
+
+      /* Calculation of y1 * fract + y0 * (1-fract) and y is in 13.27(q27) format */
+      y += (y1 * fract);
+
+      /* convert y to 1.7(q7) format */
+      return (y >> 20u);
+
+    }
+
+  }
+  /**
+   * @} end of LinearInterpolate group
+   */
+
+  /**
+   * @brief  Fast approximation to the trigonometric sine function for floating-point data.
+   * @param[in] x input value in radians.
+   * @return  sin(x).
+   */
+
+  float32_t arm_sin_f32(
+  float32_t x);
+
+  /**
+   * @brief  Fast approximation to the trigonometric sine function for Q31 data.
+   * @param[in] x Scaled input value in radians.
+   * @return  sin(x).
+   */
+
+  q31_t arm_sin_q31(
+  q31_t x);
+
+  /**
+   * @brief  Fast approximation to the trigonometric sine function for Q15 data.
+   * @param[in] x Scaled input value in radians.
+   * @return  sin(x).
+   */
+
+  q15_t arm_sin_q15(
+  q15_t x);
+
+  /**
+   * @brief  Fast approximation to the trigonometric cosine function for floating-point data.
+   * @param[in] x input value in radians.
+   * @return  cos(x).
+   */
+
+  float32_t arm_cos_f32(
+  float32_t x);
+
+  /**
+   * @brief Fast approximation to the trigonometric cosine function for Q31 data.
+   * @param[in] x Scaled input value in radians.
+   * @return  cos(x).
+   */
+
+  q31_t arm_cos_q31(
+  q31_t x);
+
+  /**
+   * @brief  Fast approximation to the trigonometric cosine function for Q15 data.
+   * @param[in] x Scaled input value in radians.
+   * @return  cos(x).
+   */
+
+  q15_t arm_cos_q15(
+  q15_t x);
+
+
+  /**
+   * @ingroup groupFastMath
+   */
+
+
+  /**
+   * @defgroup SQRT Square Root
+   *
+   * Computes the square root of a number.
+   * There are separate functions for Q15, Q31, and floating-point data types.
+   * The square root function is computed using the Newton-Raphson algorithm.
+   * This is an iterative algorithm of the form:
+   * <pre>
+   *      x1 = x0 - f(x0)/f'(x0)
+   * </pre>
+   * where <code>x1</code> is the current estimate,
+   * <code>x0</code> is the previous estimate, and
+   * <code>f'(x0)</code> is the derivative of <code>f()</code> evaluated at <code>x0</code>.
+   * For the square root function, the algorithm reduces to:
+   * <pre>
+   *     x0 = in/2                         [initial guess]
+   *     x1 = 1/2 * ( x0 + in / x0)        [each iteration]
+   * </pre>
+   */
+
+
+  /**
+   * @addtogroup SQRT
+   * @{
+   */
+
+  /**
+   * @brief  Floating-point square root function.
+   * @param[in]  in     input value.
+   * @param[out] *pOut  square root of input value.
+   * @return The function returns ARM_MATH_SUCCESS if input value is positive value or ARM_MATH_ARGUMENT_ERROR if
+   * <code>in</code> is negative value and returns zero output for negative values.
+   */
+
+  static __INLINE arm_status arm_sqrt_f32(
+  float32_t in,
+  float32_t * pOut)
+  {
+    if(in > 0)
+    {
+
+//      #if __FPU_USED
+#if (__FPU_USED == 1) && defined ( __CC_ARM   )
+      *pOut = __sqrtf(in);
+#else
+      *pOut = sqrtf(in);
+#endif
+
+      return (ARM_MATH_SUCCESS);
+    }
+    else
+    {
+      *pOut = 0.0f;
+      return (ARM_MATH_ARGUMENT_ERROR);
+    }
+
+  }
+
+
+  /**
+   * @brief Q31 square root function.
+   * @param[in]   in    input value.  The range of the input value is [0 +1) or 0x00000000 to 0x7FFFFFFF.
+   * @param[out]  *pOut square root of input value.
+   * @return The function returns ARM_MATH_SUCCESS if input value is positive value or ARM_MATH_ARGUMENT_ERROR if
+   * <code>in</code> is negative value and returns zero output for negative values.
+   */
+  arm_status arm_sqrt_q31(
+  q31_t in,
+  q31_t * pOut);
+
+  /**
+   * @brief  Q15 square root function.
+   * @param[in]   in     input value.  The range of the input value is [0 +1) or 0x0000 to 0x7FFF.
+   * @param[out]  *pOut  square root of input value.
+   * @return The function returns ARM_MATH_SUCCESS if input value is positive value or ARM_MATH_ARGUMENT_ERROR if
+   * <code>in</code> is negative value and returns zero output for negative values.
+   */
+  arm_status arm_sqrt_q15(
+  q15_t in,
+  q15_t * pOut);
+
+  /**
+   * @} end of SQRT group
+   */
+
+
+
+
+
+
+  /**
+   * @brief floating-point Circular write function.
+   */
+
+  static __INLINE void arm_circularWrite_f32(
+  int32_t * circBuffer,
+  int32_t L,
+  uint16_t * writeOffset,
+  int32_t bufferInc,
+  const int32_t * src,
+  int32_t srcInc,
+  uint32_t blockSize)
+  {
+    uint32_t i = 0u;
+    int32_t wOffset;
+
+    /* Copy the value of Index pointer that points
+     * to the current location where the input samples to be copied */
+    wOffset = *writeOffset;
+
+    /* Loop over the blockSize */
+    i = blockSize;
+
+    while(i > 0u)
+    {
+      /* copy the input sample to the circular buffer */
+      circBuffer[wOffset] = *src;
+
+      /* Update the input pointer */
+      src += srcInc;
+
+      /* Circularly update wOffset.  Watch out for positive and negative value */
+      wOffset += bufferInc;
+      if(wOffset >= L)
+        wOffset -= L;
+
+      /* Decrement the loop counter */
+      i--;
+    }
+
+    /* Update the index pointer */
+    *writeOffset = wOffset;
+  }
+
+
+
+  /**
+   * @brief floating-point Circular Read function.
+   */
+  static __INLINE void arm_circularRead_f32(
+  int32_t * circBuffer,
+  int32_t L,
+  int32_t * readOffset,
+  int32_t bufferInc,
+  int32_t * dst,
+  int32_t * dst_base,
+  int32_t dst_length,
+  int32_t dstInc,
+  uint32_t blockSize)
+  {
+    uint32_t i = 0u;
+    int32_t rOffset, dst_end;
+
+    /* Copy the value of Index pointer that points
+     * to the current location from where the input samples to be read */
+    rOffset = *readOffset;
+    dst_end = (int32_t) (dst_base + dst_length);
+
+    /* Loop over the blockSize */
+    i = blockSize;
+
+    while(i > 0u)
+    {
+      /* copy the sample from the circular buffer to the destination buffer */
+      *dst = circBuffer[rOffset];
+
+      /* Update the input pointer */
+      dst += dstInc;
+
+      if(dst == (int32_t *) dst_end)
+      {
+        dst = dst_base;
+      }
+
+      /* Circularly update rOffset.  Watch out for positive and negative value  */
+      rOffset += bufferInc;
+
+      if(rOffset >= L)
+      {
+        rOffset -= L;
+      }
+
+      /* Decrement the loop counter */
+      i--;
+    }
+
+    /* Update the index pointer */
+    *readOffset = rOffset;
+  }
+
+  /**
+   * @brief Q15 Circular write function.
+   */
+
+  static __INLINE void arm_circularWrite_q15(
+  q15_t * circBuffer,
+  int32_t L,
+  uint16_t * writeOffset,
+  int32_t bufferInc,
+  const q15_t * src,
+  int32_t srcInc,
+  uint32_t blockSize)
+  {
+    uint32_t i = 0u;
+    int32_t wOffset;
+
+    /* Copy the value of Index pointer that points
+     * to the current location where the input samples to be copied */
+    wOffset = *writeOffset;
+
+    /* Loop over the blockSize */
+    i = blockSize;
+
+    while(i > 0u)
+    {
+      /* copy the input sample to the circular buffer */
+      circBuffer[wOffset] = *src;
+
+      /* Update the input pointer */
+      src += srcInc;
+
+      /* Circularly update wOffset.  Watch out for positive and negative value */
+      wOffset += bufferInc;
+      if(wOffset >= L)
+        wOffset -= L;
+
+      /* Decrement the loop counter */
+      i--;
+    }
+
+    /* Update the index pointer */
+    *writeOffset = wOffset;
+  }
+
+
+
+  /**
+   * @brief Q15 Circular Read function.
+   */
+  static __INLINE void arm_circularRead_q15(
+  q15_t * circBuffer,
+  int32_t L,
+  int32_t * readOffset,
+  int32_t bufferInc,
+  q15_t * dst,
+  q15_t * dst_base,
+  int32_t dst_length,
+  int32_t dstInc,
+  uint32_t blockSize)
+  {
+    uint32_t i = 0;
+    int32_t rOffset, dst_end;
+
+    /* Copy the value of Index pointer that points
+     * to the current location from where the input samples to be read */
+    rOffset = *readOffset;
+
+    dst_end = (int32_t) (dst_base + dst_length);
+
+    /* Loop over the blockSize */
+    i = blockSize;
+
+    while(i > 0u)
+    {
+      /* copy the sample from the circular buffer to the destination buffer */
+      *dst = circBuffer[rOffset];
+
+      /* Update the input pointer */
+      dst += dstInc;
+
+      if(dst == (q15_t *) dst_end)
+      {
+        dst = dst_base;
+      }
+
+      /* Circularly update wOffset.  Watch out for positive and negative value */
+      rOffset += bufferInc;
+
+      if(rOffset >= L)
+      {
+        rOffset -= L;
+      }
+
+      /* Decrement the loop counter */
+      i--;
+    }
+
+    /* Update the index pointer */
+    *readOffset = rOffset;
+  }
+
+
+  /**
+   * @brief Q7 Circular write function.
+   */
+
+  static __INLINE void arm_circularWrite_q7(
+  q7_t * circBuffer,
+  int32_t L,
+  uint16_t * writeOffset,
+  int32_t bufferInc,
+  const q7_t * src,
+  int32_t srcInc,
+  uint32_t blockSize)
+  {
+    uint32_t i = 0u;
+    int32_t wOffset;
+
+    /* Copy the value of Index pointer that points
+     * to the current location where the input samples to be copied */
+    wOffset = *writeOffset;
+
+    /* Loop over the blockSize */
+    i = blockSize;
+
+    while(i > 0u)
+    {
+      /* copy the input sample to the circular buffer */
+      circBuffer[wOffset] = *src;
+
+      /* Update the input pointer */
+      src += srcInc;
+
+      /* Circularly update wOffset.  Watch out for positive and negative value */
+      wOffset += bufferInc;
+      if(wOffset >= L)
+        wOffset -= L;
+
+      /* Decrement the loop counter */
+      i--;
+    }
+
+    /* Update the index pointer */
+    *writeOffset = wOffset;
+  }
+
+
+
+  /**
+   * @brief Q7 Circular Read function.
+   */
+  static __INLINE void arm_circularRead_q7(
+  q7_t * circBuffer,
+  int32_t L,
+  int32_t * readOffset,
+  int32_t bufferInc,
+  q7_t * dst,
+  q7_t * dst_base,
+  int32_t dst_length,
+  int32_t dstInc,
+  uint32_t blockSize)
+  {
+    uint32_t i = 0;
+    int32_t rOffset, dst_end;
+
+    /* Copy the value of Index pointer that points
+     * to the current location from where the input samples to be read */
+    rOffset = *readOffset;
+
+    dst_end = (int32_t) (dst_base + dst_length);
+
+    /* Loop over the blockSize */
+    i = blockSize;
+
+    while(i > 0u)
+    {
+      /* copy the sample from the circular buffer to the destination buffer */
+      *dst = circBuffer[rOffset];
+
+      /* Update the input pointer */
+      dst += dstInc;
+
+      if(dst == (q7_t *) dst_end)
+      {
+        dst = dst_base;
+      }
+
+      /* Circularly update rOffset.  Watch out for positive and negative value */
+      rOffset += bufferInc;
+
+      if(rOffset >= L)
+      {
+        rOffset -= L;
+      }
+
+      /* Decrement the loop counter */
+      i--;
+    }
+
+    /* Update the index pointer */
+    *readOffset = rOffset;
+  }
+
+
+  /**
+   * @brief  Sum of the squares of the elements of a Q31 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_power_q31(
+  q31_t * pSrc,
+  uint32_t blockSize,
+  q63_t * pResult);
+
+  /**
+   * @brief  Sum of the squares of the elements of a floating-point vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_power_f32(
+  float32_t * pSrc,
+  uint32_t blockSize,
+  float32_t * pResult);
+
+  /**
+   * @brief  Sum of the squares of the elements of a Q15 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_power_q15(
+  q15_t * pSrc,
+  uint32_t blockSize,
+  q63_t * pResult);
+
+  /**
+   * @brief  Sum of the squares of the elements of a Q7 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_power_q7(
+  q7_t * pSrc,
+  uint32_t blockSize,
+  q31_t * pResult);
+
+  /**
+   * @brief  Mean value of a Q7 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_mean_q7(
+  q7_t * pSrc,
+  uint32_t blockSize,
+  q7_t * pResult);
+
+  /**
+   * @brief  Mean value of a Q15 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+  void arm_mean_q15(
+  q15_t * pSrc,
+  uint32_t blockSize,
+  q15_t * pResult);
+
+  /**
+   * @brief  Mean value of a Q31 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+  void arm_mean_q31(
+  q31_t * pSrc,
+  uint32_t blockSize,
+  q31_t * pResult);
+
+  /**
+   * @brief  Mean value of a floating-point vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+  void arm_mean_f32(
+  float32_t * pSrc,
+  uint32_t blockSize,
+  float32_t * pResult);
+
+  /**
+   * @brief  Variance of the elements of a floating-point vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_var_f32(
+  float32_t * pSrc,
+  uint32_t blockSize,
+  float32_t * pResult);
+
+  /**
+   * @brief  Variance of the elements of a Q31 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_var_q31(
+  q31_t * pSrc,
+  uint32_t blockSize,
+  q31_t * pResult);
+
+  /**
+   * @brief  Variance of the elements of a Q15 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_var_q15(
+  q15_t * pSrc,
+  uint32_t blockSize,
+  q15_t * pResult);
+
+  /**
+   * @brief  Root Mean Square of the elements of a floating-point vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_rms_f32(
+  float32_t * pSrc,
+  uint32_t blockSize,
+  float32_t * pResult);
+
+  /**
+   * @brief  Root Mean Square of the elements of a Q31 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_rms_q31(
+  q31_t * pSrc,
+  uint32_t blockSize,
+  q31_t * pResult);
+
+  /**
+   * @brief  Root Mean Square of the elements of a Q15 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_rms_q15(
+  q15_t * pSrc,
+  uint32_t blockSize,
+  q15_t * pResult);
+
+  /**
+   * @brief  Standard deviation of the elements of a floating-point vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_std_f32(
+  float32_t * pSrc,
+  uint32_t blockSize,
+  float32_t * pResult);
+
+  /**
+   * @brief  Standard deviation of the elements of a Q31 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_std_q31(
+  q31_t * pSrc,
+  uint32_t blockSize,
+  q31_t * pResult);
+
+  /**
+   * @brief  Standard deviation of the elements of a Q15 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output value.
+   * @return none.
+   */
+
+  void arm_std_q15(
+  q15_t * pSrc,
+  uint32_t blockSize,
+  q15_t * pResult);
+
+  /**
+   * @brief  Floating-point complex magnitude
+   * @param[in]  *pSrc points to the complex input vector
+   * @param[out]  *pDst points to the real output vector
+   * @param[in]  numSamples number of complex samples in the input vector
+   * @return none.
+   */
+
+  void arm_cmplx_mag_f32(
+  float32_t * pSrc,
+  float32_t * pDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Q31 complex magnitude
+   * @param[in]  *pSrc points to the complex input vector
+   * @param[out]  *pDst points to the real output vector
+   * @param[in]  numSamples number of complex samples in the input vector
+   * @return none.
+   */
+
+  void arm_cmplx_mag_q31(
+  q31_t * pSrc,
+  q31_t * pDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Q15 complex magnitude
+   * @param[in]  *pSrc points to the complex input vector
+   * @param[out]  *pDst points to the real output vector
+   * @param[in]  numSamples number of complex samples in the input vector
+   * @return none.
+   */
+
+  void arm_cmplx_mag_q15(
+  q15_t * pSrc,
+  q15_t * pDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Q15 complex dot product
+   * @param[in]  *pSrcA points to the first input vector
+   * @param[in]  *pSrcB points to the second input vector
+   * @param[in]  numSamples number of complex samples in each vector
+   * @param[out]  *realResult real part of the result returned here
+   * @param[out]  *imagResult imaginary part of the result returned here
+   * @return none.
+   */
+
+  void arm_cmplx_dot_prod_q15(
+  q15_t * pSrcA,
+  q15_t * pSrcB,
+  uint32_t numSamples,
+  q31_t * realResult,
+  q31_t * imagResult);
+
+  /**
+   * @brief  Q31 complex dot product
+   * @param[in]  *pSrcA points to the first input vector
+   * @param[in]  *pSrcB points to the second input vector
+   * @param[in]  numSamples number of complex samples in each vector
+   * @param[out]  *realResult real part of the result returned here
+   * @param[out]  *imagResult imaginary part of the result returned here
+   * @return none.
+   */
+
+  void arm_cmplx_dot_prod_q31(
+  q31_t * pSrcA,
+  q31_t * pSrcB,
+  uint32_t numSamples,
+  q63_t * realResult,
+  q63_t * imagResult);
+
+  /**
+   * @brief  Floating-point complex dot product
+   * @param[in]  *pSrcA points to the first input vector
+   * @param[in]  *pSrcB points to the second input vector
+   * @param[in]  numSamples number of complex samples in each vector
+   * @param[out]  *realResult real part of the result returned here
+   * @param[out]  *imagResult imaginary part of the result returned here
+   * @return none.
+   */
+
+  void arm_cmplx_dot_prod_f32(
+  float32_t * pSrcA,
+  float32_t * pSrcB,
+  uint32_t numSamples,
+  float32_t * realResult,
+  float32_t * imagResult);
+
+  /**
+   * @brief  Q15 complex-by-real multiplication
+   * @param[in]  *pSrcCmplx points to the complex input vector
+   * @param[in]  *pSrcReal points to the real input vector
+   * @param[out]  *pCmplxDst points to the complex output vector
+   * @param[in]  numSamples number of samples in each vector
+   * @return none.
+   */
+
+  void arm_cmplx_mult_real_q15(
+  q15_t * pSrcCmplx,
+  q15_t * pSrcReal,
+  q15_t * pCmplxDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Q31 complex-by-real multiplication
+   * @param[in]  *pSrcCmplx points to the complex input vector
+   * @param[in]  *pSrcReal points to the real input vector
+   * @param[out]  *pCmplxDst points to the complex output vector
+   * @param[in]  numSamples number of samples in each vector
+   * @return none.
+   */
+
+  void arm_cmplx_mult_real_q31(
+  q31_t * pSrcCmplx,
+  q31_t * pSrcReal,
+  q31_t * pCmplxDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Floating-point complex-by-real multiplication
+   * @param[in]  *pSrcCmplx points to the complex input vector
+   * @param[in]  *pSrcReal points to the real input vector
+   * @param[out]  *pCmplxDst points to the complex output vector
+   * @param[in]  numSamples number of samples in each vector
+   * @return none.
+   */
+
+  void arm_cmplx_mult_real_f32(
+  float32_t * pSrcCmplx,
+  float32_t * pSrcReal,
+  float32_t * pCmplxDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Minimum value of a Q7 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *result is output pointer
+   * @param[in]  index is the array index of the minimum value in the input buffer.
+   * @return none.
+   */
+
+  void arm_min_q7(
+  q7_t * pSrc,
+  uint32_t blockSize,
+  q7_t * result,
+  uint32_t * index);
+
+  /**
+   * @brief  Minimum value of a Q15 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output pointer
+   * @param[in]  *pIndex is the array index of the minimum value in the input buffer.
+   * @return none.
+   */
+
+  void arm_min_q15(
+  q15_t * pSrc,
+  uint32_t blockSize,
+  q15_t * pResult,
+  uint32_t * pIndex);
+
+  /**
+   * @brief  Minimum value of a Q31 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output pointer
+   * @param[out]  *pIndex is the array index of the minimum value in the input buffer.
+   * @return none.
+   */
+  void arm_min_q31(
+  q31_t * pSrc,
+  uint32_t blockSize,
+  q31_t * pResult,
+  uint32_t * pIndex);
+
+  /**
+   * @brief  Minimum value of a floating-point vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @param[out]  *pResult is output pointer
+   * @param[out]  *pIndex is the array index of the minimum value in the input buffer.
+   * @return none.
+   */
+
+  void arm_min_f32(
+  float32_t * pSrc,
+  uint32_t blockSize,
+  float32_t * pResult,
+  uint32_t * pIndex);
+
+/**
+ * @brief Maximum value of a Q7 vector.
+ * @param[in]       *pSrc points to the input buffer
+ * @param[in]       blockSize length of the input vector
+ * @param[out]      *pResult maximum value returned here
+ * @param[out]      *pIndex index of maximum value returned here
+ * @return none.
+ */
+
+  void arm_max_q7(
+  q7_t * pSrc,
+  uint32_t blockSize,
+  q7_t * pResult,
+  uint32_t * pIndex);
+
+/**
+ * @brief Maximum value of a Q15 vector.
+ * @param[in]       *pSrc points to the input buffer
+ * @param[in]       blockSize length of the input vector
+ * @param[out]      *pResult maximum value returned here
+ * @param[out]      *pIndex index of maximum value returned here
+ * @return none.
+ */
+
+  void arm_max_q15(
+  q15_t * pSrc,
+  uint32_t blockSize,
+  q15_t * pResult,
+  uint32_t * pIndex);
+
+/**
+ * @brief Maximum value of a Q31 vector.
+ * @param[in]       *pSrc points to the input buffer
+ * @param[in]       blockSize length of the input vector
+ * @param[out]      *pResult maximum value returned here
+ * @param[out]      *pIndex index of maximum value returned here
+ * @return none.
+ */
+
+  void arm_max_q31(
+  q31_t * pSrc,
+  uint32_t blockSize,
+  q31_t * pResult,
+  uint32_t * pIndex);
+
+/**
+ * @brief Maximum value of a floating-point vector.
+ * @param[in]       *pSrc points to the input buffer
+ * @param[in]       blockSize length of the input vector
+ * @param[out]      *pResult maximum value returned here
+ * @param[out]      *pIndex index of maximum value returned here
+ * @return none.
+ */
+
+  void arm_max_f32(
+  float32_t * pSrc,
+  uint32_t blockSize,
+  float32_t * pResult,
+  uint32_t * pIndex);
+
+  /**
+   * @brief  Q15 complex-by-complex multiplication
+   * @param[in]  *pSrcA points to the first input vector
+   * @param[in]  *pSrcB points to the second input vector
+   * @param[out]  *pDst  points to the output vector
+   * @param[in]  numSamples number of complex samples in each vector
+   * @return none.
+   */
+
+  void arm_cmplx_mult_cmplx_q15(
+  q15_t * pSrcA,
+  q15_t * pSrcB,
+  q15_t * pDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Q31 complex-by-complex multiplication
+   * @param[in]  *pSrcA points to the first input vector
+   * @param[in]  *pSrcB points to the second input vector
+   * @param[out]  *pDst  points to the output vector
+   * @param[in]  numSamples number of complex samples in each vector
+   * @return none.
+   */
+
+  void arm_cmplx_mult_cmplx_q31(
+  q31_t * pSrcA,
+  q31_t * pSrcB,
+  q31_t * pDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief  Floating-point complex-by-complex multiplication
+   * @param[in]  *pSrcA points to the first input vector
+   * @param[in]  *pSrcB points to the second input vector
+   * @param[out]  *pDst  points to the output vector
+   * @param[in]  numSamples number of complex samples in each vector
+   * @return none.
+   */
+
+  void arm_cmplx_mult_cmplx_f32(
+  float32_t * pSrcA,
+  float32_t * pSrcB,
+  float32_t * pDst,
+  uint32_t numSamples);
+
+  /**
+   * @brief Converts the elements of the floating-point vector to Q31 vector.
+   * @param[in]       *pSrc points to the floating-point input vector
+   * @param[out]      *pDst points to the Q31 output vector
+   * @param[in]       blockSize length of the input vector
+   * @return none.
+   */
+  void arm_float_to_q31(
+  float32_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Converts the elements of the floating-point vector to Q15 vector.
+   * @param[in]       *pSrc points to the floating-point input vector
+   * @param[out]      *pDst points to the Q15 output vector
+   * @param[in]       blockSize length of the input vector
+   * @return          none
+   */
+  void arm_float_to_q15(
+  float32_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief Converts the elements of the floating-point vector to Q7 vector.
+   * @param[in]       *pSrc points to the floating-point input vector
+   * @param[out]      *pDst points to the Q7 output vector
+   * @param[in]       blockSize length of the input vector
+   * @return          none
+   */
+  void arm_float_to_q7(
+  float32_t * pSrc,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief  Converts the elements of the Q31 vector to Q15 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[out]  *pDst is output pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @return none.
+   */
+  void arm_q31_to_q15(
+  q31_t * pSrc,
+  q15_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Converts the elements of the Q31 vector to Q7 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[out]  *pDst is output pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @return none.
+   */
+  void arm_q31_to_q7(
+  q31_t * pSrc,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+  /**
+   * @brief  Converts the elements of the Q15 vector to floating-point vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[out]  *pDst is output pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @return none.
+   */
+  void arm_q15_to_float(
+  q15_t * pSrc,
+  float32_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief  Converts the elements of the Q15 vector to Q31 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[out]  *pDst is output pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @return none.
+   */
+  void arm_q15_to_q31(
+  q15_t * pSrc,
+  q31_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @brief  Converts the elements of the Q15 vector to Q7 vector.
+   * @param[in]  *pSrc is input pointer
+   * @param[out]  *pDst is output pointer
+   * @param[in]  blockSize is the number of samples to process
+   * @return none.
+   */
+  void arm_q15_to_q7(
+  q15_t * pSrc,
+  q7_t * pDst,
+  uint32_t blockSize);
+
+
+  /**
+   * @ingroup groupInterpolation
+   */
+
+  /**
+   * @defgroup BilinearInterpolate Bilinear Interpolation
+   *
+   * Bilinear interpolation is an extension of linear interpolation applied to a two dimensional grid.
+   * The underlying function <code>f(x, y)</code> is sampled on a regular grid and the interpolation process
+   * determines values between the grid points.
+   * Bilinear interpolation is equivalent to two step linear interpolation, first in the x-dimension and then in the y-dimension.
+   * Bilinear interpolation is often used in image processing to rescale images.
+   * The CMSIS DSP library provides bilinear interpolation functions for Q7, Q15, Q31, and floating-point data types.
+   *
+   * <b>Algorithm</b>
+   * \par
+   * The instance structure used by the bilinear interpolation functions describes a two dimensional data table.
+   * For floating-point, the instance structure is defined as:
+   * <pre>
+   *   typedef struct
+   *   {
+   *     uint16_t numRows;
+   *     uint16_t numCols;
+   *     float32_t *pData;
+   * } arm_bilinear_interp_instance_f32;
+   * </pre>
+   *
+   * \par
+   * where <code>numRows</code> specifies the number of rows in the table;
+   * <code>numCols</code> specifies the number of columns in the table;
+   * and <code>pData</code> points to an array of size <code>numRows*numCols</code> values.
+   * The data table <code>pTable</code> is organized in row order and the supplied data values fall on integer indexes.
+   * That is, table element (x,y) is located at <code>pTable[x + y*numCols]</code> where x and y are integers.
+   *
+   * \par
+   * Let <code>(x, y)</code> specify the desired interpolation point.  Then define:
+   * <pre>
+   *     XF = floor(x)
+   *     YF = floor(y)
+   * </pre>
+   * \par
+   * The interpolated output point is computed as:
+   * <pre>
+   *  f(x, y) = f(XF, YF) * (1-(x-XF)) * (1-(y-YF))
+   *           + f(XF+1, YF) * (x-XF)*(1-(y-YF))
+   *           + f(XF, YF+1) * (1-(x-XF))*(y-YF)
+   *           + f(XF+1, YF+1) * (x-XF)*(y-YF)
+   * </pre>
+   * Note that the coordinates (x, y) contain integer and fractional components.
+   * The integer components specify which portion of the table to use while the
+   * fractional components control the interpolation processor.
+   *
+   * \par
+   * if (x,y) are outside of the table boundary, Bilinear interpolation returns zero output.
+   */
+
+  /**
+   * @addtogroup BilinearInterpolate
+   * @{
+   */
+
+  /**
+  *
+  * @brief  Floating-point bilinear interpolation.
+  * @param[in,out] *S points to an instance of the interpolation structure.
+  * @param[in] X interpolation coordinate.
+  * @param[in] Y interpolation coordinate.
+  * @return out interpolated value.
+  */
+
+
+  static __INLINE float32_t arm_bilinear_interp_f32(
+  const arm_bilinear_interp_instance_f32 * S,
+  float32_t X,
+  float32_t Y)
+  {
+    float32_t out;
+    float32_t f00, f01, f10, f11;
+    float32_t *pData = S->pData;
+    int32_t xIndex, yIndex, index;
+    float32_t xdiff, ydiff;
+    float32_t b1, b2, b3, b4;
+
+    xIndex = (int32_t) X;
+    yIndex = (int32_t) Y;
+
+    /* Care taken for table outside boundary */
+    /* Returns zero output when values are outside table boundary */
+    if(xIndex < 0 || xIndex > (S->numRows - 1) || yIndex < 0
+       || yIndex > (S->numCols - 1))
+    {
+      return (0);
+    }
+
+    /* Calculation of index for two nearest points in X-direction */
+    index = (xIndex - 1) + (yIndex - 1) * S->numCols;
+
+
+    /* Read two nearest points in X-direction */
+    f00 = pData[index];
+    f01 = pData[index + 1];
+
+    /* Calculation of index for two nearest points in Y-direction */
+    index = (xIndex - 1) + (yIndex) * S->numCols;
+
+
+    /* Read two nearest points in Y-direction */
+    f10 = pData[index];
+    f11 = pData[index + 1];
+
+    /* Calculation of intermediate values */
+    b1 = f00;
+    b2 = f01 - f00;
+    b3 = f10 - f00;
+    b4 = f00 - f01 - f10 + f11;
+
+    /* Calculation of fractional part in X */
+    xdiff = X - xIndex;
+
+    /* Calculation of fractional part in Y */
+    ydiff = Y - yIndex;
+
+    /* Calculation of bi-linear interpolated output */
+    out = b1 + b2 * xdiff + b3 * ydiff + b4 * xdiff * ydiff;
+
+    /* return to application */
+    return (out);
+
+  }
+
+  /**
+  *
+  * @brief  Q31 bilinear interpolation.
+  * @param[in,out] *S points to an instance of the interpolation structure.
+  * @param[in] X interpolation coordinate in 12.20 format.
+  * @param[in] Y interpolation coordinate in 12.20 format.
+  * @return out interpolated value.
+  */
+
+  static __INLINE q31_t arm_bilinear_interp_q31(
+  arm_bilinear_interp_instance_q31 * S,
+  q31_t X,
+  q31_t Y)
+  {
+    q31_t out;                                   /* Temporary output */
+    q31_t acc = 0;                               /* output */
+    q31_t xfract, yfract;                        /* X, Y fractional parts */
+    q31_t x1, x2, y1, y2;                        /* Nearest output values */
+    int32_t rI, cI;                              /* Row and column indices */
+    q31_t *pYData = S->pData;                    /* pointer to output table values */
+    uint32_t nCols = S->numCols;                 /* num of rows */
+
+
+    /* Input is in 12.20 format */
+    /* 12 bits for the table index */
+    /* Index value calculation */
+    rI = ((X & 0xFFF00000) >> 20u);
+
+    /* Input is in 12.20 format */
+    /* 12 bits for the table index */
+    /* Index value calculation */
+    cI = ((Y & 0xFFF00000) >> 20u);
+
+    /* Care taken for table outside boundary */
+    /* Returns zero output when values are outside table boundary */
+    if(rI < 0 || rI > (S->numRows - 1) || cI < 0 || cI > (S->numCols - 1))
+    {
+      return (0);
+    }
+
+    /* 20 bits for the fractional part */
+    /* shift left xfract by 11 to keep 1.31 format */
+    xfract = (X & 0x000FFFFF) << 11u;
+
+    /* Read two nearest output values from the index */
+    x1 = pYData[(rI) + nCols * (cI)];
+    x2 = pYData[(rI) + nCols * (cI) + 1u];
+
+    /* 20 bits for the fractional part */
+    /* shift left yfract by 11 to keep 1.31 format */
+    yfract = (Y & 0x000FFFFF) << 11u;
+
+    /* Read two nearest output values from the index */
+    y1 = pYData[(rI) + nCols * (cI + 1)];
+    y2 = pYData[(rI) + nCols * (cI + 1) + 1u];
+
+    /* Calculation of x1 * (1-xfract ) * (1-yfract) and acc is in 3.29(q29) format */
+    out = ((q31_t) (((q63_t) x1 * (0x7FFFFFFF - xfract)) >> 32));
+    acc = ((q31_t) (((q63_t) out * (0x7FFFFFFF - yfract)) >> 32));
+
+    /* x2 * (xfract) * (1-yfract)  in 3.29(q29) and adding to acc */
+    out = ((q31_t) ((q63_t) x2 * (0x7FFFFFFF - yfract) >> 32));
+    acc += ((q31_t) ((q63_t) out * (xfract) >> 32));
+
+    /* y1 * (1 - xfract) * (yfract)  in 3.29(q29) and adding to acc */
+    out = ((q31_t) ((q63_t) y1 * (0x7FFFFFFF - xfract) >> 32));
+    acc += ((q31_t) ((q63_t) out * (yfract) >> 32));
+
+    /* y2 * (xfract) * (yfract)  in 3.29(q29) and adding to acc */
+    out = ((q31_t) ((q63_t) y2 * (xfract) >> 32));
+    acc += ((q31_t) ((q63_t) out * (yfract) >> 32));
+
+    /* Convert acc to 1.31(q31) format */
+    return (acc << 2u);
+
+  }
+
+  /**
+  * @brief  Q15 bilinear interpolation.
+  * @param[in,out] *S points to an instance of the interpolation structure.
+  * @param[in] X interpolation coordinate in 12.20 format.
+  * @param[in] Y interpolation coordinate in 12.20 format.
+  * @return out interpolated value.
+  */
+
+  static __INLINE q15_t arm_bilinear_interp_q15(
+  arm_bilinear_interp_instance_q15 * S,
+  q31_t X,
+  q31_t Y)
+  {
+    q63_t acc = 0;                               /* output */
+    q31_t out;                                   /* Temporary output */
+    q15_t x1, x2, y1, y2;                        /* Nearest output values */
+    q31_t xfract, yfract;                        /* X, Y fractional parts */
+    int32_t rI, cI;                              /* Row and column indices */
+    q15_t *pYData = S->pData;                    /* pointer to output table values */
+    uint32_t nCols = S->numCols;                 /* num of rows */
+
+    /* Input is in 12.20 format */
+    /* 12 bits for the table index */
+    /* Index value calculation */
+    rI = ((X & 0xFFF00000) >> 20);
+
+    /* Input is in 12.20 format */
+    /* 12 bits for the table index */
+    /* Index value calculation */
+    cI = ((Y & 0xFFF00000) >> 20);
+
+    /* Care taken for table outside boundary */
+    /* Returns zero output when values are outside table boundary */
+    if(rI < 0 || rI > (S->numRows - 1) || cI < 0 || cI > (S->numCols - 1))
+    {
+      return (0);
+    }
+
+    /* 20 bits for the fractional part */
+    /* xfract should be in 12.20 format */
+    xfract = (X & 0x000FFFFF);
+
+    /* Read two nearest output values from the index */
+    x1 = pYData[(rI) + nCols * (cI)];
+    x2 = pYData[(rI) + nCols * (cI) + 1u];
+
+
+    /* 20 bits for the fractional part */
+    /* yfract should be in 12.20 format */
+    yfract = (Y & 0x000FFFFF);
+
+    /* Read two nearest output values from the index */
+    y1 = pYData[(rI) + nCols * (cI + 1)];
+    y2 = pYData[(rI) + nCols * (cI + 1) + 1u];
+
+    /* Calculation of x1 * (1-xfract ) * (1-yfract) and acc is in 13.51 format */
+
+    /* x1 is in 1.15(q15), xfract in 12.20 format and out is in 13.35 format */
+    /* convert 13.35 to 13.31 by right shifting  and out is in 1.31 */
+    out = (q31_t) (((q63_t) x1 * (0xFFFFF - xfract)) >> 4u);
+    acc = ((q63_t) out * (0xFFFFF - yfract));
+
+    /* x2 * (xfract) * (1-yfract)  in 1.51 and adding to acc */
+    out = (q31_t) (((q63_t) x2 * (0xFFFFF - yfract)) >> 4u);
+    acc += ((q63_t) out * (xfract));
+
+    /* y1 * (1 - xfract) * (yfract)  in 1.51 and adding to acc */
+    out = (q31_t) (((q63_t) y1 * (0xFFFFF - xfract)) >> 4u);
+    acc += ((q63_t) out * (yfract));
+
+    /* y2 * (xfract) * (yfract)  in 1.51 and adding to acc */
+    out = (q31_t) (((q63_t) y2 * (xfract)) >> 4u);
+    acc += ((q63_t) out * (yfract));
+
+    /* acc is in 13.51 format and down shift acc by 36 times */
+    /* Convert out to 1.15 format */
+    return (acc >> 36);
+
+  }
+
+  /**
+  * @brief  Q7 bilinear interpolation.
+  * @param[in,out] *S points to an instance of the interpolation structure.
+  * @param[in] X interpolation coordinate in 12.20 format.
+  * @param[in] Y interpolation coordinate in 12.20 format.
+  * @return out interpolated value.
+  */
+
+  static __INLINE q7_t arm_bilinear_interp_q7(
+  arm_bilinear_interp_instance_q7 * S,
+  q31_t X,
+  q31_t Y)
+  {
+    q63_t acc = 0;                               /* output */
+    q31_t out;                                   /* Temporary output */
+    q31_t xfract, yfract;                        /* X, Y fractional parts */
+    q7_t x1, x2, y1, y2;                         /* Nearest output values */
+    int32_t rI, cI;                              /* Row and column indices */
+    q7_t *pYData = S->pData;                     /* pointer to output table values */
+    uint32_t nCols = S->numCols;                 /* num of rows */
+
+    /* Input is in 12.20 format */
+    /* 12 bits for the table index */
+    /* Index value calculation */
+    rI = ((X & 0xFFF00000) >> 20);
+
+    /* Input is in 12.20 format */
+    /* 12 bits for the table index */
+    /* Index value calculation */
+    cI = ((Y & 0xFFF00000) >> 20);
+
+    /* Care taken for table outside boundary */
+    /* Returns zero output when values are outside table boundary */
+    if(rI < 0 || rI > (S->numRows - 1) || cI < 0 || cI > (S->numCols - 1))
+    {
+      return (0);
+    }
+
+    /* 20 bits for the fractional part */
+    /* xfract should be in 12.20 format */
+    xfract = (X & 0x000FFFFF);
+
+    /* Read two nearest output values from the index */
+    x1 = pYData[(rI) + nCols * (cI)];
+    x2 = pYData[(rI) + nCols * (cI) + 1u];
+
+
+    /* 20 bits for the fractional part */
+    /* yfract should be in 12.20 format */
+    yfract = (Y & 0x000FFFFF);
+
+    /* Read two nearest output values from the index */
+    y1 = pYData[(rI) + nCols * (cI + 1)];
+    y2 = pYData[(rI) + nCols * (cI + 1) + 1u];
+
+    /* Calculation of x1 * (1-xfract ) * (1-yfract) and acc is in 16.47 format */
+    out = ((x1 * (0xFFFFF - xfract)));
+    acc = (((q63_t) out * (0xFFFFF - yfract)));
+
+    /* x2 * (xfract) * (1-yfract)  in 2.22 and adding to acc */
+    out = ((x2 * (0xFFFFF - yfract)));
+    acc += (((q63_t) out * (xfract)));
+
+    /* y1 * (1 - xfract) * (yfract)  in 2.22 and adding to acc */
+    out = ((y1 * (0xFFFFF - xfract)));
+    acc += (((q63_t) out * (yfract)));
+
+    /* y2 * (xfract) * (yfract)  in 2.22 and adding to acc */
+    out = ((y2 * (yfract)));
+    acc += (((q63_t) out * (xfract)));
+
+    /* acc in 16.47 format and down shift by 40 to convert to 1.7 format */
+    return (acc >> 40);
+
+  }
+
+  /**
+   * @} end of BilinearInterpolate group
+   */
+   
+
+//SMMLAR
+#define multAcc_32x32_keep32_R(a, x, y) \
+    a = (q31_t) (((((q63_t) a) << 32) + ((q63_t) x * y) + 0x80000000LL ) >> 32)
+
+//SMMLSR
+#define multSub_32x32_keep32_R(a, x, y) \
+    a = (q31_t) (((((q63_t) a) << 32) - ((q63_t) x * y) + 0x80000000LL ) >> 32)
+
+//SMMULR
+#define mult_32x32_keep32_R(a, x, y) \
+    a = (q31_t) (((q63_t) x * y + 0x80000000LL ) >> 32)
+
+//SMMLA
+#define multAcc_32x32_keep32(a, x, y) \
+    a += (q31_t) (((q63_t) x * y) >> 32)
+
+//SMMLS
+#define multSub_32x32_keep32(a, x, y) \
+    a -= (q31_t) (((q63_t) x * y) >> 32)
+
+//SMMUL
+#define mult_32x32_keep32(a, x, y) \
+    a = (q31_t) (((q63_t) x * y ) >> 32)
+
+
+#if defined ( __CC_ARM ) //Keil
+
+//Enter low optimization region - place directly above function definition
+    #ifdef ARM_MATH_CM4
+      #define LOW_OPTIMIZATION_ENTER \
+         _Pragma ("push")         \
+         _Pragma ("O1")
+    #else
+      #define LOW_OPTIMIZATION_ENTER 
+    #endif
+
+//Exit low optimization region - place directly after end of function definition
+    #ifdef ARM_MATH_CM4
+      #define LOW_OPTIMIZATION_EXIT \
+         _Pragma ("pop")
+    #else
+      #define LOW_OPTIMIZATION_EXIT  
+    #endif
+
+//Enter low optimization region - place directly above function definition
+  #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
+
+//Exit low optimization region - place directly after end of function definition
+  #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
+
+#elif defined(__ICCARM__) //IAR
+
+//Enter low optimization region - place directly above function definition
+    #ifdef ARM_MATH_CM4
+      #define LOW_OPTIMIZATION_ENTER \
+         _Pragma ("optimize=low")
+    #else
+      #define LOW_OPTIMIZATION_ENTER   
+    #endif
+
+//Exit low optimization region - place directly after end of function definition
+  #define LOW_OPTIMIZATION_EXIT
+
+//Enter low optimization region - place directly above function definition
+    #ifdef ARM_MATH_CM4
+      #define IAR_ONLY_LOW_OPTIMIZATION_ENTER \
+         _Pragma ("optimize=low")
+    #else
+      #define IAR_ONLY_LOW_OPTIMIZATION_ENTER   
+    #endif
+
+//Exit low optimization region - place directly after end of function definition
+  #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
+
+#elif defined(__GNUC__)
+
+  #define LOW_OPTIMIZATION_ENTER __attribute__(( optimize("-O1") ))
+
+  #define LOW_OPTIMIZATION_EXIT
+
+  #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
+
+  #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
+
+#elif defined(__CSMC__)		// Cosmic
+
+#define LOW_OPTIMIZATION_ENTER
+#define LOW_OPTIMIZATION_EXIT
+#define IAR_ONLY_LOW_OPTIMIZATION_ENTER
+#define IAR_ONLY_LOW_OPTIMIZATION_EXIT
+
+#endif
+
+
+#ifdef	__cplusplus
+}
+#endif
+
+
+#endif /* _ARM_MATH_H */
+
+/**
+ *
+ * End of file.
+ */

--- a/common/arm/core_cm0.h
+++ b/common/arm/core_cm0.h
@@ -1,0 +1,711 @@
+/**************************************************************************//**
+ * @file     core_cm0.h
+ * @brief    CMSIS Cortex-M0 Core Peripheral Access Layer Header File
+ * @version  V4.00
+ * @date     22. August 2014
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2014 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#if defined ( __ICCARM__ )
+ #pragma system_include  /* treat file as system include file for MISRA check */
+#endif
+
+#ifndef __CORE_CM0_H_GENERIC
+#define __CORE_CM0_H_GENERIC
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/** \ingroup Cortex_M0
+  @{
+ */
+
+/*  CMSIS CM0 definitions */
+#define __CM0_CMSIS_VERSION_MAIN  (0x04)                                   /*!< [31:16] CMSIS HAL main version   */
+#define __CM0_CMSIS_VERSION_SUB   (0x00)                                   /*!< [15:0]  CMSIS HAL sub version    */
+#define __CM0_CMSIS_VERSION       ((__CM0_CMSIS_VERSION_MAIN << 16) | \
+                                    __CM0_CMSIS_VERSION_SUB          )     /*!< CMSIS HAL version number         */
+
+#define __CORTEX_M                (0x00)                                   /*!< Cortex-M Core                    */
+
+
+#if   defined ( __CC_ARM )
+  #define __ASM            __asm                                      /*!< asm keyword for ARM Compiler          */
+  #define __INLINE         __inline                                   /*!< inline keyword for ARM Compiler       */
+  #define __STATIC_INLINE  static __inline
+
+#elif defined ( __GNUC__ )
+  #define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
+  #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __ICCARM__ )
+  #define __ASM            __asm                                      /*!< asm keyword for IAR Compiler          */
+  #define __INLINE         inline                                     /*!< inline keyword for IAR Compiler. Only available in High optimization mode! */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __TMS470__ )
+  #define __ASM            __asm                                      /*!< asm keyword for TI CCS Compiler       */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __TASKING__ )
+  #define __ASM            __asm                                      /*!< asm keyword for TASKING Compiler      */
+  #define __INLINE         inline                                     /*!< inline keyword for TASKING Compiler   */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __CSMC__ )
+  #define __packed
+  #define __ASM            _asm                                      /*!< asm keyword for COSMIC Compiler      */
+  #define __INLINE         inline                                    /*use -pc99 on compile line !< inline keyword for COSMIC Compiler   */
+  #define __STATIC_INLINE  static inline
+
+#endif
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    This core does not support an FPU at all
+*/
+#define __FPU_USED       0
+
+#if defined ( __CC_ARM )
+  #if defined __TARGET_FPU_VFP
+    #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined __ARMVFP__
+    #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TMS470__ )
+  #if defined __TI__VFP_SUPPORT____
+    #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined __FPU_VFP__
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __CSMC__ )		/* Cosmic */
+  #if ( __CSMC__ & 0x400)		// FPU present for parser
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+#endif
+
+#include <stdint.h>                      /* standard types definitions                      */
+#include <core_cmInstr.h>                /* Core Instruction Access                         */
+#include <core_cmFunc.h>                 /* Core Function Access                            */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM0_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM0_H_DEPENDANT
+#define __CORE_CM0_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM0_REV
+    #define __CM0_REV               0x0000
+    #warning "__CM0_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          2
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions                 */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions                 */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions                */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions              */
+
+/*@} end of group Cortex_M0 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+ ******************************************************************************/
+/** \defgroup CMSIS_core_register Defines and Type Definitions
+    \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_CORE  Status and Control Registers
+    \brief  Core Register type definitions.
+  @{
+ */
+
+/** \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+#if (__CORTEX_M != 0x04)
+    uint32_t _reserved0:27;              /*!< bit:  0..26  Reserved                           */
+#else
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags        */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved                           */
+#endif
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag          */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag       */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag          */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag           */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag       */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} APSR_Type;
+
+
+/** \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number                   */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved                           */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} IPSR_Type;
+
+
+/** \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number                   */
+#if (__CORTEX_M != 0x04)
+    uint32_t _reserved0:15;              /*!< bit:  9..23  Reserved                           */
+#else
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags        */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved                           */
+#endif
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0)          */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0)          */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag          */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag       */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag          */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag           */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag       */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} xPSR_Type;
+
+
+/** \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used                   */
+    uint32_t FPCA:1;                     /*!< bit:      2  FP extension active flag           */
+    uint32_t _reserved0:29;              /*!< bit:  3..31  Reserved                           */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} CONTROL_Type;
+
+/*@} end of group CMSIS_CORE */
+
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+    \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/** \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IO uint32_t ISER[1];                 /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register           */
+       uint32_t RESERVED0[31];
+  __IO uint32_t ICER[1];                 /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register          */
+       uint32_t RSERVED1[31];
+  __IO uint32_t ISPR[1];                 /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register           */
+       uint32_t RESERVED2[31];
+  __IO uint32_t ICPR[1];                 /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register         */
+       uint32_t RESERVED3[31];
+       uint32_t RESERVED4[64];
+  __IO uint32_t IP[8];                   /*!< Offset: 0x300 (R/W)  Interrupt Priority Register              */
+}  NVIC_Type;
+
+/*@} end of group CMSIS_NVIC */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SCB     System Control Block (SCB)
+    \brief      Type definitions for the System Control Block Registers
+  @{
+ */
+
+/** \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __I  uint32_t CPUID;                   /*!< Offset: 0x000 (R/ )  CPUID Base Register                                   */
+  __IO uint32_t ICSR;                    /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register                  */
+       uint32_t RESERVED0;
+  __IO uint32_t AIRCR;                   /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register      */
+  __IO uint32_t SCR;                     /*!< Offset: 0x010 (R/W)  System Control Register                               */
+  __IO uint32_t CCR;                     /*!< Offset: 0x014 (R/W)  Configuration Control Register                        */
+       uint32_t RESERVED1;
+  __IO uint32_t SHP[2];                  /*!< Offset: 0x01C (R/W)  System Handlers Priority Registers. [0] is RESERVED   */
+  __IO uint32_t SHCSR;                   /*!< Offset: 0x024 (R/W)  System Handler Control and State Register             */
+} SCB_Type;
+
+/* SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24                                             /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20                                             /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16                                             /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4                                             /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0                                             /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL << SCB_CPUID_REVISION_Pos)              /*!< SCB CPUID: REVISION Mask */
+
+/* SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31                                             /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28                                             /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27                                             /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26                                             /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25                                             /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23                                             /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22                                             /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12                                             /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0                                             /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL << SCB_ICSR_VECTACTIVE_Pos)           /*!< SCB ICSR: VECTACTIVE Mask */
+
+/* SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16                                             /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16                                             /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15                                             /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2                                             /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1                                             /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/* SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4                                             /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2                                             /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1                                             /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/* SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9                                             /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3                                             /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+/* SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_SVCALLPENDED_Pos         15                                             /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+    \brief      Type definitions for the System Timer Registers.
+  @{
+ */
+
+/** \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IO uint32_t CTRL;                    /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IO uint32_t LOAD;                    /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register       */
+  __IO uint32_t VAL;                     /*!< Offset: 0x008 (R/W)  SysTick Current Value Register      */
+  __I  uint32_t CALIB;                   /*!< Offset: 0x00C (R/ )  SysTick Calibration Register        */
+} SysTick_Type;
+
+/* SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16                                             /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2                                             /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1                                             /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0                                             /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL << SysTick_CTRL_ENABLE_Pos)               /*!< SysTick CTRL: ENABLE Mask */
+
+/* SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0                                             /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL << SysTick_LOAD_RELOAD_Pos)        /*!< SysTick LOAD: RELOAD Mask */
+
+/* SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0                                             /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL << SysTick_VAL_CURRENT_Pos)        /*!< SysTick VAL: CURRENT Mask */
+
+/* SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31                                             /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30                                             /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0                                             /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL << SysTick_CALIB_TENMS_Pos)        /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+    \brief      Cortex-M0 Core Debug Registers (DCB registers, SHCSR, and DFSR)
+                are only accessible over DAP and not via processor. Therefore
+                they are not covered by the Cortex-M0 header file.
+  @{
+ */
+/*@} end of group CMSIS_CoreDebug */
+
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_core_base     Core Definitions
+    \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Cortex-M0 Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address              */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address                 */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address */
+
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct           */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct       */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct          */
+
+
+/*@} */
+
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/** \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+    \brief      Functions that manage interrupts and exceptions via the NVIC.
+    @{
+ */
+
+/* Interrupt Priorities are WORD accessible only under ARMv6M                   */
+/* The following MACROS handle generation of the register offset and byte masks */
+#define _BIT_SHIFT(IRQn)         (  (((uint32_t)(IRQn)       )    &  0x03) * 8 )
+#define _SHP_IDX(IRQn)           ( ((((uint32_t)(IRQn) & 0x0F)-8) >>    2)     )
+#define _IP_IDX(IRQn)            (   ((uint32_t)(IRQn)            >>    2)     )
+
+
+/** \brief  Enable External Interrupt
+
+    The function enables a device-specific interrupt in the NVIC interrupt controller.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  NVIC->ISER[0] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+
+/** \brief  Disable External Interrupt
+
+    The function disables a device-specific interrupt in the NVIC interrupt controller.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  NVIC->ICER[0] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+
+/** \brief  Get Pending Interrupt
+
+    The function reads the pending register in the NVIC and returns the pending bit
+    for the specified interrupt.
+
+    \param [in]      IRQn  Interrupt number.
+
+    \return             0  Interrupt status is not pending.
+    \return             1  Interrupt status is pending.
+ */
+__STATIC_INLINE uint32_t NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  return((uint32_t) ((NVIC->ISPR[0] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
+}
+
+
+/** \brief  Set Pending Interrupt
+
+    The function sets the pending bit of an external interrupt.
+
+    \param [in]      IRQn  Interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->ISPR[0] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+
+/** \brief  Clear Pending Interrupt
+
+    The function clears the pending bit of an external interrupt.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->ICPR[0] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* Clear pending interrupt */
+}
+
+
+/** \brief  Set Interrupt Priority
+
+    The function sets the priority of an interrupt.
+
+    \note The priority cannot be set for every core interrupt.
+
+    \param [in]      IRQn  Interrupt number.
+    \param [in]  priority  Priority to set.
+ */
+__STATIC_INLINE void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if(IRQn < 0) {
+    SCB->SHP[_SHP_IDX(IRQn)] = (SCB->SHP[_SHP_IDX(IRQn)] & ~(0xFF << _BIT_SHIFT(IRQn))) |
+        (((priority << (8 - __NVIC_PRIO_BITS)) & 0xFF) << _BIT_SHIFT(IRQn)); }
+  else {
+    NVIC->IP[_IP_IDX(IRQn)] = (NVIC->IP[_IP_IDX(IRQn)] & ~(0xFF << _BIT_SHIFT(IRQn))) |
+        (((priority << (8 - __NVIC_PRIO_BITS)) & 0xFF) << _BIT_SHIFT(IRQn)); }
+}
+
+
+/** \brief  Get Interrupt Priority
+
+    The function reads the priority of an interrupt. The interrupt
+    number can be positive to specify an external (device specific)
+    interrupt, or negative to specify an internal (core) interrupt.
+
+
+    \param [in]   IRQn  Interrupt number.
+    \return             Interrupt Priority. Value is aligned automatically to the implemented
+                        priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if(IRQn < 0) {
+    return((uint32_t)(((SCB->SHP[_SHP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & 0xFF) >> (8 - __NVIC_PRIO_BITS)));  } /* get priority for Cortex-M0 system interrupts */
+  else {
+    return((uint32_t)(((NVIC->IP[ _IP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & 0xFF) >> (8 - __NVIC_PRIO_BITS)));  } /* get priority for device specific interrupts  */
+}
+
+
+/** \brief  System Reset
+
+    The function initiates a system reset request to reset the MCU.
+ */
+__STATIC_INLINE void NVIC_SystemReset(void)
+{
+  __DSB();                                                     /* Ensure all outstanding memory accesses included
+                                                                  buffered write are completed before reset */
+  SCB->AIRCR  = ((0x5FA << SCB_AIRCR_VECTKEY_Pos)      |
+                 SCB_AIRCR_SYSRESETREQ_Msk);
+  __DSB();                                                     /* Ensure completion of memory access */
+  while(1);                                                    /* wait until reset */
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+    \brief      Functions that configure the System.
+  @{
+ */
+
+#if (__Vendor_SysTickConfig == 0)
+
+/** \brief  System Tick Configuration
+
+    The function initializes the System Timer and its interrupt, and starts the System Tick Timer.
+    Counter is in free running mode to generate periodic interrupts.
+
+    \param [in]  ticks  Number of ticks between two interrupts.
+
+    \return          0  Function succeeded.
+    \return          1  Function failed.
+
+    \note     When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+    function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+    must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1) > SysTick_LOAD_RELOAD_Msk)  return (1);      /* Reload value impossible */
+
+  SysTick->LOAD  = ticks - 1;                                  /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1<<__NVIC_PRIO_BITS) - 1);  /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0;                                          /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                    /* Enable SysTick IRQ and SysTick Timer */
+  return (0);                                                  /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM0_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/common/arm/core_cm4.h
+++ b/common/arm/core_cm4.h
@@ -1,0 +1,1802 @@
+/**************************************************************************//**
+ * @file     core_cm4.h
+ * @brief    CMSIS Cortex-M4 Core Peripheral Access Layer Header File
+ * @version  V4.00
+ * @date     22. August 2014
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2014 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#if defined ( __ICCARM__ )
+ #pragma system_include  /* treat file as system include file for MISRA check */
+#endif
+
+#ifndef __CORE_CM4_H_GENERIC
+#define __CORE_CM4_H_GENERIC
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/** \ingroup Cortex_M4
+  @{
+ */
+
+/*  CMSIS CM4 definitions */
+#define __CM4_CMSIS_VERSION_MAIN  (0x04)                                   /*!< [31:16] CMSIS HAL main version   */
+#define __CM4_CMSIS_VERSION_SUB   (0x00)                                   /*!< [15:0]  CMSIS HAL sub version    */
+#define __CM4_CMSIS_VERSION       ((__CM4_CMSIS_VERSION_MAIN << 16) | \
+                                    __CM4_CMSIS_VERSION_SUB          )     /*!< CMSIS HAL version number         */
+
+#define __CORTEX_M                (0x04)                                   /*!< Cortex-M Core                    */
+
+
+#if   defined ( __CC_ARM )
+  #define __ASM            __asm                                      /*!< asm keyword for ARM Compiler          */
+  #define __INLINE         __inline                                   /*!< inline keyword for ARM Compiler       */
+  #define __STATIC_INLINE  static __inline
+
+#elif defined ( __GNUC__ )
+  #define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
+  #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __ICCARM__ )
+  #define __ASM            __asm                                      /*!< asm keyword for IAR Compiler          */
+  #define __INLINE         inline                                     /*!< inline keyword for IAR Compiler. Only available in High optimization mode! */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __TMS470__ )
+  #define __ASM            __asm                                      /*!< asm keyword for TI CCS Compiler       */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __TASKING__ )
+  #define __ASM            __asm                                      /*!< asm keyword for TASKING Compiler      */
+  #define __INLINE         inline                                     /*!< inline keyword for TASKING Compiler   */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __CSMC__ )
+  #define __packed
+  #define __ASM            _asm                                      /*!< asm keyword for COSMIC Compiler      */
+  #define __INLINE         inline                                    /*use -pc99 on compile line !< inline keyword for COSMIC Compiler   */
+  #define __STATIC_INLINE  static inline
+
+#endif
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    For this, __FPU_PRESENT has to be checked prior to making use of FPU specific registers and functions.
+*/
+#if defined ( __CC_ARM )
+  #if defined __TARGET_FPU_VFP
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined __ARMVFP__
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __TMS470__ )
+  #if defined __TI_VFP_SUPPORT__
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined __FPU_VFP__
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __CSMC__ )		/* Cosmic */
+  #if ( __CSMC__ & 0x400)		// FPU present for parser
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+#endif
+
+#include <stdint.h>                      /* standard types definitions                      */
+#include <core_cmInstr.h>                /* Core Instruction Access                         */
+#include <core_cmFunc.h>                 /* Core Function Access                            */
+#include <core_cmSimd.h>                 /* Compiler specific SIMD Intrinsics               */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM4_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM4_H_DEPENDANT
+#define __CORE_CM4_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM4_REV
+    #define __CM4_REV               0x0000
+    #warning "__CM4_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          4
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions                 */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions                 */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions                */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions              */
+
+/*@} end of group Cortex_M4 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+  - Core FPU Register
+ ******************************************************************************/
+/** \defgroup CMSIS_core_register Defines and Type Definitions
+    \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_CORE  Status and Control Registers
+    \brief  Core Register type definitions.
+  @{
+ */
+
+/** \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+#if (__CORTEX_M != 0x04)
+    uint32_t _reserved0:27;              /*!< bit:  0..26  Reserved                           */
+#else
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags        */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved                           */
+#endif
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag          */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag       */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag          */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag           */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag       */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} APSR_Type;
+
+
+/** \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number                   */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved                           */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} IPSR_Type;
+
+
+/** \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number                   */
+#if (__CORTEX_M != 0x04)
+    uint32_t _reserved0:15;              /*!< bit:  9..23  Reserved                           */
+#else
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags        */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved                           */
+#endif
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0)          */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0)          */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag          */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag       */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag          */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag           */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag       */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} xPSR_Type;
+
+
+/** \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used                   */
+    uint32_t FPCA:1;                     /*!< bit:      2  FP extension active flag           */
+    uint32_t _reserved0:29;              /*!< bit:  3..31  Reserved                           */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} CONTROL_Type;
+
+/*@} end of group CMSIS_CORE */
+
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+    \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/** \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IO uint32_t ISER[8];                 /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register           */
+       uint32_t RESERVED0[24];
+  __IO uint32_t ICER[8];                 /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register         */
+       uint32_t RSERVED1[24];
+  __IO uint32_t ISPR[8];                 /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register          */
+       uint32_t RESERVED2[24];
+  __IO uint32_t ICPR[8];                 /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register        */
+       uint32_t RESERVED3[24];
+  __IO uint32_t IABR[8];                 /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register           */
+       uint32_t RESERVED4[56];
+  __IO uint8_t  IP[240];                 /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+       uint32_t RESERVED5[644];
+  __O  uint32_t STIR;                    /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register     */
+}  NVIC_Type;
+
+/* Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0                                          /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL << NVIC_STIR_INTID_Pos)            /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SCB     System Control Block (SCB)
+    \brief      Type definitions for the System Control Block Registers
+  @{
+ */
+
+/** \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __I  uint32_t CPUID;                   /*!< Offset: 0x000 (R/ )  CPUID Base Register                                   */
+  __IO uint32_t ICSR;                    /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register                  */
+  __IO uint32_t VTOR;                    /*!< Offset: 0x008 (R/W)  Vector Table Offset Register                          */
+  __IO uint32_t AIRCR;                   /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register      */
+  __IO uint32_t SCR;                     /*!< Offset: 0x010 (R/W)  System Control Register                               */
+  __IO uint32_t CCR;                     /*!< Offset: 0x014 (R/W)  Configuration Control Register                        */
+  __IO uint8_t  SHP[12];                 /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IO uint32_t SHCSR;                   /*!< Offset: 0x024 (R/W)  System Handler Control and State Register             */
+  __IO uint32_t CFSR;                    /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register                    */
+  __IO uint32_t HFSR;                    /*!< Offset: 0x02C (R/W)  HardFault Status Register                             */
+  __IO uint32_t DFSR;                    /*!< Offset: 0x030 (R/W)  Debug Fault Status Register                           */
+  __IO uint32_t MMFAR;                   /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register                      */
+  __IO uint32_t BFAR;                    /*!< Offset: 0x038 (R/W)  BusFault Address Register                             */
+  __IO uint32_t AFSR;                    /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register                       */
+  __I  uint32_t PFR[2];                  /*!< Offset: 0x040 (R/ )  Processor Feature Register                            */
+  __I  uint32_t DFR;                     /*!< Offset: 0x048 (R/ )  Debug Feature Register                                */
+  __I  uint32_t ADR;                     /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register                            */
+  __I  uint32_t MMFR[4];                 /*!< Offset: 0x050 (R/ )  Memory Model Feature Register                         */
+  __I  uint32_t ISAR[5];                 /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register                   */
+       uint32_t RESERVED0[5];
+  __IO uint32_t CPACR;                   /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register                   */
+} SCB_Type;
+
+/* SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24                                             /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20                                             /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16                                             /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4                                             /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0                                             /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL << SCB_CPUID_REVISION_Pos)              /*!< SCB CPUID: REVISION Mask */
+
+/* SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31                                             /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28                                             /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27                                             /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26                                             /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25                                             /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23                                             /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22                                             /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12                                             /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11                                             /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0                                             /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL << SCB_ICSR_VECTACTIVE_Pos)           /*!< SCB ICSR: VECTACTIVE Mask */
+
+/* SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7                                             /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/* SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16                                             /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16                                             /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15                                             /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8                                             /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2                                             /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1                                             /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+#define SCB_AIRCR_VECTRESET_Pos             0                                             /*!< SCB AIRCR: VECTRESET Position */
+#define SCB_AIRCR_VECTRESET_Msk            (1UL << SCB_AIRCR_VECTRESET_Pos)               /*!< SCB AIRCR: VECTRESET Mask */
+
+/* SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4                                             /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2                                             /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1                                             /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/* SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9                                             /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8                                             /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4                                             /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3                                             /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1                                             /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+#define SCB_CCR_NONBASETHRDENA_Pos          0                                             /*!< SCB CCR: NONBASETHRDENA Position */
+#define SCB_CCR_NONBASETHRDENA_Msk         (1UL << SCB_CCR_NONBASETHRDENA_Pos)            /*!< SCB CCR: NONBASETHRDENA Mask */
+
+/* SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_USGFAULTENA_Pos          18                                             /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17                                             /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16                                             /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15                                             /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14                                             /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13                                             /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12                                             /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11                                             /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10                                             /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8                                             /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7                                             /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3                                             /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1                                             /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0                                             /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL << SCB_SHCSR_MEMFAULTACT_Pos)             /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/* SCB Configurable Fault Status Registers Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16                                             /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8                                             /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0                                             /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL << SCB_CFSR_MEMFAULTSR_Pos)            /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/* SCB Hard Fault Status Registers Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31                                             /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30                                             /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1                                             /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/* SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4                                             /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3                                             /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2                                             /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1                                             /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0                                             /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL << SCB_DFSR_HALTED_Pos)                   /*!< SCB DFSR: HALTED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+    \brief      Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/** \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+       uint32_t RESERVED0[1];
+  __I  uint32_t ICTR;                    /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register      */
+  __IO uint32_t ACTLR;                   /*!< Offset: 0x008 (R/W)  Auxiliary Control Register              */
+} SCnSCB_Type;
+
+/* Interrupt Controller Type Register Definitions */
+#define SCnSCB_ICTR_INTLINESNUM_Pos         0                                          /*!< ICTR: INTLINESNUM Position */
+#define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL << SCnSCB_ICTR_INTLINESNUM_Pos)      /*!< ICTR: INTLINESNUM Mask */
+
+/* Auxiliary Control Register Definitions */
+#define SCnSCB_ACTLR_DISOOFP_Pos            9                                          /*!< ACTLR: DISOOFP Position */
+#define SCnSCB_ACTLR_DISOOFP_Msk           (1UL << SCnSCB_ACTLR_DISOOFP_Pos)           /*!< ACTLR: DISOOFP Mask */
+
+#define SCnSCB_ACTLR_DISFPCA_Pos            8                                          /*!< ACTLR: DISFPCA Position */
+#define SCnSCB_ACTLR_DISFPCA_Msk           (1UL << SCnSCB_ACTLR_DISFPCA_Pos)           /*!< ACTLR: DISFPCA Mask */
+
+#define SCnSCB_ACTLR_DISFOLD_Pos            2                                          /*!< ACTLR: DISFOLD Position */
+#define SCnSCB_ACTLR_DISFOLD_Msk           (1UL << SCnSCB_ACTLR_DISFOLD_Pos)           /*!< ACTLR: DISFOLD Mask */
+
+#define SCnSCB_ACTLR_DISDEFWBUF_Pos         1                                          /*!< ACTLR: DISDEFWBUF Position */
+#define SCnSCB_ACTLR_DISDEFWBUF_Msk        (1UL << SCnSCB_ACTLR_DISDEFWBUF_Pos)        /*!< ACTLR: DISDEFWBUF Mask */
+
+#define SCnSCB_ACTLR_DISMCYCINT_Pos         0                                          /*!< ACTLR: DISMCYCINT Position */
+#define SCnSCB_ACTLR_DISMCYCINT_Msk        (1UL << SCnSCB_ACTLR_DISMCYCINT_Pos)        /*!< ACTLR: DISMCYCINT Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+    \brief      Type definitions for the System Timer Registers.
+  @{
+ */
+
+/** \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IO uint32_t CTRL;                    /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IO uint32_t LOAD;                    /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register       */
+  __IO uint32_t VAL;                     /*!< Offset: 0x008 (R/W)  SysTick Current Value Register      */
+  __I  uint32_t CALIB;                   /*!< Offset: 0x00C (R/ )  SysTick Calibration Register        */
+} SysTick_Type;
+
+/* SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16                                             /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2                                             /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1                                             /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0                                             /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL << SysTick_CTRL_ENABLE_Pos)               /*!< SysTick CTRL: ENABLE Mask */
+
+/* SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0                                             /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL << SysTick_LOAD_RELOAD_Pos)        /*!< SysTick LOAD: RELOAD Mask */
+
+/* SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0                                             /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL << SysTick_VAL_CURRENT_Pos)        /*!< SysTick VAL: CURRENT Mask */
+
+/* SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31                                             /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30                                             /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0                                             /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL << SysTick_CALIB_TENMS_Pos)        /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+    \brief      Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/** \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __O  union
+  {
+    __O  uint8_t    u8;                  /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 8-bit                   */
+    __O  uint16_t   u16;                 /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 16-bit                  */
+    __O  uint32_t   u32;                 /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 32-bit                  */
+  }  PORT [32];                          /*!< Offset: 0x000 ( /W)  ITM Stimulus Port Registers               */
+       uint32_t RESERVED0[864];
+  __IO uint32_t TER;                     /*!< Offset: 0xE00 (R/W)  ITM Trace Enable Register                 */
+       uint32_t RESERVED1[15];
+  __IO uint32_t TPR;                     /*!< Offset: 0xE40 (R/W)  ITM Trace Privilege Register              */
+       uint32_t RESERVED2[15];
+  __IO uint32_t TCR;                     /*!< Offset: 0xE80 (R/W)  ITM Trace Control Register                */
+       uint32_t RESERVED3[29];
+  __O  uint32_t IWR;                     /*!< Offset: 0xEF8 ( /W)  ITM Integration Write Register            */
+  __I  uint32_t IRR;                     /*!< Offset: 0xEFC (R/ )  ITM Integration Read Register             */
+  __IO uint32_t IMCR;                    /*!< Offset: 0xF00 (R/W)  ITM Integration Mode Control Register     */
+       uint32_t RESERVED4[43];
+  __O  uint32_t LAR;                     /*!< Offset: 0xFB0 ( /W)  ITM Lock Access Register                  */
+  __I  uint32_t LSR;                     /*!< Offset: 0xFB4 (R/ )  ITM Lock Status Register                  */
+       uint32_t RESERVED5[6];
+  __I  uint32_t PID4;                    /*!< Offset: 0xFD0 (R/ )  ITM Peripheral Identification Register #4 */
+  __I  uint32_t PID5;                    /*!< Offset: 0xFD4 (R/ )  ITM Peripheral Identification Register #5 */
+  __I  uint32_t PID6;                    /*!< Offset: 0xFD8 (R/ )  ITM Peripheral Identification Register #6 */
+  __I  uint32_t PID7;                    /*!< Offset: 0xFDC (R/ )  ITM Peripheral Identification Register #7 */
+  __I  uint32_t PID0;                    /*!< Offset: 0xFE0 (R/ )  ITM Peripheral Identification Register #0 */
+  __I  uint32_t PID1;                    /*!< Offset: 0xFE4 (R/ )  ITM Peripheral Identification Register #1 */
+  __I  uint32_t PID2;                    /*!< Offset: 0xFE8 (R/ )  ITM Peripheral Identification Register #2 */
+  __I  uint32_t PID3;                    /*!< Offset: 0xFEC (R/ )  ITM Peripheral Identification Register #3 */
+  __I  uint32_t CID0;                    /*!< Offset: 0xFF0 (R/ )  ITM Component  Identification Register #0 */
+  __I  uint32_t CID1;                    /*!< Offset: 0xFF4 (R/ )  ITM Component  Identification Register #1 */
+  __I  uint32_t CID2;                    /*!< Offset: 0xFF8 (R/ )  ITM Component  Identification Register #2 */
+  __I  uint32_t CID3;                    /*!< Offset: 0xFFC (R/ )  ITM Component  Identification Register #3 */
+} ITM_Type;
+
+/* ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0                                             /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL << ITM_TPR_PRIVMASK_Pos)                /*!< ITM TPR: PRIVMASK Mask */
+
+/* ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23                                             /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TraceBusID_Pos             16                                             /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TraceBusID_Msk             (0x7FUL << ITM_TCR_TraceBusID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10                                             /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPrescale_Pos              8                                             /*!< ITM TCR: TSPrescale Position */
+#define ITM_TCR_TSPrescale_Msk             (3UL << ITM_TCR_TSPrescale_Pos)                /*!< ITM TCR: TSPrescale Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4                                             /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3                                             /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2                                             /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1                                             /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0                                             /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL << ITM_TCR_ITMENA_Pos)                    /*!< ITM TCR: ITM Enable bit Mask */
+
+/* ITM Integration Write Register Definitions */
+#define ITM_IWR_ATVALIDM_Pos                0                                             /*!< ITM IWR: ATVALIDM Position */
+#define ITM_IWR_ATVALIDM_Msk               (1UL << ITM_IWR_ATVALIDM_Pos)                  /*!< ITM IWR: ATVALIDM Mask */
+
+/* ITM Integration Read Register Definitions */
+#define ITM_IRR_ATREADYM_Pos                0                                             /*!< ITM IRR: ATREADYM Position */
+#define ITM_IRR_ATREADYM_Msk               (1UL << ITM_IRR_ATREADYM_Pos)                  /*!< ITM IRR: ATREADYM Mask */
+
+/* ITM Integration Mode Control Register Definitions */
+#define ITM_IMCR_INTEGRATION_Pos            0                                             /*!< ITM IMCR: INTEGRATION Position */
+#define ITM_IMCR_INTEGRATION_Msk           (1UL << ITM_IMCR_INTEGRATION_Pos)              /*!< ITM IMCR: INTEGRATION Mask */
+
+/* ITM Lock Status Register Definitions */
+#define ITM_LSR_ByteAcc_Pos                 2                                             /*!< ITM LSR: ByteAcc Position */
+#define ITM_LSR_ByteAcc_Msk                (1UL << ITM_LSR_ByteAcc_Pos)                   /*!< ITM LSR: ByteAcc Mask */
+
+#define ITM_LSR_Access_Pos                  1                                             /*!< ITM LSR: Access Position */
+#define ITM_LSR_Access_Msk                 (1UL << ITM_LSR_Access_Pos)                    /*!< ITM LSR: Access Mask */
+
+#define ITM_LSR_Present_Pos                 0                                             /*!< ITM LSR: Present Position */
+#define ITM_LSR_Present_Msk                (1UL << ITM_LSR_Present_Pos)                   /*!< ITM LSR: Present Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+    \brief      Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/** \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IO uint32_t CTRL;                    /*!< Offset: 0x000 (R/W)  Control Register                          */
+  __IO uint32_t CYCCNT;                  /*!< Offset: 0x004 (R/W)  Cycle Count Register                      */
+  __IO uint32_t CPICNT;                  /*!< Offset: 0x008 (R/W)  CPI Count Register                        */
+  __IO uint32_t EXCCNT;                  /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register         */
+  __IO uint32_t SLEEPCNT;                /*!< Offset: 0x010 (R/W)  Sleep Count Register                      */
+  __IO uint32_t LSUCNT;                  /*!< Offset: 0x014 (R/W)  LSU Count Register                        */
+  __IO uint32_t FOLDCNT;                 /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register         */
+  __I  uint32_t PCSR;                    /*!< Offset: 0x01C (R/ )  Program Counter Sample Register           */
+  __IO uint32_t COMP0;                   /*!< Offset: 0x020 (R/W)  Comparator Register 0                     */
+  __IO uint32_t MASK0;                   /*!< Offset: 0x024 (R/W)  Mask Register 0                           */
+  __IO uint32_t FUNCTION0;               /*!< Offset: 0x028 (R/W)  Function Register 0                       */
+       uint32_t RESERVED0[1];
+  __IO uint32_t COMP1;                   /*!< Offset: 0x030 (R/W)  Comparator Register 1                     */
+  __IO uint32_t MASK1;                   /*!< Offset: 0x034 (R/W)  Mask Register 1                           */
+  __IO uint32_t FUNCTION1;               /*!< Offset: 0x038 (R/W)  Function Register 1                       */
+       uint32_t RESERVED1[1];
+  __IO uint32_t COMP2;                   /*!< Offset: 0x040 (R/W)  Comparator Register 2                     */
+  __IO uint32_t MASK2;                   /*!< Offset: 0x044 (R/W)  Mask Register 2                           */
+  __IO uint32_t FUNCTION2;               /*!< Offset: 0x048 (R/W)  Function Register 2                       */
+       uint32_t RESERVED2[1];
+  __IO uint32_t COMP3;                   /*!< Offset: 0x050 (R/W)  Comparator Register 3                     */
+  __IO uint32_t MASK3;                   /*!< Offset: 0x054 (R/W)  Mask Register 3                           */
+  __IO uint32_t FUNCTION3;               /*!< Offset: 0x058 (R/W)  Function Register 3                       */
+} DWT_Type;
+
+/* DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28                                          /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27                                          /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (0x1UL << DWT_CTRL_NOTRCPKT_Pos)            /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26                                          /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (0x1UL << DWT_CTRL_NOEXTTRIG_Pos)           /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25                                          /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (0x1UL << DWT_CTRL_NOCYCCNT_Pos)            /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24                                          /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (0x1UL << DWT_CTRL_NOPRFCNT_Pos)            /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22                                          /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (0x1UL << DWT_CTRL_CYCEVTENA_Pos)           /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21                                          /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (0x1UL << DWT_CTRL_FOLDEVTENA_Pos)          /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20                                          /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (0x1UL << DWT_CTRL_LSUEVTENA_Pos)           /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19                                          /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (0x1UL << DWT_CTRL_SLEEPEVTENA_Pos)         /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18                                          /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (0x1UL << DWT_CTRL_EXCEVTENA_Pos)           /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17                                          /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (0x1UL << DWT_CTRL_CPIEVTENA_Pos)           /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16                                          /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (0x1UL << DWT_CTRL_EXCTRCENA_Pos)           /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12                                          /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (0x1UL << DWT_CTRL_PCSAMPLENA_Pos)          /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10                                          /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9                                          /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (0x1UL << DWT_CTRL_CYCTAP_Pos)              /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5                                          /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1                                          /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0                                          /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (0x1UL << DWT_CTRL_CYCCNTENA_Pos)           /*!< DWT CTRL: CYCCNTENA Mask */
+
+/* DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0                                          /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL << DWT_CPICNT_CPICNT_Pos)           /*!< DWT CPICNT: CPICNT Mask */
+
+/* DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0                                          /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL << DWT_EXCCNT_EXCCNT_Pos)           /*!< DWT EXCCNT: EXCCNT Mask */
+
+/* DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0                                          /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL << DWT_SLEEPCNT_SLEEPCNT_Pos)       /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/* DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0                                          /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL << DWT_LSUCNT_LSUCNT_Pos)           /*!< DWT LSUCNT: LSUCNT Mask */
+
+/* DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0                                          /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL << DWT_FOLDCNT_FOLDCNT_Pos)         /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/* DWT Comparator Mask Register Definitions */
+#define DWT_MASK_MASK_Pos                   0                                          /*!< DWT MASK: MASK Position */
+#define DWT_MASK_MASK_Msk                  (0x1FUL << DWT_MASK_MASK_Pos)               /*!< DWT MASK: MASK Mask */
+
+/* DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_MATCHED_Pos           24                                          /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (0x1UL << DWT_FUNCTION_MATCHED_Pos)         /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVADDR1_Pos        16                                          /*!< DWT FUNCTION: DATAVADDR1 Position */
+#define DWT_FUNCTION_DATAVADDR1_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR1_Pos)      /*!< DWT FUNCTION: DATAVADDR1 Mask */
+
+#define DWT_FUNCTION_DATAVADDR0_Pos        12                                          /*!< DWT FUNCTION: DATAVADDR0 Position */
+#define DWT_FUNCTION_DATAVADDR0_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR0_Pos)      /*!< DWT FUNCTION: DATAVADDR0 Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10                                          /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_LNK1ENA_Pos            9                                          /*!< DWT FUNCTION: LNK1ENA Position */
+#define DWT_FUNCTION_LNK1ENA_Msk           (0x1UL << DWT_FUNCTION_LNK1ENA_Pos)         /*!< DWT FUNCTION: LNK1ENA Mask */
+
+#define DWT_FUNCTION_DATAVMATCH_Pos         8                                          /*!< DWT FUNCTION: DATAVMATCH Position */
+#define DWT_FUNCTION_DATAVMATCH_Msk        (0x1UL << DWT_FUNCTION_DATAVMATCH_Pos)      /*!< DWT FUNCTION: DATAVMATCH Mask */
+
+#define DWT_FUNCTION_CYCMATCH_Pos           7                                          /*!< DWT FUNCTION: CYCMATCH Position */
+#define DWT_FUNCTION_CYCMATCH_Msk          (0x1UL << DWT_FUNCTION_CYCMATCH_Pos)        /*!< DWT FUNCTION: CYCMATCH Mask */
+
+#define DWT_FUNCTION_EMITRANGE_Pos          5                                          /*!< DWT FUNCTION: EMITRANGE Position */
+#define DWT_FUNCTION_EMITRANGE_Msk         (0x1UL << DWT_FUNCTION_EMITRANGE_Pos)       /*!< DWT FUNCTION: EMITRANGE Mask */
+
+#define DWT_FUNCTION_FUNCTION_Pos           0                                          /*!< DWT FUNCTION: FUNCTION Position */
+#define DWT_FUNCTION_FUNCTION_Msk          (0xFUL << DWT_FUNCTION_FUNCTION_Pos)        /*!< DWT FUNCTION: FUNCTION Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_TPI     Trace Port Interface (TPI)
+    \brief      Type definitions for the Trace Port Interface (TPI)
+  @{
+ */
+
+/** \brief  Structure type to access the Trace Port Interface Register (TPI).
+ */
+typedef struct
+{
+  __IO uint32_t SSPSR;                   /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register     */
+  __IO uint32_t CSPSR;                   /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+       uint32_t RESERVED0[2];
+  __IO uint32_t ACPR;                    /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+       uint32_t RESERVED1[55];
+  __IO uint32_t SPPR;                    /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+       uint32_t RESERVED2[131];
+  __I  uint32_t FFSR;                    /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IO uint32_t FFCR;                    /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __I  uint32_t FSCR;                    /*!< Offset: 0x308 (R/ )  Formatter Synchronization Counter Register */
+       uint32_t RESERVED3[759];
+  __I  uint32_t TRIGGER;                 /*!< Offset: 0xEE8 (R/ )  TRIGGER */
+  __I  uint32_t FIFO0;                   /*!< Offset: 0xEEC (R/ )  Integration ETM Data */
+  __I  uint32_t ITATBCTR2;               /*!< Offset: 0xEF0 (R/ )  ITATBCTR2 */
+       uint32_t RESERVED4[1];
+  __I  uint32_t ITATBCTR0;               /*!< Offset: 0xEF8 (R/ )  ITATBCTR0 */
+  __I  uint32_t FIFO1;                   /*!< Offset: 0xEFC (R/ )  Integration ITM Data */
+  __IO uint32_t ITCTRL;                  /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+       uint32_t RESERVED5[39];
+  __IO uint32_t CLAIMSET;                /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IO uint32_t CLAIMCLR;                /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+       uint32_t RESERVED7[8];
+  __I  uint32_t DEVID;                   /*!< Offset: 0xFC8 (R/ )  TPIU_DEVID */
+  __I  uint32_t DEVTYPE;                 /*!< Offset: 0xFCC (R/ )  TPIU_DEVTYPE */
+} TPI_Type;
+
+/* TPI Asynchronous Clock Prescaler Register Definitions */
+#define TPI_ACPR_PRESCALER_Pos              0                                          /*!< TPI ACPR: PRESCALER Position */
+#define TPI_ACPR_PRESCALER_Msk             (0x1FFFUL << TPI_ACPR_PRESCALER_Pos)        /*!< TPI ACPR: PRESCALER Mask */
+
+/* TPI Selected Pin Protocol Register Definitions */
+#define TPI_SPPR_TXMODE_Pos                 0                                          /*!< TPI SPPR: TXMODE Position */
+#define TPI_SPPR_TXMODE_Msk                (0x3UL << TPI_SPPR_TXMODE_Pos)              /*!< TPI SPPR: TXMODE Mask */
+
+/* TPI Formatter and Flush Status Register Definitions */
+#define TPI_FFSR_FtNonStop_Pos              3                                          /*!< TPI FFSR: FtNonStop Position */
+#define TPI_FFSR_FtNonStop_Msk             (0x1UL << TPI_FFSR_FtNonStop_Pos)           /*!< TPI FFSR: FtNonStop Mask */
+
+#define TPI_FFSR_TCPresent_Pos              2                                          /*!< TPI FFSR: TCPresent Position */
+#define TPI_FFSR_TCPresent_Msk             (0x1UL << TPI_FFSR_TCPresent_Pos)           /*!< TPI FFSR: TCPresent Mask */
+
+#define TPI_FFSR_FtStopped_Pos              1                                          /*!< TPI FFSR: FtStopped Position */
+#define TPI_FFSR_FtStopped_Msk             (0x1UL << TPI_FFSR_FtStopped_Pos)           /*!< TPI FFSR: FtStopped Mask */
+
+#define TPI_FFSR_FlInProg_Pos               0                                          /*!< TPI FFSR: FlInProg Position */
+#define TPI_FFSR_FlInProg_Msk              (0x1UL << TPI_FFSR_FlInProg_Pos)            /*!< TPI FFSR: FlInProg Mask */
+
+/* TPI Formatter and Flush Control Register Definitions */
+#define TPI_FFCR_TrigIn_Pos                 8                                          /*!< TPI FFCR: TrigIn Position */
+#define TPI_FFCR_TrigIn_Msk                (0x1UL << TPI_FFCR_TrigIn_Pos)              /*!< TPI FFCR: TrigIn Mask */
+
+#define TPI_FFCR_EnFCont_Pos                1                                          /*!< TPI FFCR: EnFCont Position */
+#define TPI_FFCR_EnFCont_Msk               (0x1UL << TPI_FFCR_EnFCont_Pos)             /*!< TPI FFCR: EnFCont Mask */
+
+/* TPI TRIGGER Register Definitions */
+#define TPI_TRIGGER_TRIGGER_Pos             0                                          /*!< TPI TRIGGER: TRIGGER Position */
+#define TPI_TRIGGER_TRIGGER_Msk            (0x1UL << TPI_TRIGGER_TRIGGER_Pos)          /*!< TPI TRIGGER: TRIGGER Mask */
+
+/* TPI Integration ETM Data Register Definitions (FIFO0) */
+#define TPI_FIFO0_ITM_ATVALID_Pos          29                                          /*!< TPI FIFO0: ITM_ATVALID Position */
+#define TPI_FIFO0_ITM_ATVALID_Msk          (0x3UL << TPI_FIFO0_ITM_ATVALID_Pos)        /*!< TPI FIFO0: ITM_ATVALID Mask */
+
+#define TPI_FIFO0_ITM_bytecount_Pos        27                                          /*!< TPI FIFO0: ITM_bytecount Position */
+#define TPI_FIFO0_ITM_bytecount_Msk        (0x3UL << TPI_FIFO0_ITM_bytecount_Pos)      /*!< TPI FIFO0: ITM_bytecount Mask */
+
+#define TPI_FIFO0_ETM_ATVALID_Pos          26                                          /*!< TPI FIFO0: ETM_ATVALID Position */
+#define TPI_FIFO0_ETM_ATVALID_Msk          (0x3UL << TPI_FIFO0_ETM_ATVALID_Pos)        /*!< TPI FIFO0: ETM_ATVALID Mask */
+
+#define TPI_FIFO0_ETM_bytecount_Pos        24                                          /*!< TPI FIFO0: ETM_bytecount Position */
+#define TPI_FIFO0_ETM_bytecount_Msk        (0x3UL << TPI_FIFO0_ETM_bytecount_Pos)      /*!< TPI FIFO0: ETM_bytecount Mask */
+
+#define TPI_FIFO0_ETM2_Pos                 16                                          /*!< TPI FIFO0: ETM2 Position */
+#define TPI_FIFO0_ETM2_Msk                 (0xFFUL << TPI_FIFO0_ETM2_Pos)              /*!< TPI FIFO0: ETM2 Mask */
+
+#define TPI_FIFO0_ETM1_Pos                  8                                          /*!< TPI FIFO0: ETM1 Position */
+#define TPI_FIFO0_ETM1_Msk                 (0xFFUL << TPI_FIFO0_ETM1_Pos)              /*!< TPI FIFO0: ETM1 Mask */
+
+#define TPI_FIFO0_ETM0_Pos                  0                                          /*!< TPI FIFO0: ETM0 Position */
+#define TPI_FIFO0_ETM0_Msk                 (0xFFUL << TPI_FIFO0_ETM0_Pos)              /*!< TPI FIFO0: ETM0 Mask */
+
+/* TPI ITATBCTR2 Register Definitions */
+#define TPI_ITATBCTR2_ATREADY_Pos           0                                          /*!< TPI ITATBCTR2: ATREADY Position */
+#define TPI_ITATBCTR2_ATREADY_Msk          (0x1UL << TPI_ITATBCTR2_ATREADY_Pos)        /*!< TPI ITATBCTR2: ATREADY Mask */
+
+/* TPI Integration ITM Data Register Definitions (FIFO1) */
+#define TPI_FIFO1_ITM_ATVALID_Pos          29                                          /*!< TPI FIFO1: ITM_ATVALID Position */
+#define TPI_FIFO1_ITM_ATVALID_Msk          (0x3UL << TPI_FIFO1_ITM_ATVALID_Pos)        /*!< TPI FIFO1: ITM_ATVALID Mask */
+
+#define TPI_FIFO1_ITM_bytecount_Pos        27                                          /*!< TPI FIFO1: ITM_bytecount Position */
+#define TPI_FIFO1_ITM_bytecount_Msk        (0x3UL << TPI_FIFO1_ITM_bytecount_Pos)      /*!< TPI FIFO1: ITM_bytecount Mask */
+
+#define TPI_FIFO1_ETM_ATVALID_Pos          26                                          /*!< TPI FIFO1: ETM_ATVALID Position */
+#define TPI_FIFO1_ETM_ATVALID_Msk          (0x3UL << TPI_FIFO1_ETM_ATVALID_Pos)        /*!< TPI FIFO1: ETM_ATVALID Mask */
+
+#define TPI_FIFO1_ETM_bytecount_Pos        24                                          /*!< TPI FIFO1: ETM_bytecount Position */
+#define TPI_FIFO1_ETM_bytecount_Msk        (0x3UL << TPI_FIFO1_ETM_bytecount_Pos)      /*!< TPI FIFO1: ETM_bytecount Mask */
+
+#define TPI_FIFO1_ITM2_Pos                 16                                          /*!< TPI FIFO1: ITM2 Position */
+#define TPI_FIFO1_ITM2_Msk                 (0xFFUL << TPI_FIFO1_ITM2_Pos)              /*!< TPI FIFO1: ITM2 Mask */
+
+#define TPI_FIFO1_ITM1_Pos                  8                                          /*!< TPI FIFO1: ITM1 Position */
+#define TPI_FIFO1_ITM1_Msk                 (0xFFUL << TPI_FIFO1_ITM1_Pos)              /*!< TPI FIFO1: ITM1 Mask */
+
+#define TPI_FIFO1_ITM0_Pos                  0                                          /*!< TPI FIFO1: ITM0 Position */
+#define TPI_FIFO1_ITM0_Msk                 (0xFFUL << TPI_FIFO1_ITM0_Pos)              /*!< TPI FIFO1: ITM0 Mask */
+
+/* TPI ITATBCTR0 Register Definitions */
+#define TPI_ITATBCTR0_ATREADY_Pos           0                                          /*!< TPI ITATBCTR0: ATREADY Position */
+#define TPI_ITATBCTR0_ATREADY_Msk          (0x1UL << TPI_ITATBCTR0_ATREADY_Pos)        /*!< TPI ITATBCTR0: ATREADY Mask */
+
+/* TPI Integration Mode Control Register Definitions */
+#define TPI_ITCTRL_Mode_Pos                 0                                          /*!< TPI ITCTRL: Mode Position */
+#define TPI_ITCTRL_Mode_Msk                (0x1UL << TPI_ITCTRL_Mode_Pos)              /*!< TPI ITCTRL: Mode Mask */
+
+/* TPI DEVID Register Definitions */
+#define TPI_DEVID_NRZVALID_Pos             11                                          /*!< TPI DEVID: NRZVALID Position */
+#define TPI_DEVID_NRZVALID_Msk             (0x1UL << TPI_DEVID_NRZVALID_Pos)           /*!< TPI DEVID: NRZVALID Mask */
+
+#define TPI_DEVID_MANCVALID_Pos            10                                          /*!< TPI DEVID: MANCVALID Position */
+#define TPI_DEVID_MANCVALID_Msk            (0x1UL << TPI_DEVID_MANCVALID_Pos)          /*!< TPI DEVID: MANCVALID Mask */
+
+#define TPI_DEVID_PTINVALID_Pos             9                                          /*!< TPI DEVID: PTINVALID Position */
+#define TPI_DEVID_PTINVALID_Msk            (0x1UL << TPI_DEVID_PTINVALID_Pos)          /*!< TPI DEVID: PTINVALID Mask */
+
+#define TPI_DEVID_MinBufSz_Pos              6                                          /*!< TPI DEVID: MinBufSz Position */
+#define TPI_DEVID_MinBufSz_Msk             (0x7UL << TPI_DEVID_MinBufSz_Pos)           /*!< TPI DEVID: MinBufSz Mask */
+
+#define TPI_DEVID_AsynClkIn_Pos             5                                          /*!< TPI DEVID: AsynClkIn Position */
+#define TPI_DEVID_AsynClkIn_Msk            (0x1UL << TPI_DEVID_AsynClkIn_Pos)          /*!< TPI DEVID: AsynClkIn Mask */
+
+#define TPI_DEVID_NrTraceInput_Pos          0                                          /*!< TPI DEVID: NrTraceInput Position */
+#define TPI_DEVID_NrTraceInput_Msk         (0x1FUL << TPI_DEVID_NrTraceInput_Pos)      /*!< TPI DEVID: NrTraceInput Mask */
+
+/* TPI DEVTYPE Register Definitions */
+#define TPI_DEVTYPE_SubType_Pos             0                                          /*!< TPI DEVTYPE: SubType Position */
+#define TPI_DEVTYPE_SubType_Msk            (0xFUL << TPI_DEVTYPE_SubType_Pos)          /*!< TPI DEVTYPE: SubType Mask */
+
+#define TPI_DEVTYPE_MajorType_Pos           4                                          /*!< TPI DEVTYPE: MajorType Position */
+#define TPI_DEVTYPE_MajorType_Msk          (0xFUL << TPI_DEVTYPE_MajorType_Pos)        /*!< TPI DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPI */
+
+
+#if (__MPU_PRESENT == 1)
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+    \brief      Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/** \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __I  uint32_t TYPE;                    /*!< Offset: 0x000 (R/ )  MPU Type Register                              */
+  __IO uint32_t CTRL;                    /*!< Offset: 0x004 (R/W)  MPU Control Register                           */
+  __IO uint32_t RNR;                     /*!< Offset: 0x008 (R/W)  MPU Region RNRber Register                     */
+  __IO uint32_t RBAR;                    /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register               */
+  __IO uint32_t RASR;                    /*!< Offset: 0x010 (R/W)  MPU Region Attribute and Size Register         */
+  __IO uint32_t RBAR_A1;                 /*!< Offset: 0x014 (R/W)  MPU Alias 1 Region Base Address Register       */
+  __IO uint32_t RASR_A1;                 /*!< Offset: 0x018 (R/W)  MPU Alias 1 Region Attribute and Size Register */
+  __IO uint32_t RBAR_A2;                 /*!< Offset: 0x01C (R/W)  MPU Alias 2 Region Base Address Register       */
+  __IO uint32_t RASR_A2;                 /*!< Offset: 0x020 (R/W)  MPU Alias 2 Region Attribute and Size Register */
+  __IO uint32_t RBAR_A3;                 /*!< Offset: 0x024 (R/W)  MPU Alias 3 Region Base Address Register       */
+  __IO uint32_t RASR_A3;                 /*!< Offset: 0x028 (R/W)  MPU Alias 3 Region Attribute and Size Register */
+} MPU_Type;
+
+/* MPU Type Register */
+#define MPU_TYPE_IREGION_Pos               16                                             /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8                                             /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0                                             /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL << MPU_TYPE_SEPARATE_Pos)                 /*!< MPU TYPE: SEPARATE Mask */
+
+/* MPU Control Register */
+#define MPU_CTRL_PRIVDEFENA_Pos             2                                             /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1                                             /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0                                             /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL << MPU_CTRL_ENABLE_Pos)                   /*!< MPU CTRL: ENABLE Mask */
+
+/* MPU Region Number Register */
+#define MPU_RNR_REGION_Pos                  0                                             /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL << MPU_RNR_REGION_Pos)                 /*!< MPU RNR: REGION Mask */
+
+/* MPU Region Base Address Register */
+#define MPU_RBAR_ADDR_Pos                   5                                             /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)             /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4                                             /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0                                             /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL << MPU_RBAR_REGION_Pos)                 /*!< MPU RBAR: REGION Mask */
+
+/* MPU Region Attribute and Size Register */
+#define MPU_RASR_ATTRS_Pos                 16                                             /*!< MPU RASR: MPU Region Attribute field Position */
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+
+#define MPU_RASR_XN_Pos                    28                                             /*!< MPU RASR: ATTRS.XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+
+#define MPU_RASR_AP_Pos                    24                                             /*!< MPU RASR: ATTRS.AP Position */
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19                                             /*!< MPU RASR: ATTRS.TEX Position */
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+
+#define MPU_RASR_S_Pos                     18                                             /*!< MPU RASR: ATTRS.S Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+
+#define MPU_RASR_C_Pos                     17                                             /*!< MPU RASR: ATTRS.C Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+
+#define MPU_RASR_B_Pos                     16                                             /*!< MPU RASR: ATTRS.B Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+
+#define MPU_RASR_SRD_Pos                    8                                             /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1                                             /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENABLE_Pos                 0                                             /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENABLE_Msk                (1UL << MPU_RASR_ENABLE_Pos)                   /*!< MPU RASR: Region enable bit Disable Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if (__FPU_PRESENT == 1)
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+    \brief      Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/** \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+       uint32_t RESERVED0[1];
+  __IO uint32_t FPCCR;                   /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register               */
+  __IO uint32_t FPCAR;                   /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register               */
+  __IO uint32_t FPDSCR;                  /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register        */
+  __I  uint32_t MVFR0;                   /*!< Offset: 0x010 (R/ )  Media and FP Feature Register 0                       */
+  __I  uint32_t MVFR1;                   /*!< Offset: 0x014 (R/ )  Media and FP Feature Register 1                       */
+} FPU_Type;
+
+/* Floating-Point Context Control Register */
+#define FPU_FPCCR_ASPEN_Pos                31                                             /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30                                             /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8                                             /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6                                             /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5                                             /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4                                             /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3                                             /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1                                             /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0                                             /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL << FPU_FPCCR_LSPACT_Pos)                  /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/* Floating-Point Context Address Register */
+#define FPU_FPCAR_ADDRESS_Pos               3                                             /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/* Floating-Point Default Status Control Register */
+#define FPU_FPDSCR_AHP_Pos                 26                                             /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25                                             /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24                                             /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22                                             /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+/* Media and FP Feature Register 0 */
+#define FPU_MVFR0_FP_rounding_modes_Pos    28                                             /*!< MVFR0: FP rounding modes bits Position */
+#define FPU_MVFR0_FP_rounding_modes_Msk    (0xFUL << FPU_MVFR0_FP_rounding_modes_Pos)     /*!< MVFR0: FP rounding modes bits Mask */
+
+#define FPU_MVFR0_Short_vectors_Pos        24                                             /*!< MVFR0: Short vectors bits Position */
+#define FPU_MVFR0_Short_vectors_Msk        (0xFUL << FPU_MVFR0_Short_vectors_Pos)         /*!< MVFR0: Short vectors bits Mask */
+
+#define FPU_MVFR0_Square_root_Pos          20                                             /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_Square_root_Msk          (0xFUL << FPU_MVFR0_Square_root_Pos)           /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_Divide_Pos               16                                             /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_Divide_Msk               (0xFUL << FPU_MVFR0_Divide_Pos)                /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FP_excep_trapping_Pos    12                                             /*!< MVFR0: FP exception trapping bits Position */
+#define FPU_MVFR0_FP_excep_trapping_Msk    (0xFUL << FPU_MVFR0_FP_excep_trapping_Pos)     /*!< MVFR0: FP exception trapping bits Mask */
+
+#define FPU_MVFR0_Double_precision_Pos      8                                             /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_Double_precision_Msk     (0xFUL << FPU_MVFR0_Double_precision_Pos)      /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_Single_precision_Pos      4                                             /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_Single_precision_Msk     (0xFUL << FPU_MVFR0_Single_precision_Pos)      /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_A_SIMD_registers_Pos      0                                             /*!< MVFR0: A_SIMD registers bits Position */
+#define FPU_MVFR0_A_SIMD_registers_Msk     (0xFUL << FPU_MVFR0_A_SIMD_registers_Pos)      /*!< MVFR0: A_SIMD registers bits Mask */
+
+/* Media and FP Feature Register 1 */
+#define FPU_MVFR1_FP_fused_MAC_Pos         28                                             /*!< MVFR1: FP fused MAC bits Position */
+#define FPU_MVFR1_FP_fused_MAC_Msk         (0xFUL << FPU_MVFR1_FP_fused_MAC_Pos)          /*!< MVFR1: FP fused MAC bits Mask */
+
+#define FPU_MVFR1_FP_HPFP_Pos              24                                             /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FP_HPFP_Msk              (0xFUL << FPU_MVFR1_FP_HPFP_Pos)               /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_D_NaN_mode_Pos            4                                             /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_D_NaN_mode_Msk           (0xFUL << FPU_MVFR1_D_NaN_mode_Pos)            /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FtZ_mode_Pos              0                                             /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FtZ_mode_Msk             (0xFUL << FPU_MVFR1_FtZ_mode_Pos)              /*!< MVFR1: FtZ mode bits Mask */
+
+/*@} end of group CMSIS_FPU */
+#endif
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+    \brief      Type definitions for the Core Debug Registers
+  @{
+ */
+
+/** \brief  Structure type to access the Core Debug Register (CoreDebug).
+ */
+typedef struct
+{
+  __IO uint32_t DHCSR;                   /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register    */
+  __O  uint32_t DCRSR;                   /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register        */
+  __IO uint32_t DCRDR;                   /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register            */
+  __IO uint32_t DEMCR;                   /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+} CoreDebug_Type;
+
+/* Debug Halting Control and Status Register */
+#define CoreDebug_DHCSR_DBGKEY_Pos         16                                             /*!< CoreDebug DHCSR: DBGKEY Position */
+#define CoreDebug_DHCSR_DBGKEY_Msk         (0xFFFFUL << CoreDebug_DHCSR_DBGKEY_Pos)       /*!< CoreDebug DHCSR: DBGKEY Mask */
+
+#define CoreDebug_DHCSR_S_RESET_ST_Pos     25                                             /*!< CoreDebug DHCSR: S_RESET_ST Position */
+#define CoreDebug_DHCSR_S_RESET_ST_Msk     (1UL << CoreDebug_DHCSR_S_RESET_ST_Pos)        /*!< CoreDebug DHCSR: S_RESET_ST Mask */
+
+#define CoreDebug_DHCSR_S_RETIRE_ST_Pos    24                                             /*!< CoreDebug DHCSR: S_RETIRE_ST Position */
+#define CoreDebug_DHCSR_S_RETIRE_ST_Msk    (1UL << CoreDebug_DHCSR_S_RETIRE_ST_Pos)       /*!< CoreDebug DHCSR: S_RETIRE_ST Mask */
+
+#define CoreDebug_DHCSR_S_LOCKUP_Pos       19                                             /*!< CoreDebug DHCSR: S_LOCKUP Position */
+#define CoreDebug_DHCSR_S_LOCKUP_Msk       (1UL << CoreDebug_DHCSR_S_LOCKUP_Pos)          /*!< CoreDebug DHCSR: S_LOCKUP Mask */
+
+#define CoreDebug_DHCSR_S_SLEEP_Pos        18                                             /*!< CoreDebug DHCSR: S_SLEEP Position */
+#define CoreDebug_DHCSR_S_SLEEP_Msk        (1UL << CoreDebug_DHCSR_S_SLEEP_Pos)           /*!< CoreDebug DHCSR: S_SLEEP Mask */
+
+#define CoreDebug_DHCSR_S_HALT_Pos         17                                             /*!< CoreDebug DHCSR: S_HALT Position */
+#define CoreDebug_DHCSR_S_HALT_Msk         (1UL << CoreDebug_DHCSR_S_HALT_Pos)            /*!< CoreDebug DHCSR: S_HALT Mask */
+
+#define CoreDebug_DHCSR_S_REGRDY_Pos       16                                             /*!< CoreDebug DHCSR: S_REGRDY Position */
+#define CoreDebug_DHCSR_S_REGRDY_Msk       (1UL << CoreDebug_DHCSR_S_REGRDY_Pos)          /*!< CoreDebug DHCSR: S_REGRDY Mask */
+
+#define CoreDebug_DHCSR_C_SNAPSTALL_Pos     5                                             /*!< CoreDebug DHCSR: C_SNAPSTALL Position */
+#define CoreDebug_DHCSR_C_SNAPSTALL_Msk    (1UL << CoreDebug_DHCSR_C_SNAPSTALL_Pos)       /*!< CoreDebug DHCSR: C_SNAPSTALL Mask */
+
+#define CoreDebug_DHCSR_C_MASKINTS_Pos      3                                             /*!< CoreDebug DHCSR: C_MASKINTS Position */
+#define CoreDebug_DHCSR_C_MASKINTS_Msk     (1UL << CoreDebug_DHCSR_C_MASKINTS_Pos)        /*!< CoreDebug DHCSR: C_MASKINTS Mask */
+
+#define CoreDebug_DHCSR_C_STEP_Pos          2                                             /*!< CoreDebug DHCSR: C_STEP Position */
+#define CoreDebug_DHCSR_C_STEP_Msk         (1UL << CoreDebug_DHCSR_C_STEP_Pos)            /*!< CoreDebug DHCSR: C_STEP Mask */
+
+#define CoreDebug_DHCSR_C_HALT_Pos          1                                             /*!< CoreDebug DHCSR: C_HALT Position */
+#define CoreDebug_DHCSR_C_HALT_Msk         (1UL << CoreDebug_DHCSR_C_HALT_Pos)            /*!< CoreDebug DHCSR: C_HALT Mask */
+
+#define CoreDebug_DHCSR_C_DEBUGEN_Pos       0                                             /*!< CoreDebug DHCSR: C_DEBUGEN Position */
+#define CoreDebug_DHCSR_C_DEBUGEN_Msk      (1UL << CoreDebug_DHCSR_C_DEBUGEN_Pos)         /*!< CoreDebug DHCSR: C_DEBUGEN Mask */
+
+/* Debug Core Register Selector Register */
+#define CoreDebug_DCRSR_REGWnR_Pos         16                                             /*!< CoreDebug DCRSR: REGWnR Position */
+#define CoreDebug_DCRSR_REGWnR_Msk         (1UL << CoreDebug_DCRSR_REGWnR_Pos)            /*!< CoreDebug DCRSR: REGWnR Mask */
+
+#define CoreDebug_DCRSR_REGSEL_Pos          0                                             /*!< CoreDebug DCRSR: REGSEL Position */
+#define CoreDebug_DCRSR_REGSEL_Msk         (0x1FUL << CoreDebug_DCRSR_REGSEL_Pos)         /*!< CoreDebug DCRSR: REGSEL Mask */
+
+/* Debug Exception and Monitor Control Register */
+#define CoreDebug_DEMCR_TRCENA_Pos         24                                             /*!< CoreDebug DEMCR: TRCENA Position */
+#define CoreDebug_DEMCR_TRCENA_Msk         (1UL << CoreDebug_DEMCR_TRCENA_Pos)            /*!< CoreDebug DEMCR: TRCENA Mask */
+
+#define CoreDebug_DEMCR_MON_REQ_Pos        19                                             /*!< CoreDebug DEMCR: MON_REQ Position */
+#define CoreDebug_DEMCR_MON_REQ_Msk        (1UL << CoreDebug_DEMCR_MON_REQ_Pos)           /*!< CoreDebug DEMCR: MON_REQ Mask */
+
+#define CoreDebug_DEMCR_MON_STEP_Pos       18                                             /*!< CoreDebug DEMCR: MON_STEP Position */
+#define CoreDebug_DEMCR_MON_STEP_Msk       (1UL << CoreDebug_DEMCR_MON_STEP_Pos)          /*!< CoreDebug DEMCR: MON_STEP Mask */
+
+#define CoreDebug_DEMCR_MON_PEND_Pos       17                                             /*!< CoreDebug DEMCR: MON_PEND Position */
+#define CoreDebug_DEMCR_MON_PEND_Msk       (1UL << CoreDebug_DEMCR_MON_PEND_Pos)          /*!< CoreDebug DEMCR: MON_PEND Mask */
+
+#define CoreDebug_DEMCR_MON_EN_Pos         16                                             /*!< CoreDebug DEMCR: MON_EN Position */
+#define CoreDebug_DEMCR_MON_EN_Msk         (1UL << CoreDebug_DEMCR_MON_EN_Pos)            /*!< CoreDebug DEMCR: MON_EN Mask */
+
+#define CoreDebug_DEMCR_VC_HARDERR_Pos     10                                             /*!< CoreDebug DEMCR: VC_HARDERR Position */
+#define CoreDebug_DEMCR_VC_HARDERR_Msk     (1UL << CoreDebug_DEMCR_VC_HARDERR_Pos)        /*!< CoreDebug DEMCR: VC_HARDERR Mask */
+
+#define CoreDebug_DEMCR_VC_INTERR_Pos       9                                             /*!< CoreDebug DEMCR: VC_INTERR Position */
+#define CoreDebug_DEMCR_VC_INTERR_Msk      (1UL << CoreDebug_DEMCR_VC_INTERR_Pos)         /*!< CoreDebug DEMCR: VC_INTERR Mask */
+
+#define CoreDebug_DEMCR_VC_BUSERR_Pos       8                                             /*!< CoreDebug DEMCR: VC_BUSERR Position */
+#define CoreDebug_DEMCR_VC_BUSERR_Msk      (1UL << CoreDebug_DEMCR_VC_BUSERR_Pos)         /*!< CoreDebug DEMCR: VC_BUSERR Mask */
+
+#define CoreDebug_DEMCR_VC_STATERR_Pos      7                                             /*!< CoreDebug DEMCR: VC_STATERR Position */
+#define CoreDebug_DEMCR_VC_STATERR_Msk     (1UL << CoreDebug_DEMCR_VC_STATERR_Pos)        /*!< CoreDebug DEMCR: VC_STATERR Mask */
+
+#define CoreDebug_DEMCR_VC_CHKERR_Pos       6                                             /*!< CoreDebug DEMCR: VC_CHKERR Position */
+#define CoreDebug_DEMCR_VC_CHKERR_Msk      (1UL << CoreDebug_DEMCR_VC_CHKERR_Pos)         /*!< CoreDebug DEMCR: VC_CHKERR Mask */
+
+#define CoreDebug_DEMCR_VC_NOCPERR_Pos      5                                             /*!< CoreDebug DEMCR: VC_NOCPERR Position */
+#define CoreDebug_DEMCR_VC_NOCPERR_Msk     (1UL << CoreDebug_DEMCR_VC_NOCPERR_Pos)        /*!< CoreDebug DEMCR: VC_NOCPERR Mask */
+
+#define CoreDebug_DEMCR_VC_MMERR_Pos        4                                             /*!< CoreDebug DEMCR: VC_MMERR Position */
+#define CoreDebug_DEMCR_VC_MMERR_Msk       (1UL << CoreDebug_DEMCR_VC_MMERR_Pos)          /*!< CoreDebug DEMCR: VC_MMERR Mask */
+
+#define CoreDebug_DEMCR_VC_CORERESET_Pos    0                                             /*!< CoreDebug DEMCR: VC_CORERESET Position */
+#define CoreDebug_DEMCR_VC_CORERESET_Msk   (1UL << CoreDebug_DEMCR_VC_CORERESET_Pos)      /*!< CoreDebug DEMCR: VC_CORERESET Mask */
+
+/*@} end of group CMSIS_CoreDebug */
+
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_core_base     Core Definitions
+    \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Cortex-M4 Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address  */
+#define ITM_BASE            (0xE0000000UL)                            /*!< ITM Base Address                   */
+#define DWT_BASE            (0xE0001000UL)                            /*!< DWT Base Address                   */
+#define TPI_BASE            (0xE0040000UL)                            /*!< TPI Base Address                   */
+#define CoreDebug_BASE      (0xE000EDF0UL)                            /*!< Core Debug Base Address            */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address               */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address                  */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address  */
+
+#define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE      )   /*!< System control Register not in SCB */
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct           */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct       */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct          */
+#define ITM                 ((ITM_Type       *)     ITM_BASE      )   /*!< ITM configuration struct           */
+#define DWT                 ((DWT_Type       *)     DWT_BASE      )   /*!< DWT configuration struct           */
+#define TPI                 ((TPI_Type       *)     TPI_BASE      )   /*!< TPI configuration struct           */
+#define CoreDebug           ((CoreDebug_Type *)     CoreDebug_BASE)   /*!< Core Debug configuration struct    */
+
+#if (__MPU_PRESENT == 1)
+  #define MPU_BASE          (SCS_BASE +  0x0D90UL)                    /*!< Memory Protection Unit             */
+  #define MPU               ((MPU_Type       *)     MPU_BASE      )   /*!< Memory Protection Unit             */
+#endif
+
+#if (__FPU_PRESENT == 1)
+  #define FPU_BASE          (SCS_BASE +  0x0F30UL)                    /*!< Floating Point Unit                */
+  #define FPU               ((FPU_Type       *)     FPU_BASE      )   /*!< Floating Point Unit                */
+#endif
+
+/*@} */
+
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/** \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+    \brief      Functions that manage interrupts and exceptions via the NVIC.
+    @{
+ */
+
+/** \brief  Set Priority Grouping
+
+  The function sets the priority grouping field using the required unlock sequence.
+  The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+  Only values from 0..7 are used.
+  In case of a conflict between priority grouping and available
+  priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+
+    \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07);               /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk);             /* clear bits to change               */
+  reg_value  =  (reg_value                                 |
+                ((uint32_t)0x5FA << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << 8));                                     /* Insert write key and priorty group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/** \brief  Get Priority Grouping
+
+  The function reads the priority grouping field from the NVIC Interrupt Controller.
+
+    \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t NVIC_GetPriorityGrouping(void)
+{
+  return ((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos);   /* read priority grouping field */
+}
+
+
+/** \brief  Enable External Interrupt
+
+    The function enables a device-specific interrupt in the NVIC interrupt controller.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+/*  NVIC->ISER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));  enable interrupt */
+  NVIC->ISER[(uint32_t)((int32_t)IRQn) >> 5] = (uint32_t)(1 << ((uint32_t)((int32_t)IRQn) & (uint32_t)0x1F)); /* enable interrupt */
+}
+
+
+/** \brief  Disable External Interrupt
+
+    The function disables a device-specific interrupt in the NVIC interrupt controller.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  NVIC->ICER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* disable interrupt */
+}
+
+
+/** \brief  Get Pending Interrupt
+
+    The function reads the pending register in the NVIC and returns the pending bit
+    for the specified interrupt.
+
+    \param [in]      IRQn  Interrupt number.
+
+    \return             0  Interrupt status is not pending.
+    \return             1  Interrupt status is pending.
+ */
+__STATIC_INLINE uint32_t NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  return((uint32_t) ((NVIC->ISPR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0)); /* Return 1 if pending else 0 */
+}
+
+
+/** \brief  Set Pending Interrupt
+
+    The function sets the pending bit of an external interrupt.
+
+    \param [in]      IRQn  Interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->ISPR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* set interrupt pending */
+}
+
+
+/** \brief  Clear Pending Interrupt
+
+    The function clears the pending bit of an external interrupt.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->ICPR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* Clear pending interrupt */
+}
+
+
+/** \brief  Get Active Interrupt
+
+    The function reads the active register in NVIC and returns the active bit.
+
+    \param [in]      IRQn  Interrupt number.
+
+    \return             0  Interrupt status is not active.
+    \return             1  Interrupt status is active.
+ */
+__STATIC_INLINE uint32_t NVIC_GetActive(IRQn_Type IRQn)
+{
+  return((uint32_t)((NVIC->IABR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0)); /* Return 1 if active else 0 */
+}
+
+
+/** \brief  Set Interrupt Priority
+
+    The function sets the priority of an interrupt.
+
+    \note The priority cannot be set for every core interrupt.
+
+    \param [in]      IRQn  Interrupt number.
+    \param [in]  priority  Priority to set.
+ */
+__STATIC_INLINE void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if(IRQn < 0) {
+    SCB->SHP[((uint32_t)(IRQn) & 0xF)-4] = ((priority << (8 - __NVIC_PRIO_BITS)) & 0xff); } /* set Priority for Cortex-M  System Interrupts */
+  else {
+    NVIC->IP[(uint32_t)(IRQn)] = ((priority << (8 - __NVIC_PRIO_BITS)) & 0xff);    }        /* set Priority for device specific Interrupts  */
+}
+
+
+/** \brief  Get Interrupt Priority
+
+    The function reads the priority of an interrupt. The interrupt
+    number can be positive to specify an external (device specific)
+    interrupt, or negative to specify an internal (core) interrupt.
+
+
+    \param [in]   IRQn  Interrupt number.
+    \return             Interrupt Priority. Value is aligned automatically to the implemented
+                        priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if(IRQn < 0) {
+    return((uint32_t)(SCB->SHP[((uint32_t)(IRQn) & 0xF)-4] >> (8 - __NVIC_PRIO_BITS)));  } /* get priority for Cortex-M  system interrupts */
+  else {
+    return((uint32_t)(NVIC->IP[(uint32_t)(IRQn)]           >> (8 - __NVIC_PRIO_BITS)));  } /* get priority for device specific interrupts  */
+}
+
+
+/** \brief  Encode Priority
+
+    The function encodes the priority for an interrupt with the given priority group,
+    preemptive priority value, and subpriority value.
+    In case of a conflict between priority grouping and available
+    priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+
+    \param [in]     PriorityGroup  Used priority group.
+    \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+    \param [in]       SubPriority  Subpriority value (starting from 0).
+    \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & 0x07);          /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7 - PriorityGroupTmp) > __NVIC_PRIO_BITS) ? __NVIC_PRIO_BITS : 7 - PriorityGroupTmp;
+  SubPriorityBits     = ((PriorityGroupTmp + __NVIC_PRIO_BITS) < 7) ? 0 : PriorityGroupTmp - 7 + __NVIC_PRIO_BITS;
+
+  return (
+           ((PreemptPriority & ((1 << (PreemptPriorityBits)) - 1)) << SubPriorityBits) |
+           ((SubPriority     & ((1 << (SubPriorityBits    )) - 1)))
+         );
+}
+
+
+/** \brief  Decode Priority
+
+    The function decodes an interrupt priority value with a given priority group to
+    preemptive priority value and subpriority value.
+    In case of a conflict between priority grouping and available
+    priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+
+    \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+    \param [in]     PriorityGroup  Used priority group.
+    \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+    \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* pPreemptPriority, uint32_t* pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & 0x07);          /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7 - PriorityGroupTmp) > __NVIC_PRIO_BITS) ? __NVIC_PRIO_BITS : 7 - PriorityGroupTmp;
+  SubPriorityBits     = ((PriorityGroupTmp + __NVIC_PRIO_BITS) < 7) ? 0 : PriorityGroupTmp - 7 + __NVIC_PRIO_BITS;
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & ((1 << (PreemptPriorityBits)) - 1);
+  *pSubPriority     = (Priority                   ) & ((1 << (SubPriorityBits    )) - 1);
+}
+
+
+/** \brief  System Reset
+
+    The function initiates a system reset request to reset the MCU.
+ */
+__STATIC_INLINE void NVIC_SystemReset(void)
+{
+  __DSB();                                                     /* Ensure all outstanding memory accesses included
+                                                                  buffered write are completed before reset */
+  SCB->AIRCR  = ((0x5FA << SCB_AIRCR_VECTKEY_Pos)      |
+                 (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                 SCB_AIRCR_SYSRESETREQ_Msk);                   /* Keep priority group unchanged */
+  __DSB();                                                     /* Ensure completion of memory access */
+  while(1);                                                    /* wait until reset */
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+    \brief      Functions that configure the System.
+  @{
+ */
+
+#if (__Vendor_SysTickConfig == 0)
+
+/** \brief  System Tick Configuration
+
+    The function initializes the System Timer and its interrupt, and starts the System Tick Timer.
+    Counter is in free running mode to generate periodic interrupts.
+
+    \param [in]  ticks  Number of ticks between two interrupts.
+
+    \return          0  Function succeeded.
+    \return          1  Function failed.
+
+    \note     When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+    function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+    must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1) > SysTick_LOAD_RELOAD_Msk)  return (1);      /* Reload value impossible */
+
+  SysTick->LOAD  = ticks - 1;                                  /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1<<__NVIC_PRIO_BITS) - 1);  /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0;                                          /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                    /* Enable SysTick IRQ and SysTick Timer */
+  return (0);                                                  /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_core_DebugFunctions ITM Functions
+    \brief   Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                    /*!< External variable to receive characters.                         */
+#define                 ITM_RXBUFFER_EMPTY    0x5AA55AA5 /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/** \brief  ITM Send Character
+
+    The function transmits a character via the ITM channel 0, and
+    \li Just returns when no debugger is connected that has booked the output.
+    \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+
+    \param [in]     ch  Character to transmit.
+
+    \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if ((ITM->TCR & ITM_TCR_ITMENA_Msk)                  &&      /* ITM enabled */
+      (ITM->TER & (1UL << 0)        )                    )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0].u32 == 0);
+    ITM->PORT[0].u8 = (uint8_t) ch;
+  }
+  return (ch);
+}
+
+
+/** \brief  ITM Receive Character
+
+    The function inputs a character via the external variable \ref ITM_RxBuffer.
+
+    \return             Received character.
+    \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void) {
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY) {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/** \brief  ITM Check Character
+
+    The function checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+
+    \return          0  No character available.
+    \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void) {
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY) {
+    return (0);                                 /* no character available */
+  } else {
+    return (1);                                 /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM4_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/common/arm/core_cmFunc.h
+++ b/common/arm/core_cmFunc.h
@@ -1,0 +1,637 @@
+/**************************************************************************//**
+ * @file     core_cmFunc.h
+ * @brief    CMSIS Cortex-M Core Function Access Header File
+ * @version  V4.00
+ * @date     28. August 2014
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2014 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#ifndef __CORE_CMFUNC_H
+#define __CORE_CMFUNC_H
+
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+#if   defined ( __CC_ARM ) /*------------------RealView Compiler -----------------*/
+/* ARM armcc specific functions */
+
+#if (__ARMCC_VERSION < 400677)
+  #error "Please use ARM Compiler Toolchain V4.0.677 or later!"
+#endif
+
+/* intrinsic void __enable_irq();     */
+/* intrinsic void __disable_irq();    */
+
+/** \brief  Get Control Register
+
+    This function returns the content of the Control Register.
+
+    \return               Control Register value
+ */
+__STATIC_INLINE uint32_t __get_CONTROL(void)
+{
+  register uint32_t __regControl         __ASM("control");
+  return(__regControl);
+}
+
+
+/** \brief  Set Control Register
+
+    This function writes the given value to the Control Register.
+
+    \param [in]    control  Control Register value to set
+ */
+__STATIC_INLINE void __set_CONTROL(uint32_t control)
+{
+  register uint32_t __regControl         __ASM("control");
+  __regControl = control;
+}
+
+
+/** \brief  Get IPSR Register
+
+    This function returns the content of the IPSR Register.
+
+    \return               IPSR Register value
+ */
+__STATIC_INLINE uint32_t __get_IPSR(void)
+{
+  register uint32_t __regIPSR          __ASM("ipsr");
+  return(__regIPSR);
+}
+
+
+/** \brief  Get APSR Register
+
+    This function returns the content of the APSR Register.
+
+    \return               APSR Register value
+ */
+__STATIC_INLINE uint32_t __get_APSR(void)
+{
+  register uint32_t __regAPSR          __ASM("apsr");
+  return(__regAPSR);
+}
+
+
+/** \brief  Get xPSR Register
+
+    This function returns the content of the xPSR Register.
+
+    \return               xPSR Register value
+ */
+__STATIC_INLINE uint32_t __get_xPSR(void)
+{
+  register uint32_t __regXPSR          __ASM("xpsr");
+  return(__regXPSR);
+}
+
+
+/** \brief  Get Process Stack Pointer
+
+    This function returns the current value of the Process Stack Pointer (PSP).
+
+    \return               PSP Register value
+ */
+__STATIC_INLINE uint32_t __get_PSP(void)
+{
+  register uint32_t __regProcessStackPointer  __ASM("psp");
+  return(__regProcessStackPointer);
+}
+
+
+/** \brief  Set Process Stack Pointer
+
+    This function assigns the given value to the Process Stack Pointer (PSP).
+
+    \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  register uint32_t __regProcessStackPointer  __ASM("psp");
+  __regProcessStackPointer = topOfProcStack;
+}
+
+
+/** \brief  Get Main Stack Pointer
+
+    This function returns the current value of the Main Stack Pointer (MSP).
+
+    \return               MSP Register value
+ */
+__STATIC_INLINE uint32_t __get_MSP(void)
+{
+  register uint32_t __regMainStackPointer     __ASM("msp");
+  return(__regMainStackPointer);
+}
+
+
+/** \brief  Set Main Stack Pointer
+
+    This function assigns the given value to the Main Stack Pointer (MSP).
+
+    \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  register uint32_t __regMainStackPointer     __ASM("msp");
+  __regMainStackPointer = topOfMainStack;
+}
+
+
+/** \brief  Get Priority Mask
+
+    This function returns the current state of the priority mask bit from the Priority Mask Register.
+
+    \return               Priority Mask value
+ */
+__STATIC_INLINE uint32_t __get_PRIMASK(void)
+{
+  register uint32_t __regPriMask         __ASM("primask");
+  return(__regPriMask);
+}
+
+
+/** \brief  Set Priority Mask
+
+    This function assigns the given value to the Priority Mask Register.
+
+    \param [in]    priMask  Priority Mask
+ */
+__STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
+{
+  register uint32_t __regPriMask         __ASM("primask");
+  __regPriMask = (priMask);
+}
+
+
+#if       (__CORTEX_M >= 0x03) || (__CORTEX_SC >= 300)
+
+/** \brief  Enable FIQ
+
+    This function enables FIQ interrupts by clearing the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+#define __enable_fault_irq                __enable_fiq
+
+
+/** \brief  Disable FIQ
+
+    This function disables FIQ interrupts by setting the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+#define __disable_fault_irq               __disable_fiq
+
+
+/** \brief  Get Base Priority
+
+    This function returns the current value of the Base Priority register.
+
+    \return               Base Priority register value
+ */
+__STATIC_INLINE uint32_t  __get_BASEPRI(void)
+{
+  register uint32_t __regBasePri         __ASM("basepri");
+  return(__regBasePri);
+}
+
+
+/** \brief  Set Base Priority
+
+    This function assigns the given value to the Base Priority register.
+
+    \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
+{
+  register uint32_t __regBasePri         __ASM("basepri");
+  __regBasePri = (basePri & 0xff);
+}
+
+
+/** \brief  Get Fault Mask
+
+    This function returns the current value of the Fault Mask register.
+
+    \return               Fault Mask register value
+ */
+__STATIC_INLINE uint32_t __get_FAULTMASK(void)
+{
+  register uint32_t __regFaultMask       __ASM("faultmask");
+  return(__regFaultMask);
+}
+
+
+/** \brief  Set Fault Mask
+
+    This function assigns the given value to the Fault Mask register.
+
+    \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  register uint32_t __regFaultMask       __ASM("faultmask");
+  __regFaultMask = (faultMask & (uint32_t)1);
+}
+
+#endif /* (__CORTEX_M >= 0x03) || (__CORTEX_SC >= 300) */
+
+
+#if       (__CORTEX_M == 0x04) || (__CORTEX_M == 0x07)
+
+/** \brief  Get FPSCR
+
+    This function returns the current value of the Floating Point Status/Control register.
+
+    \return               Floating Point Status/Control register value
+ */
+__STATIC_INLINE uint32_t __get_FPSCR(void)
+{
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  register uint32_t __regfpscr         __ASM("fpscr");
+  return(__regfpscr);
+#else
+   return(0);
+#endif
+}
+
+
+/** \brief  Set FPSCR
+
+    This function assigns the given value to the Floating Point Status/Control register.
+
+    \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  register uint32_t __regfpscr         __ASM("fpscr");
+  __regfpscr = (fpscr);
+#endif
+}
+
+#endif /* (__CORTEX_M == 0x04) || (__CORTEX_M == 0x07) */
+
+
+#elif defined ( __GNUC__ ) /*------------------ GNU Compiler ---------------------*/
+/* GNU gcc specific functions */
+
+/** \brief  Enable IRQ Interrupts
+
+  This function enables IRQ interrupts by clearing the I-bit in the CPSR.
+  Can only be executed in Privileged modes.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+
+
+/** \brief  Disable IRQ Interrupts
+
+  This function disables IRQ interrupts by setting the I-bit in the CPSR.
+  Can only be executed in Privileged modes.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+
+
+/** \brief  Get Control Register
+
+    This function returns the content of the Control Register.
+
+    \return               Control Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_CONTROL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Control Register
+
+    This function writes the given value to the Control Register.
+
+    \param [in]    control  Control Register value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_CONTROL(uint32_t control)
+{
+  __ASM volatile ("MSR control, %0" : : "r" (control) : "memory");
+}
+
+
+/** \brief  Get IPSR Register
+
+    This function returns the content of the IPSR Register.
+
+    \return               IPSR Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_IPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Get APSR Register
+
+    This function returns the content of the APSR Register.
+
+    \return               APSR Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_APSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Get xPSR Register
+
+    This function returns the content of the xPSR Register.
+
+    \return               xPSR Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Get Process Stack Pointer
+
+    This function returns the current value of the Process Stack Pointer (PSP).
+
+    \return               PSP Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Process Stack Pointer
+
+    This function assigns the given value to the Process Stack Pointer (PSP).
+
+    \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp, %0\n" : : "r" (topOfProcStack) : "sp");
+}
+
+
+/** \brief  Get Main Stack Pointer
+
+    This function returns the current value of the Main Stack Pointer (MSP).
+
+    \return               MSP Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Main Stack Pointer
+
+    This function assigns the given value to the Main Stack Pointer (MSP).
+
+    \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp, %0\n" : : "r" (topOfMainStack) : "sp");
+}
+
+
+/** \brief  Get Priority Mask
+
+    This function returns the current state of the priority mask bit from the Priority Mask Register.
+
+    \return               Priority Mask value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PRIMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Priority Mask
+
+    This function assigns the given value to the Priority Mask Register.
+
+    \param [in]    priMask  Priority Mask
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
+}
+
+
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Enable FIQ
+
+    This function enables FIQ interrupts by clearing the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/** \brief  Disable FIQ
+
+    This function disables FIQ interrupts by setting the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+
+/** \brief  Get Base Priority
+
+    This function returns the current value of the Base Priority register.
+
+    \return               Base Priority register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_BASEPRI(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri_max" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Base Priority
+
+    This function assigns the given value to the Base Priority register.
+
+    \param [in]    basePri  Base Priority value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_BASEPRI(uint32_t value)
+{
+  __ASM volatile ("MSR basepri, %0" : : "r" (value) : "memory");
+}
+
+
+/** \brief  Get Fault Mask
+
+    This function returns the current value of the Fault Mask register.
+
+    \return               Fault Mask register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_FAULTMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Fault Mask
+
+    This function assigns the given value to the Fault Mask register.
+
+    \param [in]    faultMask  Fault Mask value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask, %0" : : "r" (faultMask) : "memory");
+}
+
+#endif /* (__CORTEX_M >= 0x03) */
+
+
+#if       (__CORTEX_M == 0x04) || (__CORTEX_M == 0x07)
+
+/** \brief  Get FPSCR
+
+    This function returns the current value of the Floating Point Status/Control register.
+
+    \return               Floating Point Status/Control register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_FPSCR(void)
+{
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  uint32_t result;
+
+  /* Empty asm statement works as a scheduling barrier */
+  __ASM volatile ("");
+  __ASM volatile ("VMRS %0, fpscr" : "=r" (result) );
+  __ASM volatile ("");
+  return(result);
+#else
+   return(0);
+#endif
+}
+
+
+/** \brief  Set FPSCR
+
+    This function assigns the given value to the Floating Point Status/Control register.
+
+    \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  /* Empty asm statement works as a scheduling barrier */
+  __ASM volatile ("");
+  __ASM volatile ("VMSR fpscr, %0" : : "r" (fpscr) : "vfpcc");
+  __ASM volatile ("");
+#endif
+}
+
+#endif /* (__CORTEX_M == 0x04) || (__CORTEX_M == 0x07) */
+
+
+#elif defined ( __ICCARM__ ) /*------------------ ICC Compiler -------------------*/
+/* IAR iccarm specific functions */
+#include <cmsis_iar.h>
+
+
+#elif defined ( __TMS470__ ) /*---------------- TI CCS Compiler ------------------*/
+/* TI CCS specific functions */
+#include <cmsis_ccs.h>
+
+
+#elif defined ( __TASKING__ ) /*------------------ TASKING Compiler --------------*/
+/* TASKING carm specific functions */
+/*
+ * The CMSIS functions have been implemented as intrinsics in the compiler.
+ * Please use "carm -?i" to get an up to date list of all intrinsics,
+ * Including the CMSIS ones.
+ */
+
+
+#elif defined ( __CSMC__ ) /*------------------ COSMIC Compiler -------------------*/
+/* Cosmic specific functions */
+#include <cmsis_csm.h>
+
+#endif
+
+/*@} end of CMSIS_Core_RegAccFunctions */
+
+#endif /* __CORE_CMFUNC_H */

--- a/common/arm/core_cmInstr.h
+++ b/common/arm/core_cmInstr.h
@@ -1,0 +1,880 @@
+/**************************************************************************//**
+ * @file     core_cmInstr.h
+ * @brief    CMSIS Cortex-M Core Instruction Access Header File
+ * @version  V4.00
+ * @date     28. August 2014
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2014 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#ifndef __CORE_CMINSTR_H
+#define __CORE_CMINSTR_H
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+#if   defined ( __CC_ARM ) /*------------------RealView Compiler -----------------*/
+/* ARM armcc specific functions */
+
+#if (__ARMCC_VERSION < 400677)
+  #error "Please use ARM Compiler Toolchain V4.0.677 or later!"
+#endif
+
+
+/** \brief  No Operation
+
+    No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP                             __nop
+
+
+/** \brief  Wait For Interrupt
+
+    Wait For Interrupt is a hint instruction that suspends execution
+    until one of a number of events occurs.
+ */
+#define __WFI                             __wfi
+
+
+/** \brief  Wait For Event
+
+    Wait For Event is a hint instruction that permits the processor to enter
+    a low-power state until one of a number of events occurs.
+ */
+#define __WFE                             __wfe
+
+
+/** \brief  Send Event
+
+    Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV                             __sev
+
+
+/** \brief  Instruction Synchronization Barrier
+
+    Instruction Synchronization Barrier flushes the pipeline in the processor,
+    so that all instructions following the ISB are fetched from cache or
+    memory, after the instruction has been completed.
+ */
+#define __ISB()                           __isb(0xF)
+
+
+/** \brief  Data Synchronization Barrier
+
+    This function acts as a special kind of Data Memory Barrier.
+    It completes when all explicit memory accesses before this instruction complete.
+ */
+#define __DSB()                           __dsb(0xF)
+
+
+/** \brief  Data Memory Barrier
+
+    This function ensures the apparent order of the explicit memory operations before
+    and after the instruction, without ensuring their completion.
+ */
+#define __DMB()                           __dmb(0xF)
+
+
+/** \brief  Reverse byte order (32 bit)
+
+    This function reverses the byte order in integer value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#define __REV                             __rev
+
+
+/** \brief  Reverse byte order (16 bit)
+
+    This function reverses the byte order in two unsigned short values.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#ifndef __NO_EMBEDDED_ASM
+__attribute__((section(".rev16_text"))) __STATIC_INLINE __ASM uint32_t __REV16(uint32_t value)
+{
+  rev16 r0, r0
+  bx lr
+}
+#endif
+
+/** \brief  Reverse byte order in signed short value
+
+    This function reverses the byte order in a signed short value with sign extension to integer.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#ifndef __NO_EMBEDDED_ASM
+__attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int32_t __REVSH(int32_t value)
+{
+  revsh r0, r0
+  bx lr
+}
+#endif
+
+
+/** \brief  Rotate Right in unsigned value (32 bit)
+
+    This function Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+
+    \param [in]    value  Value to rotate
+    \param [in]    value  Number of Bits to rotate
+    \return               Rotated value
+ */
+#define __ROR                             __ror
+
+
+/** \brief  Breakpoint
+
+    This function causes the processor to enter Debug state.
+    Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+
+    \param [in]    value  is ignored by the processor.
+                   If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)                       __breakpoint(value)
+
+
+#if       (__CORTEX_M >= 0x03) || (__CORTEX_SC >= 300)
+
+/** \brief  Reverse bit order of value
+
+    This function reverses the bit order of the given value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#define __RBIT                            __rbit
+
+
+/** \brief  LDR Exclusive (8 bit)
+
+    This function executes a exclusive LDR instruction for 8 bit value.
+
+    \param [in]    ptr  Pointer to data
+    \return             value of type uint8_t at (*ptr)
+ */
+#define __LDREXB(ptr)                     ((uint8_t ) __ldrex(ptr))
+
+
+/** \brief  LDR Exclusive (16 bit)
+
+    This function executes a exclusive LDR instruction for 16 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint16_t at (*ptr)
+ */
+#define __LDREXH(ptr)                     ((uint16_t) __ldrex(ptr))
+
+
+/** \brief  LDR Exclusive (32 bit)
+
+    This function executes a exclusive LDR instruction for 32 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint32_t at (*ptr)
+ */
+#define __LDREXW(ptr)                     ((uint32_t ) __ldrex(ptr))
+
+
+/** \brief  STR Exclusive (8 bit)
+
+    This function executes a exclusive STR instruction for 8 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+#define __STREXB(value, ptr)              __strex(value, ptr)
+
+
+/** \brief  STR Exclusive (16 bit)
+
+    This function executes a exclusive STR instruction for 16 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+#define __STREXH(value, ptr)              __strex(value, ptr)
+
+
+/** \brief  STR Exclusive (32 bit)
+
+    This function executes a exclusive STR instruction for 32 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+#define __STREXW(value, ptr)              __strex(value, ptr)
+
+
+/** \brief  Remove the exclusive lock
+
+    This function removes the exclusive lock which is created by LDREX.
+
+ */
+#define __CLREX                           __clrex
+
+
+/** \brief  Signed Saturate
+
+    This function saturates a signed value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (1..32)
+    \return             Saturated value
+ */
+#define __SSAT                            __ssat
+
+
+/** \brief  Unsigned Saturate
+
+    This function saturates an unsigned value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (0..31)
+    \return             Saturated value
+ */
+#define __USAT                            __usat
+
+
+/** \brief  Count leading zeros
+
+    This function counts the number of leading zeros of a data value.
+
+    \param [in]  value  Value to count the leading zeros
+    \return             number of leading zeros in value
+ */
+#define __CLZ                             __clz
+
+
+/** \brief  Rotate Right with Extend (32 bit)
+
+    This function moves each bit of a bitstring right by one bit. The carry input is shifted in at the left end of the bitstring.
+
+    \param [in]    value  Value to rotate
+    \return               Rotated value
+ */
+#ifndef __NO_EMBEDDED_ASM
+__attribute__((section(".rrx_text"))) __STATIC_INLINE __ASM uint32_t __RRX(uint32_t value)
+{
+  rrx r0, r0
+  bx lr
+}
+#endif
+
+
+/** \brief  LDRT Unprivileged (8 bit)
+
+    This function executes a Unprivileged LDRT instruction for 8 bit value.
+
+    \param [in]    ptr  Pointer to data
+    \return             value of type uint8_t at (*ptr)
+ */
+#define __LDRBT(ptr)                      ((uint8_t )  __ldrt(ptr))
+
+
+/** \brief  LDRT Unprivileged (16 bit)
+
+    This function executes a Unprivileged LDRT instruction for 16 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint16_t at (*ptr)
+ */
+#define __LDRHT(ptr)                      ((uint16_t)  __ldrt(ptr))
+
+
+/** \brief  LDRT Unprivileged (32 bit)
+
+    This function executes a Unprivileged LDRT instruction for 32 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint32_t at (*ptr)
+ */
+#define __LDRT(ptr)                       ((uint32_t ) __ldrt(ptr))
+
+
+/** \brief  STRT Unprivileged (8 bit)
+
+    This function executes a Unprivileged STRT instruction for 8 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+ */
+#define __STRBT(value, ptr)               __strt(value, ptr)
+
+
+/** \brief  STRT Unprivileged (16 bit)
+
+    This function executes a Unprivileged STRT instruction for 16 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+ */
+#define __STRHT(value, ptr)               __strt(value, ptr)
+
+
+/** \brief  STRT Unprivileged (32 bit)
+
+    This function executes a Unprivileged STRT instruction for 32 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+ */
+#define __STRT(value, ptr)                __strt(value, ptr)
+
+#endif /* (__CORTEX_M >= 0x03) || (__CORTEX_SC >= 300) */
+
+
+#elif defined ( __GNUC__ ) /*------------------ GNU Compiler ---------------------*/
+/* GNU gcc specific functions */
+
+/* Define macros for porting to both thumb1 and thumb2.
+ * For thumb1, use low register (r0-r7), specified by constrant "l"
+ * Otherwise, use general registers, specified by constrant "r" */
+#if defined (__thumb__) && !defined (__thumb2__)
+#define __CMSIS_GCC_OUT_REG(r) "=l" (r)
+#define __CMSIS_GCC_USE_REG(r) "l" (r)
+#else
+#define __CMSIS_GCC_OUT_REG(r) "=r" (r)
+#define __CMSIS_GCC_USE_REG(r) "r" (r)
+#endif
+
+/** \brief  No Operation
+
+    No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __NOP(void)
+{
+  __ASM volatile ("nop");
+}
+
+
+/** \brief  Wait For Interrupt
+
+    Wait For Interrupt is a hint instruction that suspends execution
+    until one of a number of events occurs.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __WFI(void)
+{
+  __ASM volatile ("wfi");
+}
+
+
+/** \brief  Wait For Event
+
+    Wait For Event is a hint instruction that permits the processor to enter
+    a low-power state until one of a number of events occurs.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __WFE(void)
+{
+  __ASM volatile ("wfe");
+}
+
+
+/** \brief  Send Event
+
+    Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __SEV(void)
+{
+  __ASM volatile ("sev");
+}
+
+
+/** \brief  Instruction Synchronization Barrier
+
+    Instruction Synchronization Barrier flushes the pipeline in the processor,
+    so that all instructions following the ISB are fetched from cache or
+    memory, after the instruction has been completed.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __ISB(void)
+{
+  __ASM volatile ("isb");
+}
+
+
+/** \brief  Data Synchronization Barrier
+
+    This function acts as a special kind of Data Memory Barrier.
+    It completes when all explicit memory accesses before this instruction complete.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __DSB(void)
+{
+  __ASM volatile ("dsb");
+}
+
+
+/** \brief  Data Memory Barrier
+
+    This function ensures the apparent order of the explicit memory operations before
+    and after the instruction, without ensuring their completion.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __DMB(void)
+{
+  __ASM volatile ("dmb");
+}
+
+
+/** \brief  Reverse byte order (32 bit)
+
+    This function reverses the byte order in integer value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __REV(uint32_t value)
+{
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+  return __builtin_bswap32(value);
+#else
+  uint32_t result;
+
+  __ASM volatile ("rev %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+#endif
+}
+
+
+/** \brief  Reverse byte order (16 bit)
+
+    This function reverses the byte order in two unsigned short values.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __REV16(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rev16 %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+}
+
+
+/** \brief  Reverse byte order in signed short value
+
+    This function reverses the byte order in a signed short value with sign extension to integer.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE int32_t __REVSH(int32_t value)
+{
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+  return (short)__builtin_bswap16(value);
+#else
+  uint32_t result;
+
+  __ASM volatile ("revsh %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+#endif
+}
+
+
+/** \brief  Rotate Right in unsigned value (32 bit)
+
+    This function Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+
+    \param [in]    value  Value to rotate
+    \param [in]    value  Number of Bits to rotate
+    \return               Rotated value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
+{
+  return (op1 >> op2) | (op1 << (32 - op2)); 
+}
+
+
+/** \brief  Breakpoint
+
+    This function causes the processor to enter Debug state.
+    Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+
+    \param [in]    value  is ignored by the processor.
+                   If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)                       __ASM volatile ("bkpt "#value)
+
+
+#if       (__CORTEX_M >= 0x03) || (__CORTEX_SC >= 300)
+
+/** \brief  Reverse bit order of value
+
+    This function reverses the bit order of the given value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __RBIT(uint32_t value)
+{
+  uint32_t result;
+
+   __ASM volatile ("rbit %0, %1" : "=r" (result) : "r" (value) );
+   return(result);
+}
+
+
+/** \brief  LDR Exclusive (8 bit)
+
+    This function executes a exclusive LDR instruction for 8 bit value.
+
+    \param [in]    ptr  Pointer to data
+    \return             value of type uint8_t at (*ptr)
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint8_t __LDREXB(volatile uint8_t *addr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrexb %0, %1" : "=r" (result) : "Q" (*addr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrexb %0, [%1]" : "=r" (result) : "r" (addr) : "memory" );
+#endif
+   return ((uint8_t) result);    /* Add explicit type cast here */
+}
+
+
+/** \brief  LDR Exclusive (16 bit)
+
+    This function executes a exclusive LDR instruction for 16 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint16_t at (*ptr)
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint16_t __LDREXH(volatile uint16_t *addr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrexh %0, %1" : "=r" (result) : "Q" (*addr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrexh %0, [%1]" : "=r" (result) : "r" (addr) : "memory" );
+#endif
+   return ((uint16_t) result);    /* Add explicit type cast here */
+}
+
+
+/** \brief  LDR Exclusive (32 bit)
+
+    This function executes a exclusive LDR instruction for 32 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint32_t at (*ptr)
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __LDREXW(volatile uint32_t *addr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldrex %0, %1" : "=r" (result) : "Q" (*addr) );
+   return(result);
+}
+
+
+/** \brief  STR Exclusive (8 bit)
+
+    This function executes a exclusive STR instruction for 8 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __STREXB(uint8_t value, volatile uint8_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strexb %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+
+/** \brief  STR Exclusive (16 bit)
+
+    This function executes a exclusive STR instruction for 16 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __STREXH(uint16_t value, volatile uint16_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strexh %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+
+/** \brief  STR Exclusive (32 bit)
+
+    This function executes a exclusive STR instruction for 32 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __STREXW(uint32_t value, volatile uint32_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strex %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" (value) );
+   return(result);
+}
+
+
+/** \brief  Remove the exclusive lock
+
+    This function removes the exclusive lock which is created by LDREX.
+
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __CLREX(void)
+{
+  __ASM volatile ("clrex" ::: "memory");
+}
+
+
+/** \brief  Signed Saturate
+
+    This function saturates a signed value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (1..32)
+    \return             Saturated value
+ */
+#define __SSAT(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("ssat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+
+/** \brief  Unsigned Saturate
+
+    This function saturates an unsigned value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (0..31)
+    \return             Saturated value
+ */
+#define __USAT(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("usat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+
+/** \brief  Count leading zeros
+
+    This function counts the number of leading zeros of a data value.
+
+    \param [in]  value  Value to count the leading zeros
+    \return             number of leading zeros in value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint8_t __CLZ(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("clz %0, %1" : "=r" (result) : "r" (value) );
+   return ((uint8_t) result);    /* Add explicit type cast here */
+}
+
+
+/** \brief  Rotate Right with Extend (32 bit)
+
+    This function moves each bit of a bitstring right by one bit. The carry input is shifted in at the left end of the bitstring.
+
+    \param [in]    value  Value to rotate
+    \return               Rotated value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+}
+
+
+/** \brief  LDRT Unprivileged (8 bit)
+
+    This function executes a Unprivileged LDRT instruction for 8 bit value.
+
+    \param [in]    ptr  Pointer to data
+    \return             value of type uint8_t at (*ptr)
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint8_t __LDRBT(volatile uint8_t *addr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*addr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrbt %0, [%1]" : "=r" (result) : "r" (addr) : "memory" );
+#endif
+   return ((uint8_t) result);    /* Add explicit type cast here */
+}
+
+
+/** \brief  LDRT Unprivileged (16 bit)
+
+    This function executes a Unprivileged LDRT instruction for 16 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint16_t at (*ptr)
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint16_t __LDRHT(volatile uint16_t *addr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*addr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrht %0, [%1]" : "=r" (result) : "r" (addr) : "memory" );
+#endif
+   return ((uint16_t) result);    /* Add explicit type cast here */
+}
+
+
+/** \brief  LDRT Unprivileged (32 bit)
+
+    This function executes a Unprivileged LDRT instruction for 32 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint32_t at (*ptr)
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __LDRT(volatile uint32_t *addr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*addr) );
+   return(result);
+}
+
+
+/** \brief  STRT Unprivileged (8 bit)
+
+    This function executes a Unprivileged STRT instruction for 8 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __STRBT(uint8_t value, volatile uint8_t *addr)
+{
+   __ASM volatile ("strbt %1, %0" : "=Q" (*addr) : "r" ((uint32_t)value) );
+}
+
+
+/** \brief  STRT Unprivileged (16 bit)
+
+    This function executes a Unprivileged STRT instruction for 16 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __STRHT(uint16_t value, volatile uint16_t *addr)
+{
+   __ASM volatile ("strht %1, %0" : "=Q" (*addr) : "r" ((uint32_t)value) );
+}
+
+
+/** \brief  STRT Unprivileged (32 bit)
+
+    This function executes a Unprivileged STRT instruction for 32 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __STRT(uint32_t value, volatile uint32_t *addr)
+{
+   __ASM volatile ("strt %1, %0" : "=Q" (*addr) : "r" (value) );
+}
+
+#endif /* (__CORTEX_M >= 0x03) || (__CORTEX_SC >= 300) */
+
+
+#elif defined ( __ICCARM__ ) /*------------------ ICC Compiler -------------------*/
+/* IAR iccarm specific functions */
+#include <cmsis_iar.h>
+
+
+#elif defined ( __TMS470__ ) /*---------------- TI CCS Compiler ------------------*/
+/* TI CCS specific functions */
+#include <cmsis_ccs.h>
+
+
+#elif defined ( __TASKING__ ) /*------------------ TASKING Compiler --------------*/
+/* TASKING carm specific functions */
+/*
+ * The CMSIS functions have been implemented as intrinsics in the compiler.
+ * Please use "carm -?i" to get an up to date list of all intrinsics,
+ * Including the CMSIS ones.
+ */
+
+
+#elif defined ( __CSMC__ ) /*------------------ COSMIC Compiler -------------------*/
+/* Cosmic specific functions */
+#include <cmsis_csm.h>
+
+#endif
+
+/*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+#endif /* __CORE_CMINSTR_H */

--- a/common/arm/core_cmSimd.h
+++ b/common/arm/core_cmSimd.h
@@ -1,0 +1,697 @@
+/**************************************************************************//**
+ * @file     core_cmSimd.h
+ * @brief    CMSIS Cortex-M SIMD Header File
+ * @version  V4.00
+ * @date     22. August 2014
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2014 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#if defined ( __ICCARM__ )
+ #pragma system_include  /* treat file as system include file for MISRA check */
+#endif
+
+#ifndef __CORE_CMSIMD_H
+#define __CORE_CMSIMD_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+ ******************************************************************************/
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if   defined ( __CC_ARM ) /*------------------RealView Compiler -----------------*/
+/* ARM armcc specific functions */
+#define __SADD8                           __sadd8
+#define __QADD8                           __qadd8
+#define __SHADD8                          __shadd8
+#define __UADD8                           __uadd8
+#define __UQADD8                          __uqadd8
+#define __UHADD8                          __uhadd8
+#define __SSUB8                           __ssub8
+#define __QSUB8                           __qsub8
+#define __SHSUB8                          __shsub8
+#define __USUB8                           __usub8
+#define __UQSUB8                          __uqsub8
+#define __UHSUB8                          __uhsub8
+#define __SADD16                          __sadd16
+#define __QADD16                          __qadd16
+#define __SHADD16                         __shadd16
+#define __UADD16                          __uadd16
+#define __UQADD16                         __uqadd16
+#define __UHADD16                         __uhadd16
+#define __SSUB16                          __ssub16
+#define __QSUB16                          __qsub16
+#define __SHSUB16                         __shsub16
+#define __USUB16                          __usub16
+#define __UQSUB16                         __uqsub16
+#define __UHSUB16                         __uhsub16
+#define __SASX                            __sasx
+#define __QASX                            __qasx
+#define __SHASX                           __shasx
+#define __UASX                            __uasx
+#define __UQASX                           __uqasx
+#define __UHASX                           __uhasx
+#define __SSAX                            __ssax
+#define __QSAX                            __qsax
+#define __SHSAX                           __shsax
+#define __USAX                            __usax
+#define __UQSAX                           __uqsax
+#define __UHSAX                           __uhsax
+#define __USAD8                           __usad8
+#define __USADA8                          __usada8
+#define __SSAT16                          __ssat16
+#define __USAT16                          __usat16
+#define __UXTB16                          __uxtb16
+#define __UXTAB16                         __uxtab16
+#define __SXTB16                          __sxtb16
+#define __SXTAB16                         __sxtab16
+#define __SMUAD                           __smuad
+#define __SMUADX                          __smuadx
+#define __SMLAD                           __smlad
+#define __SMLADX                          __smladx
+#define __SMLALD                          __smlald
+#define __SMLALDX                         __smlaldx
+#define __SMUSD                           __smusd
+#define __SMUSDX                          __smusdx
+#define __SMLSD                           __smlsd
+#define __SMLSDX                          __smlsdx
+#define __SMLSLD                          __smlsld
+#define __SMLSLDX                         __smlsldx
+#define __SEL                             __sel
+#define __QADD                            __qadd
+#define __QSUB                            __qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
+                                           ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
+
+#define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
+                                           ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
+
+#define __SMMLA(ARG1,ARG2,ARG3)          ( (int32_t)((((int64_t)(ARG1) * (ARG2)) + \
+                                                      ((int64_t)(ARG3) << 32)      ) >> 32))
+
+
+#elif defined ( __GNUC__ ) /*------------------ GNU Compiler ---------------------*/
+/* GNU gcc specific functions */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USAD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usad8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USADA8(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("usada8 %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+#define __SSAT16(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("ssat16 %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+#define __USAT16(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("usat16 %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UXTAB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtab16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SXTAB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtab16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUAD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuad %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUADX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuadx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLAD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlad %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLADX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smladx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint64_t __SMLALD (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   // Little endian
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               // Big endian
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint64_t __SMLALDX (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   // Little endian
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               // Big endian
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUSD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUSDX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusdx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLSD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsd %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLSDX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsdx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint64_t __SMLSLD (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   // Little endian
+  __ASM volatile ("smlsld %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               // Big endian
+  __ASM volatile ("smlsld %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint64_t __SMLSLDX (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   // Little endian
+  __ASM volatile ("smlsldx %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               // Big endian
+  __ASM volatile ("smlsldx %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SEL  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sel %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QADD(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSUB(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+#define __PKHBT(ARG1,ARG2,ARG3) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+ int32_t result;
+
+ __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+ return(result);
+}
+
+
+#elif defined ( __ICCARM__ ) /*------------------ ICC Compiler -------------------*/
+/* IAR iccarm specific functions */
+#include <cmsis_iar.h>
+
+
+#elif defined ( __TMS470__ ) /*---------------- TI CCS Compiler ------------------*/
+/* TI CCS specific functions */
+#include <cmsis_ccs.h>
+
+
+#elif defined ( __TASKING__ ) /*------------------ TASKING Compiler --------------*/
+/* TASKING carm specific functions */
+/* not yet supported */
+
+
+#elif defined ( __CSMC__ ) /*------------------ COSMIC Compiler -------------------*/
+/* Cosmic specific functions */
+#include <cmsis_csm.h>
+
+#endif
+
+/*@} end of group CMSIS_SIMD_intrinsics */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CMSIMD_H */

--- a/common/gcc/Makefile
+++ b/common/gcc/Makefile
@@ -1,8 +1,8 @@
 DEVICE = NRF52
-DEVICE_VARIANT =xxaa
+DEVICE_VARIANT = xxaa
 
-# We have to use SDK, not MDK because core_cm4.h is not provided in MDK
-xDK_TOP ?=../../../../nRF52_SDK_0.9.2_dbc28c9
+CMSIS ?= ../../../common/arm
+MDK   ?= ../../../common/nRF5x_MDK_8_1_0_GCC
 
 SOURCES = ../main.c
 
@@ -20,12 +20,12 @@ PROG_NAME ?= example
 # CPU related flags
 ifeq ($(DEVICE),NRF51)
 CFLAGS += -mthumb -mcpu=cortex-m0 -march=armv6-m
-LINKER_SCRIPT = $(xDK_TOP)/components/toolchain/gcc/nrf51_$(DEVICE_VARIANT).ld
+LINKER_SCRIPT = $(MDK)/nrf51_$(DEVICE_VARIANT).ld
 endif
 
 ifeq ($(DEVICE),NRF52)
 CFLAGS +=  -mcpu=cortex-m4 -mthumb -mabi=aapcs -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-LINKER_SCRIPT = $(xDK_TOP)/components/toolchain/gcc/nrf52_$(DEVICE_VARIANT).ld
+LINKER_SCRIPT = $(MDK)/nrf52_$(DEVICE_VARIANT).ld
 endif
 
 ifeq ($(DEBUG),yes)
@@ -42,15 +42,14 @@ CFLAGS += -std=gnu99   -Wall -D$(DEVICE)
 
 # Linker flags (passed to gcc)
 CFLAGS += -T $(LINKER_SCRIPT)
-CFLAGS += -L $(xDK_TOP)/components/toolchain/gcc
+CFLAGS += -L $(MDK)
 
 # Include search path
-CFLAGS += -I$(xDK_TOP)/components/device
-CFLAGS += -I$(xDK_TOP)/components/toolchain
-CFLAGS += -I$(xDK_TOP)/components/toolchain/gcc
+CFLAGS += -I$(CMSIS)
+CFLAGS += -I$(MDK)
 
-SOURCES += $(xDK_TOP)/components/toolchain/system_$(DEVICE_LC).c
-SOURCES += $(xDK_TOP)/components/toolchain/gcc/gcc_startup_$(DEVICE_LC).s
+SOURCES += $(MDK)/system_$(DEVICE_LC).c
+SOURCES += $(MDK)/gcc_startup_$(DEVICE_LC).S
 
 all:
 	@echo "Program : $(PROG_NAME)"
@@ -76,6 +75,7 @@ clean:
 	@rm -f gcc_startup_$(DEVICE_LC).o
 
 check_setup:
-	@echo "xDK_TOP   = " $(xDK_TOP)
+	@echo "MDK       = " $(MDK)
+	@echo "CMSIS     = " $(CMSIS)
 	@echo "SOURCES   = " $(SOURCES)
 	@echo "PROG_NAME = " $(PROG_NAME)

--- a/common/nRF5x_MDK_8_1_0_GCC/compiler_abstraction.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/compiler_abstraction.h
@@ -1,0 +1,126 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef _COMPILER_ABSTRACTION_H
+#define _COMPILER_ABSTRACTION_H
+
+/*lint ++flb "Enter library region" */
+
+#if defined ( __CC_ARM )
+    
+    #ifndef __ASM
+        #define __ASM               __asm                       
+    #endif
+    
+    #ifndef __INLINE
+        #define __INLINE            __inline                    
+    #endif
+    
+    #ifndef __WEAK
+        #define __WEAK              __weak                      
+    #endif
+    
+    #ifndef __ALIGN
+        #define __ALIGN(n)          __align(n)                  
+    #endif
+    
+    #define GET_SP()                __current_sp()              
+  
+#elif defined ( __ICCARM__ )
+    
+    #ifndef __ASM
+        #define __ASM               __asm                       
+    #endif
+    
+    #ifndef __INLINE
+        #define __INLINE            inline                      
+    #endif
+    
+    #ifndef __WEAK
+        #define __WEAK              __weak                      
+    #endif
+
+    /* Not defined for IAR since it requires a new line to work, and C preprocessor does not allow that. */
+    #ifndef __ALIGN
+        #define __ALIGN(n)          
+    #endif
+    
+    #define GET_SP()                __get_SP()                  
+    
+#elif defined   ( __GNUC__ )
+    
+    #ifndef __ASM
+        #define __ASM               __asm                       
+    #endif
+    
+    #ifndef __INLINE
+        #define __INLINE            inline                      
+    #endif
+    
+    #ifndef __WEAK
+        #define __WEAK              __attribute__((weak))       
+    #endif
+    
+    #ifndef __ALIGN
+        #define __ALIGN(n)          __attribute__((aligned(n))) 
+    #endif
+    
+    #define GET_SP()                gcc_current_sp()            
+
+    static inline unsigned int gcc_current_sp(void)
+    {
+        register unsigned sp __ASM("sp");
+        return sp;
+    }
+    
+#elif defined   ( __TASKING__ )
+        
+    #ifndef __ASM        
+        #define __ASM               __asm                      
+    #endif
+    
+    #ifndef __INLINE
+        #define __INLINE            inline                     
+    #endif
+    
+    #ifndef __WEAK
+        #define __WEAK              __attribute__((weak))      
+    #endif
+    
+    #ifndef __ALIGN
+        #define __ALIGN(n)          __align(n)                  
+    #endif
+    
+    #define GET_SP()                __get_MSP()                
+    
+#endif
+
+/*lint --flb "Leave library region" */
+
+#endif

--- a/common/nRF5x_MDK_8_1_0_GCC/gcc_startup_nrf51.S
+++ b/common/nRF5x_MDK_8_1_0_GCC/gcc_startup_nrf51.S
@@ -1,0 +1,266 @@
+/* 
+Copyright (c) 2015, Nordic Semiconductor ASA
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Nordic Semiconductor ASA nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* 
+NOTE: Template files (including this one) are application specific and therefore 
+expected to be copied into the application project folder prior to its use!
+*/
+
+    .syntax unified
+    .arch armv6-m
+
+    .section .stack
+    .align 3
+#ifdef __STACK_SIZE
+    .equ    Stack_Size, __STACK_SIZE
+#else
+    .equ    Stack_Size, 2048
+#endif
+    .globl    __StackTop
+    .globl    __StackLimit
+__StackLimit:
+    .space    Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
+
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ    Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 2048
+#endif
+    .globl    __HeapBase
+    .globl    __HeapLimit
+__HeapBase:
+    .if    Heap_Size
+    .space    Heap_Size
+    .endif
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
+    
+    .section .Vectors
+    .align 2
+    .globl __Vectors
+__Vectors:
+    .long   __StackTop                  /* Top of Stack */
+    .long   Reset_Handler
+    .long   NMI_Handler
+    .long   HardFault_Handler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   SVC_Handler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   PendSV_Handler
+    .long   SysTick_Handler
+
+  /* External Interrupts */
+    .long   POWER_CLOCK_IRQHandler
+    .long   RADIO_IRQHandler
+    .long   UART0_IRQHandler
+    .long   SPI0_TWI0_IRQHandler
+    .long   SPI1_TWI1_IRQHandler
+    .long   0                           /*Reserved */
+    .long   GPIOTE_IRQHandler
+    .long   ADC_IRQHandler
+    .long   TIMER0_IRQHandler
+    .long   TIMER1_IRQHandler
+    .long   TIMER2_IRQHandler
+    .long   RTC0_IRQHandler
+    .long   TEMP_IRQHandler
+    .long   RNG_IRQHandler
+    .long   ECB_IRQHandler
+    .long   CCM_AAR_IRQHandler
+    .long   WDT_IRQHandler
+    .long   RTC1_IRQHandler
+    .long   QDEC_IRQHandler
+    .long   LPCOMP_IRQHandler
+    .long   SWI0_IRQHandler
+    .long   SWI1_IRQHandler
+    .long   SWI2_IRQHandler
+    .long   SWI3_IRQHandler
+    .long   SWI4_IRQHandler
+    .long   SWI5_IRQHandler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+
+    .size    __Vectors, . - __Vectors
+
+/* Reset Handler */
+
+    .equ    NRF_POWER_RAMON_ADDRESS,             0x40000524
+    .equ    NRF_POWER_RAMONB_ADDRESS,            0x40000554
+    .equ    NRF_POWER_RAMONx_RAMxON_ONMODE_Msk,  0x3  
+
+    .text
+    .thumb
+    .thumb_func
+    .align 1
+    .globl    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+    .fnstart
+
+/* Make sure ALL RAM banks are powered on */
+    MOVS    R1, #NRF_POWER_RAMONx_RAMxON_ONMODE_Msk
+    
+    LDR     R0, =NRF_POWER_RAMON_ADDRESS
+    LDR     R2, [R0]
+    ORRS    R2, R1
+    STR     R2, [R0]
+
+    LDR     R0, =NRF_POWER_RAMONB_ADDRESS
+    LDR     R2, [R0]
+    ORRS    R2, R1
+    STR     R2, [R0]
+
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in 
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+    subs    r3, r2
+    ble     .LC0
+
+.LC1:
+    subs    r3, 4
+    ldr    r0, [r1,r3]
+    str    r0, [r2,r3]
+    bgt    .LC1
+.LC0:
+    
+    LDR     R0, =SystemInit
+    BLX     R0
+    LDR     R0, =_start
+    BX      R0
+
+    .pool
+    .cantunwind
+    .fnend
+    .size   Reset_Handler,.-Reset_Handler
+
+    .section ".text"
+
+
+/* Dummy Exception Handlers (infinite loops which can be modified) */
+
+    .weak   NMI_Handler
+    .type   NMI_Handler, %function
+NMI_Handler:
+    B       .
+    .size   NMI_Handler, . - NMI_Handler
+
+
+    .weak   HardFault_Handler
+    .type   HardFault_Handler, %function
+HardFault_Handler:
+    B       .
+    .size   HardFault_Handler, . - HardFault_Handler
+
+
+    .weak   SVC_Handler
+    .type   SVC_Handler, %function
+SVC_Handler:
+    B       .
+    .size   SVC_Handler, . - SVC_Handler
+
+
+    .weak   PendSV_Handler
+    .type   PendSV_Handler, %function
+PendSV_Handler:
+    B       .
+    .size   PendSV_Handler, . - PendSV_Handler
+
+
+    .weak   SysTick_Handler
+    .type   SysTick_Handler, %function
+SysTick_Handler:
+    B       .
+    .size   SysTick_Handler, . - SysTick_Handler
+
+
+/* IRQ Handlers */
+
+    .globl  Default_Handler
+    .type   Default_Handler, %function
+Default_Handler:
+    B       .
+    .size   Default_Handler, . - Default_Handler
+
+    .macro  IRQ handler
+    .weak   \handler
+    .set    \handler, Default_Handler
+    .endm
+
+    IRQ  POWER_CLOCK_IRQHandler
+    IRQ  RADIO_IRQHandler
+    IRQ  UART0_IRQHandler
+    IRQ  SPI0_TWI0_IRQHandler
+    IRQ  SPI1_TWI1_IRQHandler
+    IRQ  GPIOTE_IRQHandler
+    IRQ  ADC_IRQHandler
+    IRQ  TIMER0_IRQHandler
+    IRQ  TIMER1_IRQHandler
+    IRQ  TIMER2_IRQHandler
+    IRQ  RTC0_IRQHandler
+    IRQ  TEMP_IRQHandler
+    IRQ  RNG_IRQHandler
+    IRQ  ECB_IRQHandler
+    IRQ  CCM_AAR_IRQHandler
+    IRQ  WDT_IRQHandler
+    IRQ  RTC1_IRQHandler
+    IRQ  QDEC_IRQHandler
+    IRQ  LPCOMP_IRQHandler
+    IRQ  SWI0_IRQHandler
+    IRQ  SWI1_IRQHandler
+    IRQ  SWI2_IRQHandler
+    IRQ  SWI3_IRQHandler
+    IRQ  SWI4_IRQHandler
+    IRQ  SWI5_IRQHandler
+
+  .end

--- a/common/nRF5x_MDK_8_1_0_GCC/gcc_startup_nrf52.S
+++ b/common/nRF5x_MDK_8_1_0_GCC/gcc_startup_nrf52.S
@@ -1,0 +1,490 @@
+/* 
+Copyright (c) 2015, Nordic Semiconductor ASA
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Nordic Semiconductor ASA nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* 
+NOTE: Template files (including this one) are application specific and therefore 
+expected to be copied into the application project folder prior to its use!
+*/
+
+    .syntax unified
+    .arch armv7e-m
+
+    .section .stack
+    .align 3
+#ifdef __STACK_SIZE
+    .equ    Stack_Size, __STACK_SIZE
+#else
+    .equ    Stack_Size, 8192
+#endif
+    .globl    __StackTop
+    .globl    __StackLimit
+__StackLimit:
+    .space    Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
+
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ    Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 8192
+#endif
+    .globl    __HeapBase
+    .globl    __HeapLimit
+__HeapBase:
+    .if    Heap_Size
+    .space    Heap_Size
+    .endif
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
+    
+    .section .Vectors
+    .align 2
+    .globl __Vectors
+__Vectors:
+    .long   __StackTop                  /* Top of Stack */
+    .long   Reset_Handler
+    .long   NMI_Handler
+    .long   HardFault_Handler
+    .long   MemoryManagement_Handler
+    .long   BusFault_Handler
+    .long   UsageFault_Handler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   SVC_Handler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   PendSV_Handler
+    .long   SysTick_Handler
+
+  /* External Interrupts */
+    .long   POWER_CLOCK_IRQHandler
+    .long   RADIO_IRQHandler
+    .long   UARTE0_UART0_IRQHandler
+    .long   SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler
+    .long   SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler
+    .long   NFCT_IRQHandler
+    .long   GPIOTE_IRQHandler
+    .long   SAADC_IRQHandler
+    .long   TIMER0_IRQHandler
+    .long   TIMER1_IRQHandler
+    .long   TIMER2_IRQHandler
+    .long   RTC0_IRQHandler
+    .long   TEMP_IRQHandler
+    .long   RNG_IRQHandler
+    .long   ECB_IRQHandler
+    .long   CCM_AAR_IRQHandler
+    .long   WDT_IRQHandler
+    .long   RTC1_IRQHandler
+    .long   QDEC_IRQHandler
+    .long   COMP_LPCOMP_IRQHandler
+    .long   SWI0_EGU0_IRQHandler
+    .long   SWI1_EGU1_IRQHandler
+    .long   SWI2_EGU2_IRQHandler
+    .long   SWI3_EGU3_IRQHandler
+    .long   SWI4_EGU4_IRQHandler
+    .long   SWI5_EGU5_IRQHandler
+    .long   TIMER3_IRQHandler
+    .long   TIMER4_IRQHandler
+    .long   PWM0_IRQHandler
+    .long   PDM_IRQHandler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   MWU_IRQHandler
+    .long   PWM1_IRQHandler
+    .long   PWM2_IRQHandler
+    .long   SPIM2_SPIS2_SPI2_IRQHandler
+    .long   RTC2_IRQHandler
+    .long   I2S_IRQHandler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+
+    .size    __Vectors, . - __Vectors
+
+/* Reset Handler */
+
+    .text
+    .thumb
+    .thumb_func
+    .align 1
+    .globl    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+    .fnstart
+
+
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in 
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+    subs    r3, r2
+    ble     .LC0
+
+.LC1:
+    subs    r3, 4
+    ldr    r0, [r1,r3]
+    str    r0, [r2,r3]
+    bgt    .LC1
+.LC0:
+    
+    LDR     R0, =SystemInit
+    BLX     R0
+    LDR     R0, =_start
+    BX      R0
+
+    .pool
+    .cantunwind
+    .fnend
+    .size   Reset_Handler,.-Reset_Handler
+
+    .section ".text"
+
+
+/* Dummy Exception Handlers (infinite loops which can be modified) */
+
+    .weak   NMI_Handler
+    .type   NMI_Handler, %function
+NMI_Handler:
+    B       .
+    .size   NMI_Handler, . - NMI_Handler
+
+
+    .weak   HardFault_Handler
+    .type   HardFault_Handler, %function
+HardFault_Handler:
+    B       .
+    .size   HardFault_Handler, . - HardFault_Handler
+
+
+    .weak   MemoryManagement_Handler
+    .type   MemoryManagement_Handler, %function
+MemoryManagement_Handler:
+    B       .
+    .size   MemoryManagement_Handler, . - MemoryManagement_Handler
+
+
+    .weak   BusFault_Handler
+    .type   BusFault_Handler, %function
+BusFault_Handler:
+    B       .
+    .size   BusFault_Handler, . - BusFault_Handler
+
+
+    .weak   UsageFault_Handler
+    .type   UsageFault_Handler, %function
+UsageFault_Handler:
+    B       .
+    .size   UsageFault_Handler, . - UsageFault_Handler
+
+
+    .weak   SVC_Handler
+    .type   SVC_Handler, %function
+SVC_Handler:
+    B       .
+    .size   SVC_Handler, . - SVC_Handler
+
+
+    .weak   PendSV_Handler
+    .type   PendSV_Handler, %function
+PendSV_Handler:
+    B       .
+    .size   PendSV_Handler, . - PendSV_Handler
+
+
+    .weak   SysTick_Handler
+    .type   SysTick_Handler, %function
+SysTick_Handler:
+    B       .
+    .size   SysTick_Handler, . - SysTick_Handler
+
+
+/* IRQ Handlers */
+
+    .globl  Default_Handler
+    .type   Default_Handler, %function
+Default_Handler:
+    B       .
+    .size   Default_Handler, . - Default_Handler
+
+    .macro  IRQ handler
+    .weak   \handler
+    .set    \handler, Default_Handler
+    .endm
+
+    IRQ  POWER_CLOCK_IRQHandler
+    IRQ  RADIO_IRQHandler
+    IRQ  UARTE0_UART0_IRQHandler
+    IRQ  SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler
+    IRQ  SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler
+    IRQ  NFCT_IRQHandler
+    IRQ  GPIOTE_IRQHandler
+    IRQ  SAADC_IRQHandler
+    IRQ  TIMER0_IRQHandler
+    IRQ  TIMER1_IRQHandler
+    IRQ  TIMER2_IRQHandler
+    IRQ  RTC0_IRQHandler
+    IRQ  TEMP_IRQHandler
+    IRQ  RNG_IRQHandler
+    IRQ  ECB_IRQHandler
+    IRQ  CCM_AAR_IRQHandler
+    IRQ  WDT_IRQHandler
+    IRQ  RTC1_IRQHandler
+    IRQ  QDEC_IRQHandler
+    IRQ  COMP_LPCOMP_IRQHandler
+    IRQ  SWI0_EGU0_IRQHandler
+    IRQ  SWI1_EGU1_IRQHandler
+    IRQ  SWI2_EGU2_IRQHandler
+    IRQ  SWI3_EGU3_IRQHandler
+    IRQ  SWI4_EGU4_IRQHandler
+    IRQ  SWI5_EGU5_IRQHandler
+    IRQ  TIMER3_IRQHandler
+    IRQ  TIMER4_IRQHandler
+    IRQ  PWM0_IRQHandler
+    IRQ  PDM_IRQHandler
+    IRQ  MWU_IRQHandler
+    IRQ  PWM1_IRQHandler
+    IRQ  PWM2_IRQHandler
+    IRQ  SPIM2_SPIS2_SPI2_IRQHandler
+    IRQ  RTC2_IRQHandler
+    IRQ  I2S_IRQHandler
+
+  .end

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf.h
@@ -1,0 +1,60 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef NRF_H
+#define NRF_H
+
+#if defined(_WIN32)         
+    /* Do not include nrf51 specific files when building for PC host */
+#elif defined(__unix)       
+    /* Do not include nrf51 specific files when building for PC host */
+#elif defined(__APPLE__)    
+    /* Do not include nrf51 specific files when building for PC host */
+#else
+
+    /* Family selection for family includes. */
+    #if defined (NRF51)
+        #include "nrf51.h"
+        #include "nrf51_bitfields.h"
+        #include "nrf51_deprecated.h"
+    #elif defined (NRF52)
+        #include "nrf52.h"
+        #include "nrf52_bitfields.h"
+        #include "nrf51_to_nrf52.h"
+    #else
+        #error "Device family must be defined. See nrf.h."
+    #endif /* NRF51, NRF52 */
+
+    #include "compiler_abstraction.h"
+
+#endif /* _WIN32 || __unix || __APPLE__ */
+
+#endif /* NRF_H */
+

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf51.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf51.h
@@ -1,0 +1,1285 @@
+
+/****************************************************************************************************//**
+ * @file     nrf51.h
+ *
+ * @brief    CMSIS Cortex-M0 Peripheral Access Layer Header File for
+ *           nrf51 from Nordic Semiconductor.
+ *
+ * @version  V522
+ * @date     9. October 2015
+ *
+ * @note     Generated with SVDConv V2.81d 
+ *           from CMSIS SVD File 'nrf51.svd' Version 522,
+ *
+ * @par      Copyright (c) 2013, Nordic Semiconductor ASA
+ *           All rights reserved.
+ *           
+ *           Redistribution and use in source and binary forms, with or without
+ *           modification, are permitted provided that the following conditions are met:
+ *           
+ *           * Redistributions of source code must retain the above copyright notice, this
+ *           list of conditions and the following disclaimer.
+ *           
+ *           * Redistributions in binary form must reproduce the above copyright notice,
+ *           this list of conditions and the following disclaimer in the documentation
+ *           and/or other materials provided with the distribution.
+ *           
+ *           * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *           contributors may be used to endorse or promote products derived from
+ *           this software without specific prior written permission.
+ *           
+ *           THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *           AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *           IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *           DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *           FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *           DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *           SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *           CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *           OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *           OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *           
+ *
+ *******************************************************************************************************/
+
+
+
+/** @addtogroup Nordic Semiconductor
+  * @{
+  */
+
+/** @addtogroup nrf51
+  * @{
+  */
+
+#ifndef NRF51_H
+#define NRF51_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* -------------------------  Interrupt Number Definition  ------------------------ */
+
+typedef enum {
+/* -------------------  Cortex-M0 Processor Exceptions Numbers  ------------------- */
+  Reset_IRQn                    = -15,              /*!<   1  Reset Vector, invoked on Power up and warm reset                 */
+  NonMaskableInt_IRQn           = -14,              /*!<   2  Non maskable Interrupt, cannot be stopped or preempted           */
+  HardFault_IRQn                = -13,              /*!<   3  Hard Fault, all classes of Fault                                 */
+  SVCall_IRQn                   =  -5,              /*!<  11  System Service Call via SVC instruction                          */
+  DebugMonitor_IRQn             =  -4,              /*!<  12  Debug Monitor                                                    */
+  PendSV_IRQn                   =  -2,              /*!<  14  Pendable request for system service                              */
+  SysTick_IRQn                  =  -1,              /*!<  15  System Tick Timer                                                */
+/* ----------------------  nrf51 Specific Interrupt Numbers  ---------------------- */
+  POWER_CLOCK_IRQn              =   0,              /*!<   0  POWER_CLOCK                                                      */
+  RADIO_IRQn                    =   1,              /*!<   1  RADIO                                                            */
+  UART0_IRQn                    =   2,              /*!<   2  UART0                                                            */
+  SPI0_TWI0_IRQn                =   3,              /*!<   3  SPI0_TWI0                                                        */
+  SPI1_TWI1_IRQn                =   4,              /*!<   4  SPI1_TWI1                                                        */
+  GPIOTE_IRQn                   =   6,              /*!<   6  GPIOTE                                                           */
+  ADC_IRQn                      =   7,              /*!<   7  ADC                                                              */
+  TIMER0_IRQn                   =   8,              /*!<   8  TIMER0                                                           */
+  TIMER1_IRQn                   =   9,              /*!<   9  TIMER1                                                           */
+  TIMER2_IRQn                   =  10,              /*!<  10  TIMER2                                                           */
+  RTC0_IRQn                     =  11,              /*!<  11  RTC0                                                             */
+  TEMP_IRQn                     =  12,              /*!<  12  TEMP                                                             */
+  RNG_IRQn                      =  13,              /*!<  13  RNG                                                              */
+  ECB_IRQn                      =  14,              /*!<  14  ECB                                                              */
+  CCM_AAR_IRQn                  =  15,              /*!<  15  CCM_AAR                                                          */
+  WDT_IRQn                      =  16,              /*!<  16  WDT                                                              */
+  RTC1_IRQn                     =  17,              /*!<  17  RTC1                                                             */
+  QDEC_IRQn                     =  18,              /*!<  18  QDEC                                                             */
+  LPCOMP_IRQn                   =  19,              /*!<  19  LPCOMP                                                           */
+  SWI0_IRQn                     =  20,              /*!<  20  SWI0                                                             */
+  SWI1_IRQn                     =  21,              /*!<  21  SWI1                                                             */
+  SWI2_IRQn                     =  22,              /*!<  22  SWI2                                                             */
+  SWI3_IRQn                     =  23,              /*!<  23  SWI3                                                             */
+  SWI4_IRQn                     =  24,              /*!<  24  SWI4                                                             */
+  SWI5_IRQn                     =  25               /*!<  25  SWI5                                                             */
+} IRQn_Type;
+
+
+/** @addtogroup Configuration_of_CMSIS
+  * @{
+  */
+
+
+/* ================================================================================ */
+/* ================      Processor and Core Peripheral Section     ================ */
+/* ================================================================================ */
+
+/* ----------------Configuration of the Cortex-M0 Processor and Core Peripherals---------------- */
+#define __CM0_REV                 0x0301            /*!< Cortex-M0 Core Revision                                               */
+#define __MPU_PRESENT                  0            /*!< MPU present or not                                                    */
+#define __NVIC_PRIO_BITS               2            /*!< Number of Bits used for Priority Levels                               */
+#define __Vendor_SysTickConfig         0            /*!< Set to 1 if different SysTick Config is used                          */
+/** @} */ /* End of group Configuration_of_CMSIS */
+
+#include "core_cm0.h"                               /*!< Cortex-M0 processor and core peripherals                              */
+#include "system_nrf51.h"                           /*!< nrf51 System                                                          */
+
+
+/* ================================================================================ */
+/* ================       Device Specific Peripheral Section       ================ */
+/* ================================================================================ */
+
+
+/** @addtogroup Device_Peripheral_Registers
+  * @{
+  */
+
+
+/* -------------------  Start of section using anonymous unions  ------------------ */
+#if defined(__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined(__ICCARM__)
+  #pragma language=extended
+#elif defined(__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined(__TMS470__)
+/* anonymous unions are enabled by default */
+#elif defined(__TASKING__)
+  #pragma warning 586
+#else
+  #warning Not supported compiler type
+#endif
+
+
+typedef struct {
+  __IO uint32_t  CPU0;                              /*!< Configurable priority configuration register for CPU0.                */
+  __IO uint32_t  SPIS1;                             /*!< Configurable priority configuration register for SPIS1.               */
+  __IO uint32_t  RADIO;                             /*!< Configurable priority configuration register for RADIO.               */
+  __IO uint32_t  ECB;                               /*!< Configurable priority configuration register for ECB.                 */
+  __IO uint32_t  CCM;                               /*!< Configurable priority configuration register for CCM.                 */
+  __IO uint32_t  AAR;                               /*!< Configurable priority configuration register for AAR.                 */
+} AMLI_RAMPRI_Type;
+
+typedef struct {
+  __IO uint32_t  SCK;                               /*!< Pin select for SCK.                                                   */
+  __IO uint32_t  MOSI;                              /*!< Pin select for MOSI.                                                  */
+  __IO uint32_t  MISO;                              /*!< Pin select for MISO.                                                  */
+} SPIM_PSEL_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Data pointer.                                                         */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of buffer bytes to receive.                            */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes received in the last transaction.                     */
+} SPIM_RXD_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Data pointer.                                                         */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of buffer bytes to send.                               */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes sent in the last transaction.                         */
+} SPIM_TXD_Type;
+
+typedef struct {
+  __O  uint32_t  EN;                                /*!< Enable channel group.                                                 */
+  __O  uint32_t  DIS;                               /*!< Disable channel group.                                                */
+} PPI_TASKS_CHG_Type;
+
+typedef struct {
+  __IO uint32_t  EEP;                               /*!< Channel event end-point.                                              */
+  __IO uint32_t  TEP;                               /*!< Channel task end-point.                                               */
+} PPI_CH_Type;
+
+
+/* ================================================================================ */
+/* ================                      POWER                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Power Control. (POWER)
+  */
+
+typedef struct {                                    /*!< POWER Structure                                                       */
+  __I  uint32_t  RESERVED0[30];
+  __O  uint32_t  TASKS_CONSTLAT;                    /*!< Enable constant latency mode.                                         */
+  __O  uint32_t  TASKS_LOWPWR;                      /*!< Enable low power mode (variable latency).                             */
+  __I  uint32_t  RESERVED1[34];
+  __IO uint32_t  EVENTS_POFWARN;                    /*!< Power failure warning.                                                */
+  __I  uint32_t  RESERVED2[126];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED3[61];
+  __IO uint32_t  RESETREAS;                         /*!< Reset reason.                                                         */
+  __I  uint32_t  RESERVED4[9];
+  __I  uint32_t  RAMSTATUS;                         /*!< Ram status register.                                                  */
+  __I  uint32_t  RESERVED5[53];
+  __O  uint32_t  SYSTEMOFF;                         /*!< System off register.                                                  */
+  __I  uint32_t  RESERVED6[3];
+  __IO uint32_t  POFCON;                            /*!< Power failure configuration.                                          */
+  __I  uint32_t  RESERVED7[2];
+  __IO uint32_t  GPREGRET;                          /*!< General purpose retention register. This register is a retained
+                                                         register.                                                             */
+  __I  uint32_t  RESERVED8;
+  __IO uint32_t  RAMON;                             /*!< Ram on/off.                                                           */
+  __I  uint32_t  RESERVED9[7];
+  __IO uint32_t  RESET;                             /*!< Pin reset functionality configuration register. This register
+                                                         is a retained register.                                               */
+  __I  uint32_t  RESERVED10[3];
+  __IO uint32_t  RAMONB;                            /*!< Ram on/off.                                                           */
+  __I  uint32_t  RESERVED11[8];
+  __IO uint32_t  DCDCEN;                            /*!< DCDC converter enable configuration register.                         */
+  __I  uint32_t  RESERVED12[291];
+  __IO uint32_t  DCDCFORCE;                         /*!< DCDC power-up force register.                                         */
+} NRF_POWER_Type;
+
+
+/* ================================================================================ */
+/* ================                      CLOCK                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Clock control. (CLOCK)
+  */
+
+typedef struct {                                    /*!< CLOCK Structure                                                       */
+  __O  uint32_t  TASKS_HFCLKSTART;                  /*!< Start HFCLK clock source.                                             */
+  __O  uint32_t  TASKS_HFCLKSTOP;                   /*!< Stop HFCLK clock source.                                              */
+  __O  uint32_t  TASKS_LFCLKSTART;                  /*!< Start LFCLK clock source.                                             */
+  __O  uint32_t  TASKS_LFCLKSTOP;                   /*!< Stop LFCLK clock source.                                              */
+  __O  uint32_t  TASKS_CAL;                         /*!< Start calibration of LFCLK RC oscillator.                             */
+  __O  uint32_t  TASKS_CTSTART;                     /*!< Start calibration timer.                                              */
+  __O  uint32_t  TASKS_CTSTOP;                      /*!< Stop calibration timer.                                               */
+  __I  uint32_t  RESERVED0[57];
+  __IO uint32_t  EVENTS_HFCLKSTARTED;               /*!< HFCLK oscillator started.                                             */
+  __IO uint32_t  EVENTS_LFCLKSTARTED;               /*!< LFCLK oscillator started.                                             */
+  __I  uint32_t  RESERVED1;
+  __IO uint32_t  EVENTS_DONE;                       /*!< Calibration of LFCLK RC oscillator completed.                         */
+  __IO uint32_t  EVENTS_CTTO;                       /*!< Calibration timer timeout.                                            */
+  __I  uint32_t  RESERVED2[124];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED3[63];
+  __I  uint32_t  HFCLKRUN;                          /*!< Task HFCLKSTART trigger status.                                       */
+  __I  uint32_t  HFCLKSTAT;                         /*!< High frequency clock status.                                          */
+  __I  uint32_t  RESERVED4;
+  __I  uint32_t  LFCLKRUN;                          /*!< Task LFCLKSTART triggered status.                                     */
+  __I  uint32_t  LFCLKSTAT;                         /*!< Low frequency clock status.                                           */
+  __I  uint32_t  LFCLKSRCCOPY;                      /*!< Clock source for the LFCLK clock, set when task LKCLKSTART is
+                                                         triggered.                                                            */
+  __I  uint32_t  RESERVED5[62];
+  __IO uint32_t  LFCLKSRC;                          /*!< Clock source for the LFCLK clock.                                     */
+  __I  uint32_t  RESERVED6[7];
+  __IO uint32_t  CTIV;                              /*!< Calibration timer interval.                                           */
+  __I  uint32_t  RESERVED7[5];
+  __IO uint32_t  XTALFREQ;                          /*!< Crystal frequency.                                                    */
+} NRF_CLOCK_Type;
+
+
+/* ================================================================================ */
+/* ================                       MPU                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Memory Protection Unit. (MPU)
+  */
+
+typedef struct {                                    /*!< MPU Structure                                                         */
+  __I  uint32_t  RESERVED0[330];
+  __IO uint32_t  PERR0;                             /*!< Configuration of peripherals in mpu regions.                          */
+  __IO uint32_t  RLENR0;                            /*!< Length of RAM region 0.                                               */
+  __I  uint32_t  RESERVED1[52];
+  __IO uint32_t  PROTENSET0;                        /*!< Erase and write protection bit enable set register.                   */
+  __IO uint32_t  PROTENSET1;                        /*!< Erase and write protection bit enable set register.                   */
+  __IO uint32_t  DISABLEINDEBUG;                    /*!< Disable erase and write protection mechanism in debug mode.           */
+  __IO uint32_t  PROTBLOCKSIZE;                     /*!< Erase and write protection block size.                                */
+} NRF_MPU_Type;
+
+
+/* ================================================================================ */
+/* ================                      AMLI                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief AHB Multi-Layer Interface. (AMLI)
+  */
+
+typedef struct {                                    /*!< AMLI Structure                                                        */
+  __I  uint32_t  RESERVED0[896];
+  AMLI_RAMPRI_Type RAMPRI;                          /*!< RAM configurable priority configuration structure.                    */
+} NRF_AMLI_Type;
+
+
+/* ================================================================================ */
+/* ================                      RADIO                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief The radio. (RADIO)
+  */
+
+typedef struct {                                    /*!< RADIO Structure                                                       */
+  __O  uint32_t  TASKS_TXEN;                        /*!< Enable radio in TX mode.                                              */
+  __O  uint32_t  TASKS_RXEN;                        /*!< Enable radio in RX mode.                                              */
+  __O  uint32_t  TASKS_START;                       /*!< Start radio.                                                          */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop radio.                                                           */
+  __O  uint32_t  TASKS_DISABLE;                     /*!< Disable radio.                                                        */
+  __O  uint32_t  TASKS_RSSISTART;                   /*!< Start the RSSI and take one sample of the receive signal strength.    */
+  __O  uint32_t  TASKS_RSSISTOP;                    /*!< Stop the RSSI measurement.                                            */
+  __O  uint32_t  TASKS_BCSTART;                     /*!< Start the bit counter.                                                */
+  __O  uint32_t  TASKS_BCSTOP;                      /*!< Stop the bit counter.                                                 */
+  __I  uint32_t  RESERVED0[55];
+  __IO uint32_t  EVENTS_READY;                      /*!< Ready event.                                                          */
+  __IO uint32_t  EVENTS_ADDRESS;                    /*!< Address event.                                                        */
+  __IO uint32_t  EVENTS_PAYLOAD;                    /*!< Payload event.                                                        */
+  __IO uint32_t  EVENTS_END;                        /*!< End event.                                                            */
+  __IO uint32_t  EVENTS_DISABLED;                   /*!< Disable event.                                                        */
+  __IO uint32_t  EVENTS_DEVMATCH;                   /*!< A device address match occurred on the last received packet.          */
+  __IO uint32_t  EVENTS_DEVMISS;                    /*!< No device address match occurred on the last received packet.         */
+  __IO uint32_t  EVENTS_RSSIEND;                    /*!< Sampling of the receive signal strength complete. A new RSSI
+                                                         sample is ready for readout at the RSSISAMPLE register.               */
+  __I  uint32_t  RESERVED1[2];
+  __IO uint32_t  EVENTS_BCMATCH;                    /*!< Bit counter reached bit count value specified in BCC register.        */
+  __I  uint32_t  RESERVED2[53];
+  __IO uint32_t  SHORTS;                            /*!< Shortcuts for the radio.                                              */
+  __I  uint32_t  RESERVED3[64];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED4[61];
+  __I  uint32_t  CRCSTATUS;                         /*!< CRC status of received packet.                                        */
+  __I  uint32_t  RESERVED5;
+  __I  uint32_t  RXMATCH;                           /*!< Received address.                                                     */
+  __I  uint32_t  RXCRC;                             /*!< Received CRC.                                                         */
+  __I  uint32_t  DAI;                               /*!< Device address match index.                                           */
+  __I  uint32_t  RESERVED6[60];
+  __IO uint32_t  PACKETPTR;                         /*!< Packet pointer. Decision point: START task.                           */
+  __IO uint32_t  FREQUENCY;                         /*!< Frequency.                                                            */
+  __IO uint32_t  TXPOWER;                           /*!< Output power.                                                         */
+  __IO uint32_t  MODE;                              /*!< Data rate and modulation.                                             */
+  __IO uint32_t  PCNF0;                             /*!< Packet configuration 0.                                               */
+  __IO uint32_t  PCNF1;                             /*!< Packet configuration 1.                                               */
+  __IO uint32_t  BASE0;                             /*!< Radio base address 0. Decision point: START task.                     */
+  __IO uint32_t  BASE1;                             /*!< Radio base address 1. Decision point: START task.                     */
+  __IO uint32_t  PREFIX0;                           /*!< Prefixes bytes for logical addresses 0 to 3.                          */
+  __IO uint32_t  PREFIX1;                           /*!< Prefixes bytes for logical addresses 4 to 7.                          */
+  __IO uint32_t  TXADDRESS;                         /*!< Transmit address select.                                              */
+  __IO uint32_t  RXADDRESSES;                       /*!< Receive address select.                                               */
+  __IO uint32_t  CRCCNF;                            /*!< CRC configuration.                                                    */
+  __IO uint32_t  CRCPOLY;                           /*!< CRC polynomial.                                                       */
+  __IO uint32_t  CRCINIT;                           /*!< CRC initial value.                                                    */
+  __IO uint32_t  TEST;                              /*!< Test features enable register.                                        */
+  __IO uint32_t  TIFS;                              /*!< Inter Frame Spacing in microseconds.                                  */
+  __I  uint32_t  RSSISAMPLE;                        /*!< RSSI sample.                                                          */
+  __I  uint32_t  RESERVED7;
+  __I  uint32_t  STATE;                             /*!< Current radio state.                                                  */
+  __IO uint32_t  DATAWHITEIV;                       /*!< Data whitening initial value.                                         */
+  __I  uint32_t  RESERVED8[2];
+  __IO uint32_t  BCC;                               /*!< Bit counter compare.                                                  */
+  __I  uint32_t  RESERVED9[39];
+  __IO uint32_t  DAB[8];                            /*!< Device address base segment.                                          */
+  __IO uint32_t  DAP[8];                            /*!< Device address prefix.                                                */
+  __IO uint32_t  DACNF;                             /*!< Device address match configuration.                                   */
+  __I  uint32_t  RESERVED10[56];
+  __IO uint32_t  OVERRIDE0;                         /*!< Trim value override register 0.                                       */
+  __IO uint32_t  OVERRIDE1;                         /*!< Trim value override register 1.                                       */
+  __IO uint32_t  OVERRIDE2;                         /*!< Trim value override register 2.                                       */
+  __IO uint32_t  OVERRIDE3;                         /*!< Trim value override register 3.                                       */
+  __IO uint32_t  OVERRIDE4;                         /*!< Trim value override register 4.                                       */
+  __I  uint32_t  RESERVED11[561];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_RADIO_Type;
+
+
+/* ================================================================================ */
+/* ================                      UART                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Universal Asynchronous Receiver/Transmitter. (UART)
+  */
+
+typedef struct {                                    /*!< UART Structure                                                        */
+  __O  uint32_t  TASKS_STARTRX;                     /*!< Start UART receiver.                                                  */
+  __O  uint32_t  TASKS_STOPRX;                      /*!< Stop UART receiver.                                                   */
+  __O  uint32_t  TASKS_STARTTX;                     /*!< Start UART transmitter.                                               */
+  __O  uint32_t  TASKS_STOPTX;                      /*!< Stop UART transmitter.                                                */
+  __I  uint32_t  RESERVED0[3];
+  __O  uint32_t  TASKS_SUSPEND;                     /*!< Suspend UART.                                                         */
+  __I  uint32_t  RESERVED1[56];
+  __IO uint32_t  EVENTS_CTS;                        /*!< CTS activated.                                                        */
+  __IO uint32_t  EVENTS_NCTS;                       /*!< CTS deactivated.                                                      */
+  __IO uint32_t  EVENTS_RXDRDY;                     /*!< Data received in RXD.                                                 */
+  __I  uint32_t  RESERVED2[4];
+  __IO uint32_t  EVENTS_TXDRDY;                     /*!< Data sent from TXD.                                                   */
+  __I  uint32_t  RESERVED3;
+  __IO uint32_t  EVENTS_ERROR;                      /*!< Error detected.                                                       */
+  __I  uint32_t  RESERVED4[7];
+  __IO uint32_t  EVENTS_RXTO;                       /*!< Receiver timeout.                                                     */
+  __I  uint32_t  RESERVED5[46];
+  __IO uint32_t  SHORTS;                            /*!< Shortcuts for UART.                                                   */
+  __I  uint32_t  RESERVED6[64];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED7[93];
+  __IO uint32_t  ERRORSRC;                          /*!< Error source. Write error field to 1 to clear error.                  */
+  __I  uint32_t  RESERVED8[31];
+  __IO uint32_t  ENABLE;                            /*!< Enable UART and acquire IOs.                                          */
+  __I  uint32_t  RESERVED9;
+  __IO uint32_t  PSELRTS;                           /*!< Pin select for RTS.                                                   */
+  __IO uint32_t  PSELTXD;                           /*!< Pin select for TXD.                                                   */
+  __IO uint32_t  PSELCTS;                           /*!< Pin select for CTS.                                                   */
+  __IO uint32_t  PSELRXD;                           /*!< Pin select for RXD.                                                   */
+  __I  uint32_t  RXD;                               /*!< RXD register. On read action the buffer pointer is displaced.
+                                                         Once read the character is consumed. If read when no character
+                                                          available, the UART will stop working.                               */
+  __O  uint32_t  TXD;                               /*!< TXD register.                                                         */
+  __I  uint32_t  RESERVED10;
+  __IO uint32_t  BAUDRATE;                          /*!< UART Baudrate.                                                        */
+  __I  uint32_t  RESERVED11[17];
+  __IO uint32_t  CONFIG;                            /*!< Configuration of parity and hardware flow control register.           */
+  __I  uint32_t  RESERVED12[675];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_UART_Type;
+
+
+/* ================================================================================ */
+/* ================                       SPI                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief SPI master 0. (SPI)
+  */
+
+typedef struct {                                    /*!< SPI Structure                                                         */
+  __I  uint32_t  RESERVED0[66];
+  __IO uint32_t  EVENTS_READY;                      /*!< TXD byte sent and RXD byte received.                                  */
+  __I  uint32_t  RESERVED1[126];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED2[125];
+  __IO uint32_t  ENABLE;                            /*!< Enable SPI.                                                           */
+  __I  uint32_t  RESERVED3;
+  __IO uint32_t  PSELSCK;                           /*!< Pin select for SCK.                                                   */
+  __IO uint32_t  PSELMOSI;                          /*!< Pin select for MOSI.                                                  */
+  __IO uint32_t  PSELMISO;                          /*!< Pin select for MISO.                                                  */
+  __I  uint32_t  RESERVED4;
+  __I  uint32_t  RXD;                               /*!< RX data.                                                              */
+  __IO uint32_t  TXD;                               /*!< TX data.                                                              */
+  __I  uint32_t  RESERVED5;
+  __IO uint32_t  FREQUENCY;                         /*!< SPI frequency                                                         */
+  __I  uint32_t  RESERVED6[11];
+  __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
+  __I  uint32_t  RESERVED7[681];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_SPI_Type;
+
+
+/* ================================================================================ */
+/* ================                       TWI                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Two-wire interface master 0. (TWI)
+  */
+
+typedef struct {                                    /*!< TWI Structure                                                         */
+  __O  uint32_t  TASKS_STARTRX;                     /*!< Start 2-Wire master receive sequence.                                 */
+  __I  uint32_t  RESERVED0;
+  __O  uint32_t  TASKS_STARTTX;                     /*!< Start 2-Wire master transmit sequence.                                */
+  __I  uint32_t  RESERVED1[2];
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop 2-Wire transaction.                                              */
+  __I  uint32_t  RESERVED2;
+  __O  uint32_t  TASKS_SUSPEND;                     /*!< Suspend 2-Wire transaction.                                           */
+  __O  uint32_t  TASKS_RESUME;                      /*!< Resume 2-Wire transaction.                                            */
+  __I  uint32_t  RESERVED3[56];
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< Two-wire stopped.                                                     */
+  __IO uint32_t  EVENTS_RXDREADY;                   /*!< Two-wire ready to deliver new RXD byte received.                      */
+  __I  uint32_t  RESERVED4[4];
+  __IO uint32_t  EVENTS_TXDSENT;                    /*!< Two-wire finished sending last TXD byte.                              */
+  __I  uint32_t  RESERVED5;
+  __IO uint32_t  EVENTS_ERROR;                      /*!< Two-wire error detected.                                              */
+  __I  uint32_t  RESERVED6[4];
+  __IO uint32_t  EVENTS_BB;                         /*!< Two-wire byte boundary.                                               */
+  __I  uint32_t  RESERVED7[3];
+  __IO uint32_t  EVENTS_SUSPENDED;                  /*!< Two-wire suspended.                                                   */
+  __I  uint32_t  RESERVED8[45];
+  __IO uint32_t  SHORTS;                            /*!< Shortcuts for TWI.                                                    */
+  __I  uint32_t  RESERVED9[64];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED10[110];
+  __IO uint32_t  ERRORSRC;                          /*!< Two-wire error source. Write error field to 1 to clear error.         */
+  __I  uint32_t  RESERVED11[14];
+  __IO uint32_t  ENABLE;                            /*!< Enable two-wire master.                                               */
+  __I  uint32_t  RESERVED12;
+  __IO uint32_t  PSELSCL;                           /*!< Pin select for SCL.                                                   */
+  __IO uint32_t  PSELSDA;                           /*!< Pin select for SDA.                                                   */
+  __I  uint32_t  RESERVED13[2];
+  __I  uint32_t  RXD;                               /*!< RX data register.                                                     */
+  __IO uint32_t  TXD;                               /*!< TX data register.                                                     */
+  __I  uint32_t  RESERVED14;
+  __IO uint32_t  FREQUENCY;                         /*!< Two-wire frequency.                                                   */
+  __I  uint32_t  RESERVED15[24];
+  __IO uint32_t  ADDRESS;                           /*!< Address used in the two-wire transfer.                                */
+  __I  uint32_t  RESERVED16[668];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_TWI_Type;
+
+
+/* ================================================================================ */
+/* ================                      SPIS                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief SPI slave 1. (SPIS)
+  */
+
+typedef struct {                                    /*!< SPIS Structure                                                        */
+  __I  uint32_t  RESERVED0[9];
+  __O  uint32_t  TASKS_ACQUIRE;                     /*!< Acquire SPI semaphore.                                                */
+  __O  uint32_t  TASKS_RELEASE;                     /*!< Release SPI semaphore.                                                */
+  __I  uint32_t  RESERVED1[54];
+  __IO uint32_t  EVENTS_END;                        /*!< Granted transaction completed.                                        */
+  __I  uint32_t  RESERVED2[2];
+  __IO uint32_t  EVENTS_ENDRX;                      /*!< End of RXD buffer reached                                             */
+  __I  uint32_t  RESERVED3[5];
+  __IO uint32_t  EVENTS_ACQUIRED;                   /*!< Semaphore acquired.                                                   */
+  __I  uint32_t  RESERVED4[53];
+  __IO uint32_t  SHORTS;                            /*!< Shortcuts for SPIS.                                                   */
+  __I  uint32_t  RESERVED5[64];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED6[61];
+  __I  uint32_t  SEMSTAT;                           /*!< Semaphore status.                                                     */
+  __I  uint32_t  RESERVED7[15];
+  __IO uint32_t  STATUS;                            /*!< Status from last transaction.                                         */
+  __I  uint32_t  RESERVED8[47];
+  __IO uint32_t  ENABLE;                            /*!< Enable SPIS.                                                          */
+  __I  uint32_t  RESERVED9;
+  __IO uint32_t  PSELSCK;                           /*!< Pin select for SCK.                                                   */
+  __IO uint32_t  PSELMISO;                          /*!< Pin select for MISO.                                                  */
+  __IO uint32_t  PSELMOSI;                          /*!< Pin select for MOSI.                                                  */
+  __IO uint32_t  PSELCSN;                           /*!< Pin select for CSN.                                                   */
+  __I  uint32_t  RESERVED10[7];
+  __IO uint32_t  RXDPTR;                            /*!< RX data pointer.                                                      */
+  __IO uint32_t  MAXRX;                             /*!< Maximum number of bytes in the receive buffer.                        */
+  __I  uint32_t  AMOUNTRX;                          /*!< Number of bytes received in last granted transaction.                 */
+  __I  uint32_t  RESERVED11;
+  __IO uint32_t  TXDPTR;                            /*!< TX data pointer.                                                      */
+  __IO uint32_t  MAXTX;                             /*!< Maximum number of bytes in the transmit buffer.                       */
+  __I  uint32_t  AMOUNTTX;                          /*!< Number of bytes transmitted in last granted transaction.              */
+  __I  uint32_t  RESERVED12;
+  __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
+  __I  uint32_t  RESERVED13;
+  __IO uint32_t  DEF;                               /*!< Default character.                                                    */
+  __I  uint32_t  RESERVED14[24];
+  __IO uint32_t  ORC;                               /*!< Over-read character.                                                  */
+  __I  uint32_t  RESERVED15[654];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_SPIS_Type;
+
+
+/* ================================================================================ */
+/* ================                      SPIM                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief SPI master with easyDMA 1. (SPIM)
+  */
+
+typedef struct {                                    /*!< SPIM Structure                                                        */
+  __I  uint32_t  RESERVED0[4];
+  __O  uint32_t  TASKS_START;                       /*!< Start SPI transaction.                                                */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop SPI transaction.                                                 */
+  __I  uint32_t  RESERVED1;
+  __O  uint32_t  TASKS_SUSPEND;                     /*!< Suspend SPI transaction.                                              */
+  __O  uint32_t  TASKS_RESUME;                      /*!< Resume SPI transaction.                                               */
+  __I  uint32_t  RESERVED2[56];
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< SPI transaction has stopped.                                          */
+  __I  uint32_t  RESERVED3[2];
+  __IO uint32_t  EVENTS_ENDRX;                      /*!< End of RXD buffer reached.                                            */
+  __I  uint32_t  RESERVED4[3];
+  __IO uint32_t  EVENTS_ENDTX;                      /*!< End of TXD buffer reached.                                            */
+  __I  uint32_t  RESERVED5[10];
+  __IO uint32_t  EVENTS_STARTED;                    /*!< Transaction started.                                                  */
+  __I  uint32_t  RESERVED6[109];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED7[125];
+  __IO uint32_t  ENABLE;                            /*!< Enable SPIM.                                                          */
+  __I  uint32_t  RESERVED8;
+  SPIM_PSEL_Type PSEL;                              /*!< Pin select configuration.                                             */
+  __I  uint32_t  RESERVED9[4];
+  __IO uint32_t  FREQUENCY;                         /*!< SPI frequency.                                                        */
+  __I  uint32_t  RESERVED10[3];
+  SPIM_RXD_Type RXD;                                /*!< RXD EasyDMA configuration and status.                                 */
+  __I  uint32_t  RESERVED11;
+  SPIM_TXD_Type TXD;                                /*!< TXD EasyDMA configuration and status.                                 */
+  __I  uint32_t  RESERVED12;
+  __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
+  __I  uint32_t  RESERVED13[26];
+  __IO uint32_t  ORC;                               /*!< Over-read character.                                                  */
+  __I  uint32_t  RESERVED14[654];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_SPIM_Type;
+
+
+/* ================================================================================ */
+/* ================                     GPIOTE                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief GPIO tasks and events. (GPIOTE)
+  */
+
+typedef struct {                                    /*!< GPIOTE Structure                                                      */
+  __O  uint32_t  TASKS_OUT[4];                      /*!< Tasks asssociated with GPIOTE channels.                               */
+  __I  uint32_t  RESERVED0[60];
+  __IO uint32_t  EVENTS_IN[4];                      /*!< Tasks asssociated with GPIOTE channels.                               */
+  __I  uint32_t  RESERVED1[27];
+  __IO uint32_t  EVENTS_PORT;                       /*!< Event generated from multiple pins.                                   */
+  __I  uint32_t  RESERVED2[97];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED3[129];
+  __IO uint32_t  CONFIG[4];                         /*!< Channel configuration registers.                                      */
+  __I  uint32_t  RESERVED4[695];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_GPIOTE_Type;
+
+
+/* ================================================================================ */
+/* ================                       ADC                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Analog to digital converter. (ADC)
+  */
+
+typedef struct {                                    /*!< ADC Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Start an ADC conversion.                                              */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop ADC.                                                             */
+  __I  uint32_t  RESERVED0[62];
+  __IO uint32_t  EVENTS_END;                        /*!< ADC conversion complete.                                              */
+  __I  uint32_t  RESERVED1[128];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED2[61];
+  __I  uint32_t  BUSY;                              /*!< ADC busy register.                                                    */
+  __I  uint32_t  RESERVED3[63];
+  __IO uint32_t  ENABLE;                            /*!< ADC enable.                                                           */
+  __IO uint32_t  CONFIG;                            /*!< ADC configuration register.                                           */
+  __I  uint32_t  RESULT;                            /*!< Result of ADC conversion.                                             */
+  __I  uint32_t  RESERVED4[700];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_ADC_Type;
+
+
+/* ================================================================================ */
+/* ================                      TIMER                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Timer 0. (TIMER)
+  */
+
+typedef struct {                                    /*!< TIMER Structure                                                       */
+  __O  uint32_t  TASKS_START;                       /*!< Start Timer.                                                          */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop Timer.                                                           */
+  __O  uint32_t  TASKS_COUNT;                       /*!< Increment Timer (In counter mode).                                    */
+  __O  uint32_t  TASKS_CLEAR;                       /*!< Clear timer.                                                          */
+  __O  uint32_t  TASKS_SHUTDOWN;                    /*!< Shutdown timer.                                                       */
+  __I  uint32_t  RESERVED0[11];
+  __O  uint32_t  TASKS_CAPTURE[4];                  /*!< Capture Timer value to CC[n] registers.                               */
+  __I  uint32_t  RESERVED1[60];
+  __IO uint32_t  EVENTS_COMPARE[4];                 /*!< Compare event on CC[n] match.                                         */
+  __I  uint32_t  RESERVED2[44];
+  __IO uint32_t  SHORTS;                            /*!< Shortcuts for Timer.                                                  */
+  __I  uint32_t  RESERVED3[64];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED4[126];
+  __IO uint32_t  MODE;                              /*!< Timer Mode selection.                                                 */
+  __IO uint32_t  BITMODE;                           /*!< Sets timer behaviour.                                                 */
+  __I  uint32_t  RESERVED5;
+  __IO uint32_t  PRESCALER;                         /*!< 4-bit prescaler to source clock frequency (max value 9). Source
+                                                         clock frequency is divided by 2^SCALE.                                */
+  __I  uint32_t  RESERVED6[11];
+  __IO uint32_t  CC[4];                             /*!< Capture/compare registers.                                            */
+  __I  uint32_t  RESERVED7[683];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_TIMER_Type;
+
+
+/* ================================================================================ */
+/* ================                       RTC                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Real time counter 0. (RTC)
+  */
+
+typedef struct {                                    /*!< RTC Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Start RTC Counter.                                                    */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop RTC Counter.                                                     */
+  __O  uint32_t  TASKS_CLEAR;                       /*!< Clear RTC Counter.                                                    */
+  __O  uint32_t  TASKS_TRIGOVRFLW;                  /*!< Set COUNTER to 0xFFFFFFF0.                                            */
+  __I  uint32_t  RESERVED0[60];
+  __IO uint32_t  EVENTS_TICK;                       /*!< Event on COUNTER increment.                                           */
+  __IO uint32_t  EVENTS_OVRFLW;                     /*!< Event on COUNTER overflow.                                            */
+  __I  uint32_t  RESERVED1[14];
+  __IO uint32_t  EVENTS_COMPARE[4];                 /*!< Compare event on CC[n] match.                                         */
+  __I  uint32_t  RESERVED2[109];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED3[13];
+  __IO uint32_t  EVTEN;                             /*!< Configures event enable routing to PPI for each RTC event.            */
+  __IO uint32_t  EVTENSET;                          /*!< Enable events routing to PPI. The reading of this register gives
+                                                         the value of EVTEN.                                                   */
+  __IO uint32_t  EVTENCLR;                          /*!< Disable events routing to PPI. The reading of this register
+                                                         gives the value of EVTEN.                                             */
+  __I  uint32_t  RESERVED4[110];
+  __I  uint32_t  COUNTER;                           /*!< Current COUNTER value.                                                */
+  __IO uint32_t  PRESCALER;                         /*!< 12-bit prescaler for COUNTER frequency (32768/(PRESCALER+1)).
+                                                         Must be written when RTC is STOPed.                                   */
+  __I  uint32_t  RESERVED5[13];
+  __IO uint32_t  CC[4];                             /*!< Capture/compare registers.                                            */
+  __I  uint32_t  RESERVED6[683];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_RTC_Type;
+
+
+/* ================================================================================ */
+/* ================                      TEMP                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Temperature Sensor. (TEMP)
+  */
+
+typedef struct {                                    /*!< TEMP Structure                                                        */
+  __O  uint32_t  TASKS_START;                       /*!< Start temperature measurement.                                        */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop temperature measurement.                                         */
+  __I  uint32_t  RESERVED0[62];
+  __IO uint32_t  EVENTS_DATARDY;                    /*!< Temperature measurement complete, data ready event.                   */
+  __I  uint32_t  RESERVED1[128];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED2[127];
+  __I  int32_t   TEMP;                              /*!< Die temperature in degC, 2's complement format, 0.25 degC pecision.   */
+  __I  uint32_t  RESERVED3[700];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_TEMP_Type;
+
+
+/* ================================================================================ */
+/* ================                       RNG                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Random Number Generator. (RNG)
+  */
+
+typedef struct {                                    /*!< RNG Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Start the random number generator.                                    */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop the random number generator.                                     */
+  __I  uint32_t  RESERVED0[62];
+  __IO uint32_t  EVENTS_VALRDY;                     /*!< New random number generated and written to VALUE register.            */
+  __I  uint32_t  RESERVED1[63];
+  __IO uint32_t  SHORTS;                            /*!< Shortcuts for the RNG.                                                */
+  __I  uint32_t  RESERVED2[64];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register                                         */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register                                       */
+  __I  uint32_t  RESERVED3[126];
+  __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
+  __I  uint32_t  VALUE;                             /*!< RNG random number.                                                    */
+  __I  uint32_t  RESERVED4[700];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_RNG_Type;
+
+
+/* ================================================================================ */
+/* ================                       ECB                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief AES ECB Mode Encryption. (ECB)
+  */
+
+typedef struct {                                    /*!< ECB Structure                                                         */
+  __O  uint32_t  TASKS_STARTECB;                    /*!< Start ECB block encrypt. If a crypto operation is running, this
+                                                         will not initiate a new encryption and the ERRORECB event will
+                                                          be triggered.                                                        */
+  __O  uint32_t  TASKS_STOPECB;                     /*!< Stop current ECB encryption. If a crypto operation is running,
+                                                         this will will trigger the ERRORECB event.                            */
+  __I  uint32_t  RESERVED0[62];
+  __IO uint32_t  EVENTS_ENDECB;                     /*!< ECB block encrypt complete.                                           */
+  __IO uint32_t  EVENTS_ERRORECB;                   /*!< ECB block encrypt aborted due to a STOPECB task or due to an
+                                                         error.                                                                */
+  __I  uint32_t  RESERVED1[127];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED2[126];
+  __IO uint32_t  ECBDATAPTR;                        /*!< ECB block encrypt memory pointer.                                     */
+  __I  uint32_t  RESERVED3[701];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_ECB_Type;
+
+
+/* ================================================================================ */
+/* ================                       AAR                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Accelerated Address Resolver. (AAR)
+  */
+
+typedef struct {                                    /*!< AAR Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Start resolving addresses based on IRKs specified in the IRK
+                                                         data structure.                                                       */
+  __I  uint32_t  RESERVED0;
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop resolving addresses.                                             */
+  __I  uint32_t  RESERVED1[61];
+  __IO uint32_t  EVENTS_END;                        /*!< Address resolution procedure completed.                               */
+  __IO uint32_t  EVENTS_RESOLVED;                   /*!< Address resolved.                                                     */
+  __IO uint32_t  EVENTS_NOTRESOLVED;                /*!< Address not resolved.                                                 */
+  __I  uint32_t  RESERVED2[126];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED3[61];
+  __I  uint32_t  STATUS;                            /*!< Resolution status.                                                    */
+  __I  uint32_t  RESERVED4[63];
+  __IO uint32_t  ENABLE;                            /*!< Enable AAR.                                                           */
+  __IO uint32_t  NIRK;                              /*!< Number of Identity root Keys in the IRK data structure.               */
+  __IO uint32_t  IRKPTR;                            /*!< Pointer to the IRK data structure.                                    */
+  __I  uint32_t  RESERVED5;
+  __IO uint32_t  ADDRPTR;                           /*!< Pointer to the resolvable address (6 bytes).                          */
+  __IO uint32_t  SCRATCHPTR;                        /*!< Pointer to a "scratch" data area used for temporary storage
+                                                         during resolution. A minimum of 3 bytes must be reserved.             */
+  __I  uint32_t  RESERVED6[697];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_AAR_Type;
+
+
+/* ================================================================================ */
+/* ================                       CCM                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief AES CCM Mode Encryption. (CCM)
+  */
+
+typedef struct {                                    /*!< CCM Structure                                                         */
+  __O  uint32_t  TASKS_KSGEN;                       /*!< Start generation of key-stream. This operation will stop by
+                                                         itself when completed.                                                */
+  __O  uint32_t  TASKS_CRYPT;                       /*!< Start encrypt/decrypt. This operation will stop by itself when
+                                                         completed.                                                            */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop encrypt/decrypt.                                                 */
+  __I  uint32_t  RESERVED0[61];
+  __IO uint32_t  EVENTS_ENDKSGEN;                   /*!< Keystream generation completed.                                       */
+  __IO uint32_t  EVENTS_ENDCRYPT;                   /*!< Encrypt/decrypt completed.                                            */
+  __IO uint32_t  EVENTS_ERROR;                      /*!< Error happened.                                                       */
+  __I  uint32_t  RESERVED1[61];
+  __IO uint32_t  SHORTS;                            /*!< Shortcuts for the CCM.                                                */
+  __I  uint32_t  RESERVED2[64];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED3[61];
+  __I  uint32_t  MICSTATUS;                         /*!< CCM RX MIC check result.                                              */
+  __I  uint32_t  RESERVED4[63];
+  __IO uint32_t  ENABLE;                            /*!< CCM enable.                                                           */
+  __IO uint32_t  MODE;                              /*!< Operation mode.                                                       */
+  __IO uint32_t  CNFPTR;                            /*!< Pointer to a data structure holding AES key and NONCE vector.         */
+  __IO uint32_t  INPTR;                             /*!< Pointer to the input packet.                                          */
+  __IO uint32_t  OUTPTR;                            /*!< Pointer to the output packet.                                         */
+  __IO uint32_t  SCRATCHPTR;                        /*!< Pointer to a "scratch" data area used for temporary storage
+                                                         during resolution. A minimum of 43 bytes must be reserved.            */
+  __I  uint32_t  RESERVED5[697];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_CCM_Type;
+
+
+/* ================================================================================ */
+/* ================                       WDT                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Watchdog Timer. (WDT)
+  */
+
+typedef struct {                                    /*!< WDT Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Start the watchdog.                                                   */
+  __I  uint32_t  RESERVED0[63];
+  __IO uint32_t  EVENTS_TIMEOUT;                    /*!< Watchdog timeout.                                                     */
+  __I  uint32_t  RESERVED1[128];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED2[61];
+  __I  uint32_t  RUNSTATUS;                         /*!< Watchdog running status.                                              */
+  __I  uint32_t  REQSTATUS;                         /*!< Request status.                                                       */
+  __I  uint32_t  RESERVED3[63];
+  __IO uint32_t  CRV;                               /*!< Counter reload value in number of 32kiHz clock cycles.                */
+  __IO uint32_t  RREN;                              /*!< Reload request enable.                                                */
+  __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
+  __I  uint32_t  RESERVED4[60];
+  __O  uint32_t  RR[8];                             /*!< Reload requests registers.                                            */
+  __I  uint32_t  RESERVED5[631];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_WDT_Type;
+
+
+/* ================================================================================ */
+/* ================                      QDEC                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Rotary decoder. (QDEC)
+  */
+
+typedef struct {                                    /*!< QDEC Structure                                                        */
+  __O  uint32_t  TASKS_START;                       /*!< Start the quadrature decoder.                                         */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop the quadrature decoder.                                          */
+  __O  uint32_t  TASKS_READCLRACC;                  /*!< Transfers the content from ACC registers to ACCREAD registers,
+                                                         and clears the ACC registers.                                         */
+  __I  uint32_t  RESERVED0[61];
+  __IO uint32_t  EVENTS_SAMPLERDY;                  /*!< A new sample is written to the sample register.                       */
+  __IO uint32_t  EVENTS_REPORTRDY;                  /*!< REPORTPER number of samples accumulated in ACC register, and
+                                                         ACC register different than zero.                                     */
+  __IO uint32_t  EVENTS_ACCOF;                      /*!< ACC or ACCDBL register overflow.                                      */
+  __I  uint32_t  RESERVED1[61];
+  __IO uint32_t  SHORTS;                            /*!< Shortcuts for the QDEC.                                               */
+  __I  uint32_t  RESERVED2[64];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED3[125];
+  __IO uint32_t  ENABLE;                            /*!< Enable the QDEC.                                                      */
+  __IO uint32_t  LEDPOL;                            /*!< LED output pin polarity.                                              */
+  __IO uint32_t  SAMPLEPER;                         /*!< Sample period.                                                        */
+  __I  int32_t   SAMPLE;                            /*!< Motion sample value.                                                  */
+  __IO uint32_t  REPORTPER;                         /*!< Number of samples to generate an EVENT_REPORTRDY.                     */
+  __I  int32_t   ACC;                               /*!< Accumulated valid transitions register.                               */
+  __I  int32_t   ACCREAD;                           /*!< Snapshot of ACC register. Value generated by the TASKS_READCLEACC
+                                                         task.                                                                 */
+  __IO uint32_t  PSELLED;                           /*!< Pin select for LED output.                                            */
+  __IO uint32_t  PSELA;                             /*!< Pin select for phase A input.                                         */
+  __IO uint32_t  PSELB;                             /*!< Pin select for phase B input.                                         */
+  __IO uint32_t  DBFEN;                             /*!< Enable debouncer input filters.                                       */
+  __I  uint32_t  RESERVED4[5];
+  __IO uint32_t  LEDPRE;                            /*!< Time LED is switched ON before the sample.                            */
+  __I  uint32_t  ACCDBL;                            /*!< Accumulated double (error) transitions register.                      */
+  __I  uint32_t  ACCDBLREAD;                        /*!< Snapshot of ACCDBL register. Value generated by the TASKS_READCLEACC
+                                                         task.                                                                 */
+  __I  uint32_t  RESERVED5[684];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_QDEC_Type;
+
+
+/* ================================================================================ */
+/* ================                     LPCOMP                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Low power comparator. (LPCOMP)
+  */
+
+typedef struct {                                    /*!< LPCOMP Structure                                                      */
+  __O  uint32_t  TASKS_START;                       /*!< Start the comparator.                                                 */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop the comparator.                                                  */
+  __O  uint32_t  TASKS_SAMPLE;                      /*!< Sample comparator value.                                              */
+  __I  uint32_t  RESERVED0[61];
+  __IO uint32_t  EVENTS_READY;                      /*!< LPCOMP is ready and output is valid.                                  */
+  __IO uint32_t  EVENTS_DOWN;                       /*!< Input voltage crossed the threshold going down.                       */
+  __IO uint32_t  EVENTS_UP;                         /*!< Input voltage crossed the threshold going up.                         */
+  __IO uint32_t  EVENTS_CROSS;                      /*!< Input voltage crossed the threshold in any direction.                 */
+  __I  uint32_t  RESERVED1[60];
+  __IO uint32_t  SHORTS;                            /*!< Shortcuts for the LPCOMP.                                             */
+  __I  uint32_t  RESERVED2[64];
+  __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
+  __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
+  __I  uint32_t  RESERVED3[61];
+  __I  uint32_t  RESULT;                            /*!< Result of last compare.                                               */
+  __I  uint32_t  RESERVED4[63];
+  __IO uint32_t  ENABLE;                            /*!< Enable the LPCOMP.                                                    */
+  __IO uint32_t  PSEL;                              /*!< Input pin select.                                                     */
+  __IO uint32_t  REFSEL;                            /*!< Reference select.                                                     */
+  __IO uint32_t  EXTREFSEL;                         /*!< External reference select.                                            */
+  __I  uint32_t  RESERVED5[4];
+  __IO uint32_t  ANADETECT;                         /*!< Analog detect configuration.                                          */
+  __I  uint32_t  RESERVED6[694];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
+} NRF_LPCOMP_Type;
+
+
+/* ================================================================================ */
+/* ================                       SWI                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief SW Interrupts. (SWI)
+  */
+
+typedef struct {                                    /*!< SWI Structure                                                         */
+  __I  uint32_t  UNUSED;                            /*!< Unused.                                                               */
+} NRF_SWI_Type;
+
+
+/* ================================================================================ */
+/* ================                      NVMC                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Non Volatile Memory Controller. (NVMC)
+  */
+
+typedef struct {                                    /*!< NVMC Structure                                                        */
+  __I  uint32_t  RESERVED0[256];
+  __I  uint32_t  READY;                             /*!< Ready flag.                                                           */
+  __I  uint32_t  RESERVED1[64];
+  __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
+  
+  union {
+    __IO uint32_t  ERASEPCR1;                       /*!< Register for erasing a non-protected non-volatile memory page.        */
+    __IO uint32_t  ERASEPAGE;                       /*!< Register for erasing a non-protected non-volatile memory page.        */
+  };
+  __IO uint32_t  ERASEALL;                          /*!< Register for erasing all non-volatile user memory.                    */
+  __IO uint32_t  ERASEPCR0;                         /*!< Register for erasing a protected non-volatile memory page.            */
+  __IO uint32_t  ERASEUICR;                         /*!< Register for start erasing User Information Congfiguration Registers. */
+} NRF_NVMC_Type;
+
+
+/* ================================================================================ */
+/* ================                       PPI                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief PPI controller. (PPI)
+  */
+
+typedef struct {                                    /*!< PPI Structure                                                         */
+  PPI_TASKS_CHG_Type TASKS_CHG[4];                  /*!< Channel group tasks.                                                  */
+  __I  uint32_t  RESERVED0[312];
+  __IO uint32_t  CHEN;                              /*!< Channel enable.                                                       */
+  __IO uint32_t  CHENSET;                           /*!< Channel enable set.                                                   */
+  __IO uint32_t  CHENCLR;                           /*!< Channel enable clear.                                                 */
+  __I  uint32_t  RESERVED1;
+  PPI_CH_Type CH[16];                               /*!< PPI Channel.                                                          */
+  __I  uint32_t  RESERVED2[156];
+  __IO uint32_t  CHG[4];                            /*!< Channel group configuration.                                          */
+} NRF_PPI_Type;
+
+
+/* ================================================================================ */
+/* ================                      FICR                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Factory Information Configuration. (FICR)
+  */
+
+typedef struct {                                    /*!< FICR Structure                                                        */
+  __I  uint32_t  RESERVED0[4];
+  __I  uint32_t  CODEPAGESIZE;                      /*!< Code memory page size in bytes.                                       */
+  __I  uint32_t  CODESIZE;                          /*!< Code memory size in pages.                                            */
+  __I  uint32_t  RESERVED1[4];
+  __I  uint32_t  CLENR0;                            /*!< Length of code region 0 in bytes.                                     */
+  __I  uint32_t  PPFC;                              /*!< Pre-programmed factory code present.                                  */
+  __I  uint32_t  RESERVED2;
+  __I  uint32_t  NUMRAMBLOCK;                       /*!< Number of individualy controllable RAM blocks.                        */
+  
+  union {
+    __I  uint32_t  SIZERAMBLOCK[4];                 /*!< Deprecated array of size of RAM block in bytes. This name is
+                                                         kept for backward compatinility purposes. Use SIZERAMBLOCKS
+                                                          instead.                                                             */
+    __I  uint32_t  SIZERAMBLOCKS;                   /*!< Size of RAM blocks in bytes.                                          */
+  };
+  __I  uint32_t  RESERVED3[5];
+  __I  uint32_t  CONFIGID;                          /*!< Configuration identifier.                                             */
+  __I  uint32_t  DEVICEID[2];                       /*!< Device identifier.                                                    */
+  __I  uint32_t  RESERVED4[6];
+  __I  uint32_t  ER[4];                             /*!< Encryption root.                                                      */
+  __I  uint32_t  IR[4];                             /*!< Identity root.                                                        */
+  __I  uint32_t  DEVICEADDRTYPE;                    /*!< Device address type.                                                  */
+  __I  uint32_t  DEVICEADDR[2];                     /*!< Device address.                                                       */
+  __I  uint32_t  OVERRIDEEN;                        /*!< Radio calibration override enable.                                    */
+  __I  uint32_t  NRF_1MBIT[5];                      /*!< Override values for the OVERRIDEn registers in RADIO for NRF_1Mbit
+                                                         mode.                                                                 */
+  __I  uint32_t  RESERVED5[10];
+  __I  uint32_t  BLE_1MBIT[5];                      /*!< Override values for the OVERRIDEn registers in RADIO for BLE_1Mbit
+                                                         mode.                                                                 */
+} NRF_FICR_Type;
+
+
+/* ================================================================================ */
+/* ================                      UICR                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief User Information Configuration. (UICR)
+  */
+
+typedef struct {                                    /*!< UICR Structure                                                        */
+  __IO uint32_t  CLENR0;                            /*!< Length of code region 0.                                              */
+  __IO uint32_t  RBPCONF;                           /*!< Readback protection configuration.                                    */
+  __IO uint32_t  XTALFREQ;                          /*!< Reset value for CLOCK XTALFREQ register.                              */
+  __I  uint32_t  RESERVED0;
+  __I  uint32_t  FWID;                              /*!< Firmware ID.                                                          */
+  
+  union {
+    __IO uint32_t  NRFFW[15];                       /*!< Reserved for Nordic firmware design.                                  */
+    __IO uint32_t  BOOTLOADERADDR;                  /*!< Bootloader start address.                                             */
+  };
+  __IO uint32_t  NRFHW[12];                         /*!< Reserved for Nordic hardware design.                                  */
+  __IO uint32_t  CUSTOMER[32];                      /*!< Reserved for customer.                                                */
+} NRF_UICR_Type;
+
+
+/* ================================================================================ */
+/* ================                      GPIO                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief General purpose input and output. (GPIO)
+  */
+
+typedef struct {                                    /*!< GPIO Structure                                                        */
+  __I  uint32_t  RESERVED0[321];
+  __IO uint32_t  OUT;                               /*!< Write GPIO port.                                                      */
+  __IO uint32_t  OUTSET;                            /*!< Set individual bits in GPIO port.                                     */
+  __IO uint32_t  OUTCLR;                            /*!< Clear individual bits in GPIO port.                                   */
+  __I  uint32_t  IN;                                /*!< Read GPIO port.                                                       */
+  __IO uint32_t  DIR;                               /*!< Direction of GPIO pins.                                               */
+  __IO uint32_t  DIRSET;                            /*!< DIR set register.                                                     */
+  __IO uint32_t  DIRCLR;                            /*!< DIR clear register.                                                   */
+  __I  uint32_t  RESERVED1[120];
+  __IO uint32_t  PIN_CNF[32];                       /*!< Configuration of GPIO pins.                                           */
+} NRF_GPIO_Type;
+
+
+/* --------------------  End of section using anonymous unions  ------------------- */
+#if defined(__CC_ARM)
+  #pragma pop
+#elif defined(__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif defined(__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined(__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined(__TASKING__)
+  #pragma warning restore
+#else
+  #warning Not supported compiler type
+#endif
+
+
+
+
+/* ================================================================================ */
+/* ================              Peripheral memory map             ================ */
+/* ================================================================================ */
+
+#define NRF_POWER_BASE                  0x40000000UL
+#define NRF_CLOCK_BASE                  0x40000000UL
+#define NRF_MPU_BASE                    0x40000000UL
+#define NRF_AMLI_BASE                   0x40000000UL
+#define NRF_RADIO_BASE                  0x40001000UL
+#define NRF_UART0_BASE                  0x40002000UL
+#define NRF_SPI0_BASE                   0x40003000UL
+#define NRF_TWI0_BASE                   0x40003000UL
+#define NRF_SPI1_BASE                   0x40004000UL
+#define NRF_TWI1_BASE                   0x40004000UL
+#define NRF_SPIS1_BASE                  0x40004000UL
+#define NRF_SPIM1_BASE                  0x40004000UL
+#define NRF_GPIOTE_BASE                 0x40006000UL
+#define NRF_ADC_BASE                    0x40007000UL
+#define NRF_TIMER0_BASE                 0x40008000UL
+#define NRF_TIMER1_BASE                 0x40009000UL
+#define NRF_TIMER2_BASE                 0x4000A000UL
+#define NRF_RTC0_BASE                   0x4000B000UL
+#define NRF_TEMP_BASE                   0x4000C000UL
+#define NRF_RNG_BASE                    0x4000D000UL
+#define NRF_ECB_BASE                    0x4000E000UL
+#define NRF_AAR_BASE                    0x4000F000UL
+#define NRF_CCM_BASE                    0x4000F000UL
+#define NRF_WDT_BASE                    0x40010000UL
+#define NRF_RTC1_BASE                   0x40011000UL
+#define NRF_QDEC_BASE                   0x40012000UL
+#define NRF_LPCOMP_BASE                 0x40013000UL
+#define NRF_SWI_BASE                    0x40014000UL
+#define NRF_NVMC_BASE                   0x4001E000UL
+#define NRF_PPI_BASE                    0x4001F000UL
+#define NRF_FICR_BASE                   0x10000000UL
+#define NRF_UICR_BASE                   0x10001000UL
+#define NRF_GPIO_BASE                   0x50000000UL
+
+
+/* ================================================================================ */
+/* ================             Peripheral declaration             ================ */
+/* ================================================================================ */
+
+#define NRF_POWER                       ((NRF_POWER_Type          *) NRF_POWER_BASE)
+#define NRF_CLOCK                       ((NRF_CLOCK_Type          *) NRF_CLOCK_BASE)
+#define NRF_MPU                         ((NRF_MPU_Type            *) NRF_MPU_BASE)
+#define NRF_AMLI                        ((NRF_AMLI_Type           *) NRF_AMLI_BASE)
+#define NRF_RADIO                       ((NRF_RADIO_Type          *) NRF_RADIO_BASE)
+#define NRF_UART0                       ((NRF_UART_Type           *) NRF_UART0_BASE)
+#define NRF_SPI0                        ((NRF_SPI_Type            *) NRF_SPI0_BASE)
+#define NRF_TWI0                        ((NRF_TWI_Type            *) NRF_TWI0_BASE)
+#define NRF_SPI1                        ((NRF_SPI_Type            *) NRF_SPI1_BASE)
+#define NRF_TWI1                        ((NRF_TWI_Type            *) NRF_TWI1_BASE)
+#define NRF_SPIS1                       ((NRF_SPIS_Type           *) NRF_SPIS1_BASE)
+#define NRF_SPIM1                       ((NRF_SPIM_Type           *) NRF_SPIM1_BASE)
+#define NRF_GPIOTE                      ((NRF_GPIOTE_Type         *) NRF_GPIOTE_BASE)
+#define NRF_ADC                         ((NRF_ADC_Type            *) NRF_ADC_BASE)
+#define NRF_TIMER0                      ((NRF_TIMER_Type          *) NRF_TIMER0_BASE)
+#define NRF_TIMER1                      ((NRF_TIMER_Type          *) NRF_TIMER1_BASE)
+#define NRF_TIMER2                      ((NRF_TIMER_Type          *) NRF_TIMER2_BASE)
+#define NRF_RTC0                        ((NRF_RTC_Type            *) NRF_RTC0_BASE)
+#define NRF_TEMP                        ((NRF_TEMP_Type           *) NRF_TEMP_BASE)
+#define NRF_RNG                         ((NRF_RNG_Type            *) NRF_RNG_BASE)
+#define NRF_ECB                         ((NRF_ECB_Type            *) NRF_ECB_BASE)
+#define NRF_AAR                         ((NRF_AAR_Type            *) NRF_AAR_BASE)
+#define NRF_CCM                         ((NRF_CCM_Type            *) NRF_CCM_BASE)
+#define NRF_WDT                         ((NRF_WDT_Type            *) NRF_WDT_BASE)
+#define NRF_RTC1                        ((NRF_RTC_Type            *) NRF_RTC1_BASE)
+#define NRF_QDEC                        ((NRF_QDEC_Type           *) NRF_QDEC_BASE)
+#define NRF_LPCOMP                      ((NRF_LPCOMP_Type         *) NRF_LPCOMP_BASE)
+#define NRF_SWI                         ((NRF_SWI_Type            *) NRF_SWI_BASE)
+#define NRF_NVMC                        ((NRF_NVMC_Type           *) NRF_NVMC_BASE)
+#define NRF_PPI                         ((NRF_PPI_Type            *) NRF_PPI_BASE)
+#define NRF_FICR                        ((NRF_FICR_Type           *) NRF_FICR_BASE)
+#define NRF_UICR                        ((NRF_UICR_Type           *) NRF_UICR_BASE)
+#define NRF_GPIO                        ((NRF_GPIO_Type           *) NRF_GPIO_BASE)
+
+
+/** @} */ /* End of group Device_Peripheral_Registers */
+/** @} */ /* End of group nrf51 */
+/** @} */ /* End of group Nordic Semiconductor */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  /* nrf51_H */
+

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf51422_peripherals.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf51422_peripherals.h
@@ -1,0 +1,116 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _NRF51422_PERIPHERALS_H
+#define _NRF51422_PERIPHERALS_H
+
+
+/* Software Interrupts */
+#define SWI_PRESENT
+#define SWI_COUNT 6
+
+/* Radio */
+#define RADIO_PRESENT
+#define RADIO_COUNT 1
+
+/* Peripheral to Peripheral Interconnect */
+#define PPI_PRESENT
+#define PPI_COUNT 1
+
+#define PPI_CH_NUM 16
+#define PPI_GROUP_NUM 4
+
+/* Timer/Counter */
+#define TIMER_PRESENT
+#define TIMER_COUNT 3
+
+#define TIMER0_MAX_SIZE 32
+#define TIMER1_MAX_SIZE 16
+#define TIMER2_MAX_SIZE 16
+
+#define TIMER0_CC_NUM 4
+#define TIMER1_CC_NUM 4
+#define TIMER2_CC_NUM 4
+
+/* Real Time Counter */
+#define RTC_PRESENT
+#define RTC_COUNT 2
+
+#define RTC0_CC_NUM 3
+#define RTC1_CC_NUM 4
+
+/* RNG */
+#define RNG_PRESENT
+#define RNG_COUNT 1
+
+/* Watchdog Timer */
+#define WDT_PRESENT
+#define WDT_COUNT 1
+
+/* Temperature Sensor */
+#define TEMP_PRESENT
+#define TEMP_COUNT 1
+
+/* Serial Peripheral Interface Master */
+#define SPI_PRESENT
+#define SPI_COUNT 2
+
+/* Serial Peripheral Interface Slave with DMA */
+#define SPIS_PRESENT
+#define SPIS_COUNT 1
+
+/* Two Wire Interface Master */
+#define TWI_PRESENT
+#define TWI_COUNT 2
+
+/* Universal Asynchronous Receiver-Transmitter */
+#define UART_PRESENT
+#define UART_COUNT 1
+
+/* Quadrature Decoder */
+#define QDEC_PRESENT
+#define QDEC_COUNT 1
+
+/* Analog to Digital Converter */
+#define ADC_PRESENT
+#define ADC_COUNT 1
+
+/* GPIO Tasks and Events */
+#define GPIOTE_PRESENT
+#define GPIOTE_COUNT 1
+
+#define GPIOTE_CH_NUM 4
+
+/* Low Power Comparator */
+#define LPCOMP_PRESENT
+#define LPCOMP_COUNT 1
+
+
+#endif      // _NRF51422_PERIPHERALS_H

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf51822_peripherals.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf51822_peripherals.h
@@ -1,0 +1,116 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _NRF51822_PERIPHERALS_H
+#define _NRF51822_PERIPHERALS_H
+
+
+/* Software Interrupts */
+#define SWI_PRESENT
+#define SWI_COUNT 6
+
+/* Radio */
+#define RADIO_PRESENT
+#define RADIO_COUNT 1
+
+/* Peripheral to Peripheral Interconnect */
+#define PPI_PRESENT
+#define PPI_COUNT 1
+
+#define PPI_CH_NUM 16
+#define PPI_GROUP_NUM 4
+
+/* Timer/Counter */
+#define TIMER_PRESENT
+#define TIMER_COUNT 3
+
+#define TIMER0_MAX_SIZE 32
+#define TIMER1_MAX_SIZE 16
+#define TIMER2_MAX_SIZE 16
+
+#define TIMER0_CC_NUM 4
+#define TIMER1_CC_NUM 4
+#define TIMER2_CC_NUM 4
+
+/* Real Time Counter */
+#define RTC_PRESENT
+#define RTC_COUNT 2
+
+#define RTC0_CC_NUM 3
+#define RTC1_CC_NUM 4
+
+/* RNG */
+#define RNG_PRESENT
+#define RNG_COUNT 1
+
+/* Watchdog Timer */
+#define WDT_PRESENT
+#define WDT_COUNT 1
+
+/* Temperature Sensor */
+#define TEMP_PRESENT
+#define TEMP_COUNT 1
+
+/* Serial Peripheral Interface Master */
+#define SPI_PRESENT
+#define SPI_COUNT 2
+
+/* Serial Peripheral Interface Slave with DMA */
+#define SPIS_PRESENT
+#define SPIS_COUNT 1
+
+/* Two Wire Interface Master */
+#define TWI_PRESENT
+#define TWI_COUNT 2
+
+/* Universal Asynchronous Receiver-Transmitter */
+#define UART_PRESENT
+#define UART_COUNT 1
+
+/* Quadrature Decoder */
+#define QDEC_PRESENT
+#define QDEC_COUNT 1
+
+/* Analog to Digital Converter */
+#define ADC_PRESENT
+#define ADC_COUNT 1
+
+/* GPIO Tasks and Events */
+#define GPIOTE_PRESENT
+#define GPIOTE_COUNT 1
+
+#define GPIOTE_CH_NUM 4
+
+/* Low Power Comparator */
+#define LPCOMP_PRESENT
+#define LPCOMP_COUNT 1
+
+
+#endif      // _NRF51822_PERIPHERALS_H

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf51_bitfields.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf51_bitfields.h
@@ -1,0 +1,6892 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef __NRF51_BITS_H
+#define __NRF51_BITS_H
+
+/*lint ++flb "Enter library region" */
+
+/* Peripheral: AAR */
+/* Description: Accelerated Address Resolver. */
+
+/* Register: AAR_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 2 : Enable interrupt on NOTRESOLVED event. */
+#define AAR_INTENSET_NOTRESOLVED_Pos (2UL) /*!< Position of NOTRESOLVED field. */
+#define AAR_INTENSET_NOTRESOLVED_Msk (0x1UL << AAR_INTENSET_NOTRESOLVED_Pos) /*!< Bit mask of NOTRESOLVED field. */
+#define AAR_INTENSET_NOTRESOLVED_Disabled (0UL) /*!< Interrupt disabled. */
+#define AAR_INTENSET_NOTRESOLVED_Enabled (1UL) /*!< Interrupt enabled. */
+#define AAR_INTENSET_NOTRESOLVED_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on RESOLVED event. */
+#define AAR_INTENSET_RESOLVED_Pos (1UL) /*!< Position of RESOLVED field. */
+#define AAR_INTENSET_RESOLVED_Msk (0x1UL << AAR_INTENSET_RESOLVED_Pos) /*!< Bit mask of RESOLVED field. */
+#define AAR_INTENSET_RESOLVED_Disabled (0UL) /*!< Interrupt disabled. */
+#define AAR_INTENSET_RESOLVED_Enabled (1UL) /*!< Interrupt enabled. */
+#define AAR_INTENSET_RESOLVED_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 0 : Enable interrupt on END event. */
+#define AAR_INTENSET_END_Pos (0UL) /*!< Position of END field. */
+#define AAR_INTENSET_END_Msk (0x1UL << AAR_INTENSET_END_Pos) /*!< Bit mask of END field. */
+#define AAR_INTENSET_END_Disabled (0UL) /*!< Interrupt disabled. */
+#define AAR_INTENSET_END_Enabled (1UL) /*!< Interrupt enabled. */
+#define AAR_INTENSET_END_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: AAR_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 2 : Disable interrupt on NOTRESOLVED event. */
+#define AAR_INTENCLR_NOTRESOLVED_Pos (2UL) /*!< Position of NOTRESOLVED field. */
+#define AAR_INTENCLR_NOTRESOLVED_Msk (0x1UL << AAR_INTENCLR_NOTRESOLVED_Pos) /*!< Bit mask of NOTRESOLVED field. */
+#define AAR_INTENCLR_NOTRESOLVED_Disabled (0UL) /*!< Interrupt disabled. */
+#define AAR_INTENCLR_NOTRESOLVED_Enabled (1UL) /*!< Interrupt enabled. */
+#define AAR_INTENCLR_NOTRESOLVED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on RESOLVED event. */
+#define AAR_INTENCLR_RESOLVED_Pos (1UL) /*!< Position of RESOLVED field. */
+#define AAR_INTENCLR_RESOLVED_Msk (0x1UL << AAR_INTENCLR_RESOLVED_Pos) /*!< Bit mask of RESOLVED field. */
+#define AAR_INTENCLR_RESOLVED_Disabled (0UL) /*!< Interrupt disabled. */
+#define AAR_INTENCLR_RESOLVED_Enabled (1UL) /*!< Interrupt enabled. */
+#define AAR_INTENCLR_RESOLVED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 0 : Disable interrupt on ENDKSGEN event. */
+#define AAR_INTENCLR_END_Pos (0UL) /*!< Position of END field. */
+#define AAR_INTENCLR_END_Msk (0x1UL << AAR_INTENCLR_END_Pos) /*!< Bit mask of END field. */
+#define AAR_INTENCLR_END_Disabled (0UL) /*!< Interrupt disabled. */
+#define AAR_INTENCLR_END_Enabled (1UL) /*!< Interrupt enabled. */
+#define AAR_INTENCLR_END_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: AAR_STATUS */
+/* Description: Resolution status. */
+
+/* Bits 3..0 : The IRK used last time an address was resolved. */
+#define AAR_STATUS_STATUS_Pos (0UL) /*!< Position of STATUS field. */
+#define AAR_STATUS_STATUS_Msk (0xFUL << AAR_STATUS_STATUS_Pos) /*!< Bit mask of STATUS field. */
+
+/* Register: AAR_ENABLE */
+/* Description: Enable AAR. */
+
+/* Bits 1..0 : Enable AAR. */
+#define AAR_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define AAR_ENABLE_ENABLE_Msk (0x3UL << AAR_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define AAR_ENABLE_ENABLE_Disabled (0x00UL) /*!< Disabled AAR. */
+#define AAR_ENABLE_ENABLE_Enabled (0x03UL) /*!< Enable AAR. */
+
+/* Register: AAR_NIRK */
+/* Description: Number of Identity root Keys in the IRK data structure. */
+
+/* Bits 4..0 : Number of Identity root Keys in the IRK data structure. */
+#define AAR_NIRK_NIRK_Pos (0UL) /*!< Position of NIRK field. */
+#define AAR_NIRK_NIRK_Msk (0x1FUL << AAR_NIRK_NIRK_Pos) /*!< Bit mask of NIRK field. */
+
+/* Register: AAR_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define AAR_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define AAR_POWER_POWER_Msk (0x1UL << AAR_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define AAR_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define AAR_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: ADC */
+/* Description: Analog to digital converter. */
+
+/* Register: ADC_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 0 : Enable interrupt on END event. */
+#define ADC_INTENSET_END_Pos (0UL) /*!< Position of END field. */
+#define ADC_INTENSET_END_Msk (0x1UL << ADC_INTENSET_END_Pos) /*!< Bit mask of END field. */
+#define ADC_INTENSET_END_Disabled (0UL) /*!< Interrupt disabled. */
+#define ADC_INTENSET_END_Enabled (1UL) /*!< Interrupt enabled. */
+#define ADC_INTENSET_END_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: ADC_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 0 : Disable interrupt on END event. */
+#define ADC_INTENCLR_END_Pos (0UL) /*!< Position of END field. */
+#define ADC_INTENCLR_END_Msk (0x1UL << ADC_INTENCLR_END_Pos) /*!< Bit mask of END field. */
+#define ADC_INTENCLR_END_Disabled (0UL) /*!< Interrupt disabled. */
+#define ADC_INTENCLR_END_Enabled (1UL) /*!< Interrupt enabled. */
+#define ADC_INTENCLR_END_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: ADC_BUSY */
+/* Description: ADC busy register. */
+
+/* Bit 0 : ADC busy register. */
+#define ADC_BUSY_BUSY_Pos (0UL) /*!< Position of BUSY field. */
+#define ADC_BUSY_BUSY_Msk (0x1UL << ADC_BUSY_BUSY_Pos) /*!< Bit mask of BUSY field. */
+#define ADC_BUSY_BUSY_Ready (0UL) /*!< No ongoing ADC conversion is taking place. ADC is ready. */
+#define ADC_BUSY_BUSY_Busy (1UL) /*!< An ADC conversion is taking place. ADC is busy. */
+
+/* Register: ADC_ENABLE */
+/* Description: ADC enable. */
+
+/* Bits 1..0 : ADC enable. */
+#define ADC_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define ADC_ENABLE_ENABLE_Msk (0x3UL << ADC_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define ADC_ENABLE_ENABLE_Disabled (0x00UL) /*!< ADC is disabled. */
+#define ADC_ENABLE_ENABLE_Enabled (0x01UL) /*!< ADC is enabled. If an analog input pin is selected as source of the conversion, the selected pin is configured as an analog input. */
+
+/* Register: ADC_CONFIG */
+/* Description: ADC configuration register. */
+
+/* Bits 17..16 : ADC external reference pin selection. */
+#define ADC_CONFIG_EXTREFSEL_Pos (16UL) /*!< Position of EXTREFSEL field. */
+#define ADC_CONFIG_EXTREFSEL_Msk (0x3UL << ADC_CONFIG_EXTREFSEL_Pos) /*!< Bit mask of EXTREFSEL field. */
+#define ADC_CONFIG_EXTREFSEL_None (0UL) /*!< Analog external reference inputs disabled. */
+#define ADC_CONFIG_EXTREFSEL_AnalogReference0 (1UL) /*!< Use analog reference 0 as reference. */
+#define ADC_CONFIG_EXTREFSEL_AnalogReference1 (2UL) /*!< Use analog reference 1 as reference. */
+
+/* Bits 15..8 : ADC analog pin selection. */
+#define ADC_CONFIG_PSEL_Pos (8UL) /*!< Position of PSEL field. */
+#define ADC_CONFIG_PSEL_Msk (0xFFUL << ADC_CONFIG_PSEL_Pos) /*!< Bit mask of PSEL field. */
+#define ADC_CONFIG_PSEL_Disabled (0UL) /*!< Analog input pins disabled. */
+#define ADC_CONFIG_PSEL_AnalogInput0 (1UL) /*!< Use analog input 0 as analog input. */
+#define ADC_CONFIG_PSEL_AnalogInput1 (2UL) /*!< Use analog input 1 as analog input. */
+#define ADC_CONFIG_PSEL_AnalogInput2 (4UL) /*!< Use analog input 2 as analog input. */
+#define ADC_CONFIG_PSEL_AnalogInput3 (8UL) /*!< Use analog input 3 as analog input. */
+#define ADC_CONFIG_PSEL_AnalogInput4 (16UL) /*!< Use analog input 4 as analog input. */
+#define ADC_CONFIG_PSEL_AnalogInput5 (32UL) /*!< Use analog input 5 as analog input. */
+#define ADC_CONFIG_PSEL_AnalogInput6 (64UL) /*!< Use analog input 6 as analog input. */
+#define ADC_CONFIG_PSEL_AnalogInput7 (128UL) /*!< Use analog input 7 as analog input. */
+
+/* Bits 6..5 : ADC reference selection. */
+#define ADC_CONFIG_REFSEL_Pos (5UL) /*!< Position of REFSEL field. */
+#define ADC_CONFIG_REFSEL_Msk (0x3UL << ADC_CONFIG_REFSEL_Pos) /*!< Bit mask of REFSEL field. */
+#define ADC_CONFIG_REFSEL_VBG (0x00UL) /*!< Use internal 1.2V bandgap voltage as reference for conversion. */
+#define ADC_CONFIG_REFSEL_External (0x01UL) /*!< Use external source configured by EXTREFSEL as reference for conversion. */
+#define ADC_CONFIG_REFSEL_SupplyOneHalfPrescaling (0x02UL) /*!< Use supply voltage with 1/2 prescaling as reference for conversion. Only usable when supply voltage is between 1.7V and 2.6V. */
+#define ADC_CONFIG_REFSEL_SupplyOneThirdPrescaling (0x03UL) /*!< Use supply voltage with 1/3 prescaling as reference for conversion. Only usable when supply voltage is between 2.5V and 3.6V. */
+
+/* Bits 4..2 : ADC input selection. */
+#define ADC_CONFIG_INPSEL_Pos (2UL) /*!< Position of INPSEL field. */
+#define ADC_CONFIG_INPSEL_Msk (0x7UL << ADC_CONFIG_INPSEL_Pos) /*!< Bit mask of INPSEL field. */
+#define ADC_CONFIG_INPSEL_AnalogInputNoPrescaling (0x00UL) /*!< Analog input specified by PSEL with no prescaling used as input for the conversion. */
+#define ADC_CONFIG_INPSEL_AnalogInputTwoThirdsPrescaling (0x01UL) /*!< Analog input specified by PSEL with 2/3 prescaling used as input for the conversion. */
+#define ADC_CONFIG_INPSEL_AnalogInputOneThirdPrescaling (0x02UL) /*!< Analog input specified by PSEL with 1/3 prescaling used as input for the conversion. */
+#define ADC_CONFIG_INPSEL_SupplyTwoThirdsPrescaling (0x05UL) /*!< Supply voltage with 2/3 prescaling used as input for the conversion. */
+#define ADC_CONFIG_INPSEL_SupplyOneThirdPrescaling (0x06UL) /*!< Supply voltage with 1/3 prescaling used as input for the conversion. */
+
+/* Bits 1..0 : ADC resolution. */
+#define ADC_CONFIG_RES_Pos (0UL) /*!< Position of RES field. */
+#define ADC_CONFIG_RES_Msk (0x3UL << ADC_CONFIG_RES_Pos) /*!< Bit mask of RES field. */
+#define ADC_CONFIG_RES_8bit (0x00UL) /*!< 8bit ADC resolution. */
+#define ADC_CONFIG_RES_9bit (0x01UL) /*!< 9bit ADC resolution. */
+#define ADC_CONFIG_RES_10bit (0x02UL) /*!< 10bit ADC resolution. */
+
+/* Register: ADC_RESULT */
+/* Description: Result of ADC conversion. */
+
+/* Bits 9..0 : Result of ADC conversion. */
+#define ADC_RESULT_RESULT_Pos (0UL) /*!< Position of RESULT field. */
+#define ADC_RESULT_RESULT_Msk (0x3FFUL << ADC_RESULT_RESULT_Pos) /*!< Bit mask of RESULT field. */
+
+/* Register: ADC_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define ADC_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define ADC_POWER_POWER_Msk (0x1UL << ADC_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define ADC_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define ADC_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: AMLI */
+/* Description: AHB Multi-Layer Interface. */
+
+/* Register: AMLI_RAMPRI_CPU0 */
+/* Description: Configurable priority configuration register for CPU0. */
+
+/* Bits 31..28 : Configuration field for RAM block 7. */
+#define AMLI_RAMPRI_CPU0_RAM7_Pos (28UL) /*!< Position of RAM7 field. */
+#define AMLI_RAMPRI_CPU0_RAM7_Msk (0xFUL << AMLI_RAMPRI_CPU0_RAM7_Pos) /*!< Bit mask of RAM7 field. */
+#define AMLI_RAMPRI_CPU0_RAM7_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CPU0_RAM7_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CPU0_RAM7_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CPU0_RAM7_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CPU0_RAM7_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CPU0_RAM7_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CPU0_RAM7_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CPU0_RAM7_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 27..24 : Configuration field for RAM block 6. */
+#define AMLI_RAMPRI_CPU0_RAM6_Pos (24UL) /*!< Position of RAM6 field. */
+#define AMLI_RAMPRI_CPU0_RAM6_Msk (0xFUL << AMLI_RAMPRI_CPU0_RAM6_Pos) /*!< Bit mask of RAM6 field. */
+#define AMLI_RAMPRI_CPU0_RAM6_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CPU0_RAM6_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CPU0_RAM6_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CPU0_RAM6_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CPU0_RAM6_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CPU0_RAM6_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CPU0_RAM6_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CPU0_RAM6_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 23..20 : Configuration field for RAM block 5. */
+#define AMLI_RAMPRI_CPU0_RAM5_Pos (20UL) /*!< Position of RAM5 field. */
+#define AMLI_RAMPRI_CPU0_RAM5_Msk (0xFUL << AMLI_RAMPRI_CPU0_RAM5_Pos) /*!< Bit mask of RAM5 field. */
+#define AMLI_RAMPRI_CPU0_RAM5_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CPU0_RAM5_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CPU0_RAM5_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CPU0_RAM5_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CPU0_RAM5_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CPU0_RAM5_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CPU0_RAM5_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CPU0_RAM5_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 19..16 : Configuration field for RAM block 4. */
+#define AMLI_RAMPRI_CPU0_RAM4_Pos (16UL) /*!< Position of RAM4 field. */
+#define AMLI_RAMPRI_CPU0_RAM4_Msk (0xFUL << AMLI_RAMPRI_CPU0_RAM4_Pos) /*!< Bit mask of RAM4 field. */
+#define AMLI_RAMPRI_CPU0_RAM4_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CPU0_RAM4_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CPU0_RAM4_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CPU0_RAM4_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CPU0_RAM4_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CPU0_RAM4_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CPU0_RAM4_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CPU0_RAM4_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 15..12 : Configuration field for RAM block 3. */
+#define AMLI_RAMPRI_CPU0_RAM3_Pos (12UL) /*!< Position of RAM3 field. */
+#define AMLI_RAMPRI_CPU0_RAM3_Msk (0xFUL << AMLI_RAMPRI_CPU0_RAM3_Pos) /*!< Bit mask of RAM3 field. */
+#define AMLI_RAMPRI_CPU0_RAM3_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CPU0_RAM3_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CPU0_RAM3_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CPU0_RAM3_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CPU0_RAM3_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CPU0_RAM3_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CPU0_RAM3_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CPU0_RAM3_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 11..8 : Configuration field for RAM block 2. */
+#define AMLI_RAMPRI_CPU0_RAM2_Pos (8UL) /*!< Position of RAM2 field. */
+#define AMLI_RAMPRI_CPU0_RAM2_Msk (0xFUL << AMLI_RAMPRI_CPU0_RAM2_Pos) /*!< Bit mask of RAM2 field. */
+#define AMLI_RAMPRI_CPU0_RAM2_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CPU0_RAM2_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CPU0_RAM2_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CPU0_RAM2_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CPU0_RAM2_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CPU0_RAM2_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CPU0_RAM2_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CPU0_RAM2_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 7..4 : Configuration field for RAM block 1. */
+#define AMLI_RAMPRI_CPU0_RAM1_Pos (4UL) /*!< Position of RAM1 field. */
+#define AMLI_RAMPRI_CPU0_RAM1_Msk (0xFUL << AMLI_RAMPRI_CPU0_RAM1_Pos) /*!< Bit mask of RAM1 field. */
+#define AMLI_RAMPRI_CPU0_RAM1_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CPU0_RAM1_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CPU0_RAM1_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CPU0_RAM1_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CPU0_RAM1_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CPU0_RAM1_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CPU0_RAM1_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CPU0_RAM1_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 3..0 : Configuration field for RAM block 0. */
+#define AMLI_RAMPRI_CPU0_RAM0_Pos (0UL) /*!< Position of RAM0 field. */
+#define AMLI_RAMPRI_CPU0_RAM0_Msk (0xFUL << AMLI_RAMPRI_CPU0_RAM0_Pos) /*!< Bit mask of RAM0 field. */
+#define AMLI_RAMPRI_CPU0_RAM0_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CPU0_RAM0_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CPU0_RAM0_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CPU0_RAM0_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CPU0_RAM0_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CPU0_RAM0_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CPU0_RAM0_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CPU0_RAM0_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Register: AMLI_RAMPRI_SPIS1 */
+/* Description: Configurable priority configuration register for SPIS1. */
+
+/* Bits 31..28 : Configuration field for RAM block 7. */
+#define AMLI_RAMPRI_SPIS1_RAM7_Pos (28UL) /*!< Position of RAM7 field. */
+#define AMLI_RAMPRI_SPIS1_RAM7_Msk (0xFUL << AMLI_RAMPRI_SPIS1_RAM7_Pos) /*!< Bit mask of RAM7 field. */
+#define AMLI_RAMPRI_SPIS1_RAM7_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_SPIS1_RAM7_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_SPIS1_RAM7_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_SPIS1_RAM7_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_SPIS1_RAM7_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_SPIS1_RAM7_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_SPIS1_RAM7_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_SPIS1_RAM7_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 27..24 : Configuration field for RAM block 6. */
+#define AMLI_RAMPRI_SPIS1_RAM6_Pos (24UL) /*!< Position of RAM6 field. */
+#define AMLI_RAMPRI_SPIS1_RAM6_Msk (0xFUL << AMLI_RAMPRI_SPIS1_RAM6_Pos) /*!< Bit mask of RAM6 field. */
+#define AMLI_RAMPRI_SPIS1_RAM6_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_SPIS1_RAM6_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_SPIS1_RAM6_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_SPIS1_RAM6_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_SPIS1_RAM6_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_SPIS1_RAM6_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_SPIS1_RAM6_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_SPIS1_RAM6_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 23..20 : Configuration field for RAM block 5. */
+#define AMLI_RAMPRI_SPIS1_RAM5_Pos (20UL) /*!< Position of RAM5 field. */
+#define AMLI_RAMPRI_SPIS1_RAM5_Msk (0xFUL << AMLI_RAMPRI_SPIS1_RAM5_Pos) /*!< Bit mask of RAM5 field. */
+#define AMLI_RAMPRI_SPIS1_RAM5_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_SPIS1_RAM5_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_SPIS1_RAM5_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_SPIS1_RAM5_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_SPIS1_RAM5_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_SPIS1_RAM5_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_SPIS1_RAM5_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_SPIS1_RAM5_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 19..16 : Configuration field for RAM block 4. */
+#define AMLI_RAMPRI_SPIS1_RAM4_Pos (16UL) /*!< Position of RAM4 field. */
+#define AMLI_RAMPRI_SPIS1_RAM4_Msk (0xFUL << AMLI_RAMPRI_SPIS1_RAM4_Pos) /*!< Bit mask of RAM4 field. */
+#define AMLI_RAMPRI_SPIS1_RAM4_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_SPIS1_RAM4_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_SPIS1_RAM4_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_SPIS1_RAM4_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_SPIS1_RAM4_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_SPIS1_RAM4_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_SPIS1_RAM4_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_SPIS1_RAM4_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 15..12 : Configuration field for RAM block 3. */
+#define AMLI_RAMPRI_SPIS1_RAM3_Pos (12UL) /*!< Position of RAM3 field. */
+#define AMLI_RAMPRI_SPIS1_RAM3_Msk (0xFUL << AMLI_RAMPRI_SPIS1_RAM3_Pos) /*!< Bit mask of RAM3 field. */
+#define AMLI_RAMPRI_SPIS1_RAM3_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_SPIS1_RAM3_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_SPIS1_RAM3_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_SPIS1_RAM3_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_SPIS1_RAM3_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_SPIS1_RAM3_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_SPIS1_RAM3_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_SPIS1_RAM3_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 11..8 : Configuration field for RAM block 2. */
+#define AMLI_RAMPRI_SPIS1_RAM2_Pos (8UL) /*!< Position of RAM2 field. */
+#define AMLI_RAMPRI_SPIS1_RAM2_Msk (0xFUL << AMLI_RAMPRI_SPIS1_RAM2_Pos) /*!< Bit mask of RAM2 field. */
+#define AMLI_RAMPRI_SPIS1_RAM2_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_SPIS1_RAM2_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_SPIS1_RAM2_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_SPIS1_RAM2_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_SPIS1_RAM2_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_SPIS1_RAM2_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_SPIS1_RAM2_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_SPIS1_RAM2_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 7..4 : Configuration field for RAM block 1. */
+#define AMLI_RAMPRI_SPIS1_RAM1_Pos (4UL) /*!< Position of RAM1 field. */
+#define AMLI_RAMPRI_SPIS1_RAM1_Msk (0xFUL << AMLI_RAMPRI_SPIS1_RAM1_Pos) /*!< Bit mask of RAM1 field. */
+#define AMLI_RAMPRI_SPIS1_RAM1_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_SPIS1_RAM1_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_SPIS1_RAM1_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_SPIS1_RAM1_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_SPIS1_RAM1_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_SPIS1_RAM1_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_SPIS1_RAM1_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_SPIS1_RAM1_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 3..0 : Configuration field for RAM block 0. */
+#define AMLI_RAMPRI_SPIS1_RAM0_Pos (0UL) /*!< Position of RAM0 field. */
+#define AMLI_RAMPRI_SPIS1_RAM0_Msk (0xFUL << AMLI_RAMPRI_SPIS1_RAM0_Pos) /*!< Bit mask of RAM0 field. */
+#define AMLI_RAMPRI_SPIS1_RAM0_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_SPIS1_RAM0_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_SPIS1_RAM0_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_SPIS1_RAM0_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_SPIS1_RAM0_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_SPIS1_RAM0_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_SPIS1_RAM0_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_SPIS1_RAM0_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Register: AMLI_RAMPRI_RADIO */
+/* Description: Configurable priority configuration register for RADIO. */
+
+/* Bits 31..28 : Configuration field for RAM block 7. */
+#define AMLI_RAMPRI_RADIO_RAM7_Pos (28UL) /*!< Position of RAM7 field. */
+#define AMLI_RAMPRI_RADIO_RAM7_Msk (0xFUL << AMLI_RAMPRI_RADIO_RAM7_Pos) /*!< Bit mask of RAM7 field. */
+#define AMLI_RAMPRI_RADIO_RAM7_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_RADIO_RAM7_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_RADIO_RAM7_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_RADIO_RAM7_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_RADIO_RAM7_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_RADIO_RAM7_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_RADIO_RAM7_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_RADIO_RAM7_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 27..24 : Configuration field for RAM block 6. */
+#define AMLI_RAMPRI_RADIO_RAM6_Pos (24UL) /*!< Position of RAM6 field. */
+#define AMLI_RAMPRI_RADIO_RAM6_Msk (0xFUL << AMLI_RAMPRI_RADIO_RAM6_Pos) /*!< Bit mask of RAM6 field. */
+#define AMLI_RAMPRI_RADIO_RAM6_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_RADIO_RAM6_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_RADIO_RAM6_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_RADIO_RAM6_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_RADIO_RAM6_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_RADIO_RAM6_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_RADIO_RAM6_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_RADIO_RAM6_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 23..20 : Configuration field for RAM block 5. */
+#define AMLI_RAMPRI_RADIO_RAM5_Pos (20UL) /*!< Position of RAM5 field. */
+#define AMLI_RAMPRI_RADIO_RAM5_Msk (0xFUL << AMLI_RAMPRI_RADIO_RAM5_Pos) /*!< Bit mask of RAM5 field. */
+#define AMLI_RAMPRI_RADIO_RAM5_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_RADIO_RAM5_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_RADIO_RAM5_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_RADIO_RAM5_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_RADIO_RAM5_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_RADIO_RAM5_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_RADIO_RAM5_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_RADIO_RAM5_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 19..16 : Configuration field for RAM block 4. */
+#define AMLI_RAMPRI_RADIO_RAM4_Pos (16UL) /*!< Position of RAM4 field. */
+#define AMLI_RAMPRI_RADIO_RAM4_Msk (0xFUL << AMLI_RAMPRI_RADIO_RAM4_Pos) /*!< Bit mask of RAM4 field. */
+#define AMLI_RAMPRI_RADIO_RAM4_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_RADIO_RAM4_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_RADIO_RAM4_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_RADIO_RAM4_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_RADIO_RAM4_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_RADIO_RAM4_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_RADIO_RAM4_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_RADIO_RAM4_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 15..12 : Configuration field for RAM block 3. */
+#define AMLI_RAMPRI_RADIO_RAM3_Pos (12UL) /*!< Position of RAM3 field. */
+#define AMLI_RAMPRI_RADIO_RAM3_Msk (0xFUL << AMLI_RAMPRI_RADIO_RAM3_Pos) /*!< Bit mask of RAM3 field. */
+#define AMLI_RAMPRI_RADIO_RAM3_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_RADIO_RAM3_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_RADIO_RAM3_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_RADIO_RAM3_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_RADIO_RAM3_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_RADIO_RAM3_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_RADIO_RAM3_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_RADIO_RAM3_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 11..8 : Configuration field for RAM block 2. */
+#define AMLI_RAMPRI_RADIO_RAM2_Pos (8UL) /*!< Position of RAM2 field. */
+#define AMLI_RAMPRI_RADIO_RAM2_Msk (0xFUL << AMLI_RAMPRI_RADIO_RAM2_Pos) /*!< Bit mask of RAM2 field. */
+#define AMLI_RAMPRI_RADIO_RAM2_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_RADIO_RAM2_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_RADIO_RAM2_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_RADIO_RAM2_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_RADIO_RAM2_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_RADIO_RAM2_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_RADIO_RAM2_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_RADIO_RAM2_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 7..4 : Configuration field for RAM block 1. */
+#define AMLI_RAMPRI_RADIO_RAM1_Pos (4UL) /*!< Position of RAM1 field. */
+#define AMLI_RAMPRI_RADIO_RAM1_Msk (0xFUL << AMLI_RAMPRI_RADIO_RAM1_Pos) /*!< Bit mask of RAM1 field. */
+#define AMLI_RAMPRI_RADIO_RAM1_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_RADIO_RAM1_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_RADIO_RAM1_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_RADIO_RAM1_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_RADIO_RAM1_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_RADIO_RAM1_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_RADIO_RAM1_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_RADIO_RAM1_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 3..0 : Configuration field for RAM block 0. */
+#define AMLI_RAMPRI_RADIO_RAM0_Pos (0UL) /*!< Position of RAM0 field. */
+#define AMLI_RAMPRI_RADIO_RAM0_Msk (0xFUL << AMLI_RAMPRI_RADIO_RAM0_Pos) /*!< Bit mask of RAM0 field. */
+#define AMLI_RAMPRI_RADIO_RAM0_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_RADIO_RAM0_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_RADIO_RAM0_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_RADIO_RAM0_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_RADIO_RAM0_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_RADIO_RAM0_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_RADIO_RAM0_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_RADIO_RAM0_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Register: AMLI_RAMPRI_ECB */
+/* Description: Configurable priority configuration register for ECB. */
+
+/* Bits 31..28 : Configuration field for RAM block 7. */
+#define AMLI_RAMPRI_ECB_RAM7_Pos (28UL) /*!< Position of RAM7 field. */
+#define AMLI_RAMPRI_ECB_RAM7_Msk (0xFUL << AMLI_RAMPRI_ECB_RAM7_Pos) /*!< Bit mask of RAM7 field. */
+#define AMLI_RAMPRI_ECB_RAM7_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_ECB_RAM7_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_ECB_RAM7_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_ECB_RAM7_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_ECB_RAM7_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_ECB_RAM7_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_ECB_RAM7_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_ECB_RAM7_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 27..24 : Configuration field for RAM block 6. */
+#define AMLI_RAMPRI_ECB_RAM6_Pos (24UL) /*!< Position of RAM6 field. */
+#define AMLI_RAMPRI_ECB_RAM6_Msk (0xFUL << AMLI_RAMPRI_ECB_RAM6_Pos) /*!< Bit mask of RAM6 field. */
+#define AMLI_RAMPRI_ECB_RAM6_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_ECB_RAM6_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_ECB_RAM6_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_ECB_RAM6_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_ECB_RAM6_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_ECB_RAM6_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_ECB_RAM6_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_ECB_RAM6_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 23..20 : Configuration field for RAM block 5. */
+#define AMLI_RAMPRI_ECB_RAM5_Pos (20UL) /*!< Position of RAM5 field. */
+#define AMLI_RAMPRI_ECB_RAM5_Msk (0xFUL << AMLI_RAMPRI_ECB_RAM5_Pos) /*!< Bit mask of RAM5 field. */
+#define AMLI_RAMPRI_ECB_RAM5_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_ECB_RAM5_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_ECB_RAM5_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_ECB_RAM5_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_ECB_RAM5_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_ECB_RAM5_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_ECB_RAM5_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_ECB_RAM5_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 19..16 : Configuration field for RAM block 4. */
+#define AMLI_RAMPRI_ECB_RAM4_Pos (16UL) /*!< Position of RAM4 field. */
+#define AMLI_RAMPRI_ECB_RAM4_Msk (0xFUL << AMLI_RAMPRI_ECB_RAM4_Pos) /*!< Bit mask of RAM4 field. */
+#define AMLI_RAMPRI_ECB_RAM4_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_ECB_RAM4_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_ECB_RAM4_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_ECB_RAM4_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_ECB_RAM4_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_ECB_RAM4_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_ECB_RAM4_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_ECB_RAM4_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 15..12 : Configuration field for RAM block 3. */
+#define AMLI_RAMPRI_ECB_RAM3_Pos (12UL) /*!< Position of RAM3 field. */
+#define AMLI_RAMPRI_ECB_RAM3_Msk (0xFUL << AMLI_RAMPRI_ECB_RAM3_Pos) /*!< Bit mask of RAM3 field. */
+#define AMLI_RAMPRI_ECB_RAM3_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_ECB_RAM3_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_ECB_RAM3_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_ECB_RAM3_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_ECB_RAM3_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_ECB_RAM3_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_ECB_RAM3_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_ECB_RAM3_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 11..8 : Configuration field for RAM block 2. */
+#define AMLI_RAMPRI_ECB_RAM2_Pos (8UL) /*!< Position of RAM2 field. */
+#define AMLI_RAMPRI_ECB_RAM2_Msk (0xFUL << AMLI_RAMPRI_ECB_RAM2_Pos) /*!< Bit mask of RAM2 field. */
+#define AMLI_RAMPRI_ECB_RAM2_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_ECB_RAM2_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_ECB_RAM2_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_ECB_RAM2_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_ECB_RAM2_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_ECB_RAM2_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_ECB_RAM2_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_ECB_RAM2_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 7..4 : Configuration field for RAM block 1. */
+#define AMLI_RAMPRI_ECB_RAM1_Pos (4UL) /*!< Position of RAM1 field. */
+#define AMLI_RAMPRI_ECB_RAM1_Msk (0xFUL << AMLI_RAMPRI_ECB_RAM1_Pos) /*!< Bit mask of RAM1 field. */
+#define AMLI_RAMPRI_ECB_RAM1_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_ECB_RAM1_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_ECB_RAM1_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_ECB_RAM1_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_ECB_RAM1_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_ECB_RAM1_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_ECB_RAM1_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_ECB_RAM1_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 3..0 : Configuration field for RAM block 0. */
+#define AMLI_RAMPRI_ECB_RAM0_Pos (0UL) /*!< Position of RAM0 field. */
+#define AMLI_RAMPRI_ECB_RAM0_Msk (0xFUL << AMLI_RAMPRI_ECB_RAM0_Pos) /*!< Bit mask of RAM0 field. */
+#define AMLI_RAMPRI_ECB_RAM0_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_ECB_RAM0_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_ECB_RAM0_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_ECB_RAM0_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_ECB_RAM0_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_ECB_RAM0_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_ECB_RAM0_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_ECB_RAM0_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Register: AMLI_RAMPRI_CCM */
+/* Description: Configurable priority configuration register for CCM. */
+
+/* Bits 31..28 : Configuration field for RAM block 7. */
+#define AMLI_RAMPRI_CCM_RAM7_Pos (28UL) /*!< Position of RAM7 field. */
+#define AMLI_RAMPRI_CCM_RAM7_Msk (0xFUL << AMLI_RAMPRI_CCM_RAM7_Pos) /*!< Bit mask of RAM7 field. */
+#define AMLI_RAMPRI_CCM_RAM7_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CCM_RAM7_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CCM_RAM7_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CCM_RAM7_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CCM_RAM7_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CCM_RAM7_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CCM_RAM7_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CCM_RAM7_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 27..24 : Configuration field for RAM block 6. */
+#define AMLI_RAMPRI_CCM_RAM6_Pos (24UL) /*!< Position of RAM6 field. */
+#define AMLI_RAMPRI_CCM_RAM6_Msk (0xFUL << AMLI_RAMPRI_CCM_RAM6_Pos) /*!< Bit mask of RAM6 field. */
+#define AMLI_RAMPRI_CCM_RAM6_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CCM_RAM6_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CCM_RAM6_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CCM_RAM6_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CCM_RAM6_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CCM_RAM6_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CCM_RAM6_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CCM_RAM6_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 23..20 : Configuration field for RAM block 5. */
+#define AMLI_RAMPRI_CCM_RAM5_Pos (20UL) /*!< Position of RAM5 field. */
+#define AMLI_RAMPRI_CCM_RAM5_Msk (0xFUL << AMLI_RAMPRI_CCM_RAM5_Pos) /*!< Bit mask of RAM5 field. */
+#define AMLI_RAMPRI_CCM_RAM5_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CCM_RAM5_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CCM_RAM5_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CCM_RAM5_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CCM_RAM5_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CCM_RAM5_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CCM_RAM5_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CCM_RAM5_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 19..16 : Configuration field for RAM block 4. */
+#define AMLI_RAMPRI_CCM_RAM4_Pos (16UL) /*!< Position of RAM4 field. */
+#define AMLI_RAMPRI_CCM_RAM4_Msk (0xFUL << AMLI_RAMPRI_CCM_RAM4_Pos) /*!< Bit mask of RAM4 field. */
+#define AMLI_RAMPRI_CCM_RAM4_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CCM_RAM4_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CCM_RAM4_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CCM_RAM4_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CCM_RAM4_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CCM_RAM4_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CCM_RAM4_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CCM_RAM4_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 15..12 : Configuration field for RAM block 3. */
+#define AMLI_RAMPRI_CCM_RAM3_Pos (12UL) /*!< Position of RAM3 field. */
+#define AMLI_RAMPRI_CCM_RAM3_Msk (0xFUL << AMLI_RAMPRI_CCM_RAM3_Pos) /*!< Bit mask of RAM3 field. */
+#define AMLI_RAMPRI_CCM_RAM3_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CCM_RAM3_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CCM_RAM3_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CCM_RAM3_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CCM_RAM3_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CCM_RAM3_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CCM_RAM3_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CCM_RAM3_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 11..8 : Configuration field for RAM block 2. */
+#define AMLI_RAMPRI_CCM_RAM2_Pos (8UL) /*!< Position of RAM2 field. */
+#define AMLI_RAMPRI_CCM_RAM2_Msk (0xFUL << AMLI_RAMPRI_CCM_RAM2_Pos) /*!< Bit mask of RAM2 field. */
+#define AMLI_RAMPRI_CCM_RAM2_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CCM_RAM2_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CCM_RAM2_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CCM_RAM2_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CCM_RAM2_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CCM_RAM2_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CCM_RAM2_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CCM_RAM2_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 7..4 : Configuration field for RAM block 1. */
+#define AMLI_RAMPRI_CCM_RAM1_Pos (4UL) /*!< Position of RAM1 field. */
+#define AMLI_RAMPRI_CCM_RAM1_Msk (0xFUL << AMLI_RAMPRI_CCM_RAM1_Pos) /*!< Bit mask of RAM1 field. */
+#define AMLI_RAMPRI_CCM_RAM1_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CCM_RAM1_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CCM_RAM1_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CCM_RAM1_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CCM_RAM1_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CCM_RAM1_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CCM_RAM1_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CCM_RAM1_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 3..0 : Configuration field for RAM block 0. */
+#define AMLI_RAMPRI_CCM_RAM0_Pos (0UL) /*!< Position of RAM0 field. */
+#define AMLI_RAMPRI_CCM_RAM0_Msk (0xFUL << AMLI_RAMPRI_CCM_RAM0_Pos) /*!< Bit mask of RAM0 field. */
+#define AMLI_RAMPRI_CCM_RAM0_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_CCM_RAM0_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_CCM_RAM0_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_CCM_RAM0_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_CCM_RAM0_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_CCM_RAM0_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_CCM_RAM0_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_CCM_RAM0_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Register: AMLI_RAMPRI_AAR */
+/* Description: Configurable priority configuration register for AAR. */
+
+/* Bits 31..28 : Configuration field for RAM block 7. */
+#define AMLI_RAMPRI_AAR_RAM7_Pos (28UL) /*!< Position of RAM7 field. */
+#define AMLI_RAMPRI_AAR_RAM7_Msk (0xFUL << AMLI_RAMPRI_AAR_RAM7_Pos) /*!< Bit mask of RAM7 field. */
+#define AMLI_RAMPRI_AAR_RAM7_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_AAR_RAM7_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_AAR_RAM7_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_AAR_RAM7_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_AAR_RAM7_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_AAR_RAM7_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_AAR_RAM7_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_AAR_RAM7_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 27..24 : Configuration field for RAM block 6. */
+#define AMLI_RAMPRI_AAR_RAM6_Pos (24UL) /*!< Position of RAM6 field. */
+#define AMLI_RAMPRI_AAR_RAM6_Msk (0xFUL << AMLI_RAMPRI_AAR_RAM6_Pos) /*!< Bit mask of RAM6 field. */
+#define AMLI_RAMPRI_AAR_RAM6_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_AAR_RAM6_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_AAR_RAM6_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_AAR_RAM6_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_AAR_RAM6_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_AAR_RAM6_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_AAR_RAM6_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_AAR_RAM6_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 23..20 : Configuration field for RAM block 5. */
+#define AMLI_RAMPRI_AAR_RAM5_Pos (20UL) /*!< Position of RAM5 field. */
+#define AMLI_RAMPRI_AAR_RAM5_Msk (0xFUL << AMLI_RAMPRI_AAR_RAM5_Pos) /*!< Bit mask of RAM5 field. */
+#define AMLI_RAMPRI_AAR_RAM5_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_AAR_RAM5_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_AAR_RAM5_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_AAR_RAM5_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_AAR_RAM5_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_AAR_RAM5_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_AAR_RAM5_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_AAR_RAM5_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 19..16 : Configuration field for RAM block 4. */
+#define AMLI_RAMPRI_AAR_RAM4_Pos (16UL) /*!< Position of RAM4 field. */
+#define AMLI_RAMPRI_AAR_RAM4_Msk (0xFUL << AMLI_RAMPRI_AAR_RAM4_Pos) /*!< Bit mask of RAM4 field. */
+#define AMLI_RAMPRI_AAR_RAM4_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_AAR_RAM4_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_AAR_RAM4_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_AAR_RAM4_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_AAR_RAM4_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_AAR_RAM4_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_AAR_RAM4_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_AAR_RAM4_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 15..12 : Configuration field for RAM block 3. */
+#define AMLI_RAMPRI_AAR_RAM3_Pos (12UL) /*!< Position of RAM3 field. */
+#define AMLI_RAMPRI_AAR_RAM3_Msk (0xFUL << AMLI_RAMPRI_AAR_RAM3_Pos) /*!< Bit mask of RAM3 field. */
+#define AMLI_RAMPRI_AAR_RAM3_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_AAR_RAM3_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_AAR_RAM3_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_AAR_RAM3_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_AAR_RAM3_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_AAR_RAM3_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_AAR_RAM3_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_AAR_RAM3_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 11..8 : Configuration field for RAM block 2. */
+#define AMLI_RAMPRI_AAR_RAM2_Pos (8UL) /*!< Position of RAM2 field. */
+#define AMLI_RAMPRI_AAR_RAM2_Msk (0xFUL << AMLI_RAMPRI_AAR_RAM2_Pos) /*!< Bit mask of RAM2 field. */
+#define AMLI_RAMPRI_AAR_RAM2_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_AAR_RAM2_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_AAR_RAM2_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_AAR_RAM2_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_AAR_RAM2_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_AAR_RAM2_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_AAR_RAM2_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_AAR_RAM2_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 7..4 : Configuration field for RAM block 1. */
+#define AMLI_RAMPRI_AAR_RAM1_Pos (4UL) /*!< Position of RAM1 field. */
+#define AMLI_RAMPRI_AAR_RAM1_Msk (0xFUL << AMLI_RAMPRI_AAR_RAM1_Pos) /*!< Bit mask of RAM1 field. */
+#define AMLI_RAMPRI_AAR_RAM1_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_AAR_RAM1_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_AAR_RAM1_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_AAR_RAM1_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_AAR_RAM1_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_AAR_RAM1_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_AAR_RAM1_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_AAR_RAM1_Pri14 (0xEUL) /*!< Priority 14. */
+
+/* Bits 3..0 : Configuration field for RAM block 0. */
+#define AMLI_RAMPRI_AAR_RAM0_Pos (0UL) /*!< Position of RAM0 field. */
+#define AMLI_RAMPRI_AAR_RAM0_Msk (0xFUL << AMLI_RAMPRI_AAR_RAM0_Pos) /*!< Bit mask of RAM0 field. */
+#define AMLI_RAMPRI_AAR_RAM0_Pri0 (0x0UL) /*!< Priority 0. */
+#define AMLI_RAMPRI_AAR_RAM0_Pri2 (0x2UL) /*!< Priority 2. */
+#define AMLI_RAMPRI_AAR_RAM0_Pri4 (0x4UL) /*!< Priority 4. */
+#define AMLI_RAMPRI_AAR_RAM0_Pri6 (0x6UL) /*!< Priority 6. */
+#define AMLI_RAMPRI_AAR_RAM0_Pri8 (0x8UL) /*!< Priority 8. */
+#define AMLI_RAMPRI_AAR_RAM0_Pri10 (0xAUL) /*!< Priority 10. */
+#define AMLI_RAMPRI_AAR_RAM0_Pri12 (0xCUL) /*!< Priority 12. */
+#define AMLI_RAMPRI_AAR_RAM0_Pri14 (0xEUL) /*!< Priority 14. */
+
+
+/* Peripheral: CCM */
+/* Description: AES CCM Mode Encryption. */
+
+/* Register: CCM_SHORTS */
+/* Description: Shortcuts for the CCM. */
+
+/* Bit 0 : Shortcut between ENDKSGEN event and CRYPT task. */
+#define CCM_SHORTS_ENDKSGEN_CRYPT_Pos (0UL) /*!< Position of ENDKSGEN_CRYPT field. */
+#define CCM_SHORTS_ENDKSGEN_CRYPT_Msk (0x1UL << CCM_SHORTS_ENDKSGEN_CRYPT_Pos) /*!< Bit mask of ENDKSGEN_CRYPT field. */
+#define CCM_SHORTS_ENDKSGEN_CRYPT_Disabled (0UL) /*!< Shortcut disabled. */
+#define CCM_SHORTS_ENDKSGEN_CRYPT_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Register: CCM_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 2 : Enable interrupt on ERROR event. */
+#define CCM_INTENSET_ERROR_Pos (2UL) /*!< Position of ERROR field. */
+#define CCM_INTENSET_ERROR_Msk (0x1UL << CCM_INTENSET_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define CCM_INTENSET_ERROR_Disabled (0UL) /*!< Interrupt disabled. */
+#define CCM_INTENSET_ERROR_Enabled (1UL) /*!< Interrupt enabled. */
+#define CCM_INTENSET_ERROR_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on ENDCRYPT event. */
+#define CCM_INTENSET_ENDCRYPT_Pos (1UL) /*!< Position of ENDCRYPT field. */
+#define CCM_INTENSET_ENDCRYPT_Msk (0x1UL << CCM_INTENSET_ENDCRYPT_Pos) /*!< Bit mask of ENDCRYPT field. */
+#define CCM_INTENSET_ENDCRYPT_Disabled (0UL) /*!< Interrupt disabled. */
+#define CCM_INTENSET_ENDCRYPT_Enabled (1UL) /*!< Interrupt enabled. */
+#define CCM_INTENSET_ENDCRYPT_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 0 : Enable interrupt on ENDKSGEN event. */
+#define CCM_INTENSET_ENDKSGEN_Pos (0UL) /*!< Position of ENDKSGEN field. */
+#define CCM_INTENSET_ENDKSGEN_Msk (0x1UL << CCM_INTENSET_ENDKSGEN_Pos) /*!< Bit mask of ENDKSGEN field. */
+#define CCM_INTENSET_ENDKSGEN_Disabled (0UL) /*!< Interrupt disabled. */
+#define CCM_INTENSET_ENDKSGEN_Enabled (1UL) /*!< Interrupt enabled. */
+#define CCM_INTENSET_ENDKSGEN_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: CCM_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 2 : Disable interrupt on ERROR event. */
+#define CCM_INTENCLR_ERROR_Pos (2UL) /*!< Position of ERROR field. */
+#define CCM_INTENCLR_ERROR_Msk (0x1UL << CCM_INTENCLR_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define CCM_INTENCLR_ERROR_Disabled (0UL) /*!< Interrupt disabled. */
+#define CCM_INTENCLR_ERROR_Enabled (1UL) /*!< Interrupt enabled. */
+#define CCM_INTENCLR_ERROR_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on ENDCRYPT event. */
+#define CCM_INTENCLR_ENDCRYPT_Pos (1UL) /*!< Position of ENDCRYPT field. */
+#define CCM_INTENCLR_ENDCRYPT_Msk (0x1UL << CCM_INTENCLR_ENDCRYPT_Pos) /*!< Bit mask of ENDCRYPT field. */
+#define CCM_INTENCLR_ENDCRYPT_Disabled (0UL) /*!< Interrupt disabled. */
+#define CCM_INTENCLR_ENDCRYPT_Enabled (1UL) /*!< Interrupt enabled. */
+#define CCM_INTENCLR_ENDCRYPT_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 0 : Disable interrupt on ENDKSGEN event. */
+#define CCM_INTENCLR_ENDKSGEN_Pos (0UL) /*!< Position of ENDKSGEN field. */
+#define CCM_INTENCLR_ENDKSGEN_Msk (0x1UL << CCM_INTENCLR_ENDKSGEN_Pos) /*!< Bit mask of ENDKSGEN field. */
+#define CCM_INTENCLR_ENDKSGEN_Disabled (0UL) /*!< Interrupt disabled. */
+#define CCM_INTENCLR_ENDKSGEN_Enabled (1UL) /*!< Interrupt enabled. */
+#define CCM_INTENCLR_ENDKSGEN_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: CCM_MICSTATUS */
+/* Description: CCM RX MIC check result. */
+
+/* Bit 0 : Result of the MIC check performed during the previous CCM RX STARTCRYPT */
+#define CCM_MICSTATUS_MICSTATUS_Pos (0UL) /*!< Position of MICSTATUS field. */
+#define CCM_MICSTATUS_MICSTATUS_Msk (0x1UL << CCM_MICSTATUS_MICSTATUS_Pos) /*!< Bit mask of MICSTATUS field. */
+#define CCM_MICSTATUS_MICSTATUS_CheckFailed (0UL) /*!< MIC check failed. */
+#define CCM_MICSTATUS_MICSTATUS_CheckPassed (1UL) /*!< MIC check passed. */
+
+/* Register: CCM_ENABLE */
+/* Description: CCM enable. */
+
+/* Bits 1..0 : CCM enable. */
+#define CCM_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define CCM_ENABLE_ENABLE_Msk (0x3UL << CCM_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define CCM_ENABLE_ENABLE_Disabled (0x00UL) /*!< CCM is disabled. */
+#define CCM_ENABLE_ENABLE_Enabled (0x02UL) /*!< CCM is enabled. */
+
+/* Register: CCM_MODE */
+/* Description: Operation mode. */
+
+/* Bit 0 : CCM mode operation. */
+#define CCM_MODE_MODE_Pos (0UL) /*!< Position of MODE field. */
+#define CCM_MODE_MODE_Msk (0x1UL << CCM_MODE_MODE_Pos) /*!< Bit mask of MODE field. */
+#define CCM_MODE_MODE_Encryption (0UL) /*!< CCM mode TX */
+#define CCM_MODE_MODE_Decryption (1UL) /*!< CCM mode TX */
+
+/* Register: CCM_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define CCM_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define CCM_POWER_POWER_Msk (0x1UL << CCM_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define CCM_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define CCM_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: CLOCK */
+/* Description: Clock control. */
+
+/* Register: CLOCK_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 4 : Enable interrupt on CTTO event. */
+#define CLOCK_INTENSET_CTTO_Pos (4UL) /*!< Position of CTTO field. */
+#define CLOCK_INTENSET_CTTO_Msk (0x1UL << CLOCK_INTENSET_CTTO_Pos) /*!< Bit mask of CTTO field. */
+#define CLOCK_INTENSET_CTTO_Disabled (0UL) /*!< Interrupt disabled. */
+#define CLOCK_INTENSET_CTTO_Enabled (1UL) /*!< Interrupt enabled. */
+#define CLOCK_INTENSET_CTTO_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 3 : Enable interrupt on DONE event. */
+#define CLOCK_INTENSET_DONE_Pos (3UL) /*!< Position of DONE field. */
+#define CLOCK_INTENSET_DONE_Msk (0x1UL << CLOCK_INTENSET_DONE_Pos) /*!< Bit mask of DONE field. */
+#define CLOCK_INTENSET_DONE_Disabled (0UL) /*!< Interrupt disabled. */
+#define CLOCK_INTENSET_DONE_Enabled (1UL) /*!< Interrupt enabled. */
+#define CLOCK_INTENSET_DONE_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on LFCLKSTARTED event. */
+#define CLOCK_INTENSET_LFCLKSTARTED_Pos (1UL) /*!< Position of LFCLKSTARTED field. */
+#define CLOCK_INTENSET_LFCLKSTARTED_Msk (0x1UL << CLOCK_INTENSET_LFCLKSTARTED_Pos) /*!< Bit mask of LFCLKSTARTED field. */
+#define CLOCK_INTENSET_LFCLKSTARTED_Disabled (0UL) /*!< Interrupt disabled. */
+#define CLOCK_INTENSET_LFCLKSTARTED_Enabled (1UL) /*!< Interrupt enabled. */
+#define CLOCK_INTENSET_LFCLKSTARTED_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 0 : Enable interrupt on HFCLKSTARTED event. */
+#define CLOCK_INTENSET_HFCLKSTARTED_Pos (0UL) /*!< Position of HFCLKSTARTED field. */
+#define CLOCK_INTENSET_HFCLKSTARTED_Msk (0x1UL << CLOCK_INTENSET_HFCLKSTARTED_Pos) /*!< Bit mask of HFCLKSTARTED field. */
+#define CLOCK_INTENSET_HFCLKSTARTED_Disabled (0UL) /*!< Interrupt disabled. */
+#define CLOCK_INTENSET_HFCLKSTARTED_Enabled (1UL) /*!< Interrupt enabled. */
+#define CLOCK_INTENSET_HFCLKSTARTED_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: CLOCK_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 4 : Disable interrupt on CTTO event. */
+#define CLOCK_INTENCLR_CTTO_Pos (4UL) /*!< Position of CTTO field. */
+#define CLOCK_INTENCLR_CTTO_Msk (0x1UL << CLOCK_INTENCLR_CTTO_Pos) /*!< Bit mask of CTTO field. */
+#define CLOCK_INTENCLR_CTTO_Disabled (0UL) /*!< Interrupt disabled. */
+#define CLOCK_INTENCLR_CTTO_Enabled (1UL) /*!< Interrupt enabled. */
+#define CLOCK_INTENCLR_CTTO_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 3 : Disable interrupt on DONE event. */
+#define CLOCK_INTENCLR_DONE_Pos (3UL) /*!< Position of DONE field. */
+#define CLOCK_INTENCLR_DONE_Msk (0x1UL << CLOCK_INTENCLR_DONE_Pos) /*!< Bit mask of DONE field. */
+#define CLOCK_INTENCLR_DONE_Disabled (0UL) /*!< Interrupt disabled. */
+#define CLOCK_INTENCLR_DONE_Enabled (1UL) /*!< Interrupt enabled. */
+#define CLOCK_INTENCLR_DONE_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on LFCLKSTARTED event. */
+#define CLOCK_INTENCLR_LFCLKSTARTED_Pos (1UL) /*!< Position of LFCLKSTARTED field. */
+#define CLOCK_INTENCLR_LFCLKSTARTED_Msk (0x1UL << CLOCK_INTENCLR_LFCLKSTARTED_Pos) /*!< Bit mask of LFCLKSTARTED field. */
+#define CLOCK_INTENCLR_LFCLKSTARTED_Disabled (0UL) /*!< Interrupt disabled. */
+#define CLOCK_INTENCLR_LFCLKSTARTED_Enabled (1UL) /*!< Interrupt enabled. */
+#define CLOCK_INTENCLR_LFCLKSTARTED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 0 : Disable interrupt on HFCLKSTARTED event. */
+#define CLOCK_INTENCLR_HFCLKSTARTED_Pos (0UL) /*!< Position of HFCLKSTARTED field. */
+#define CLOCK_INTENCLR_HFCLKSTARTED_Msk (0x1UL << CLOCK_INTENCLR_HFCLKSTARTED_Pos) /*!< Bit mask of HFCLKSTARTED field. */
+#define CLOCK_INTENCLR_HFCLKSTARTED_Disabled (0UL) /*!< Interrupt disabled. */
+#define CLOCK_INTENCLR_HFCLKSTARTED_Enabled (1UL) /*!< Interrupt enabled. */
+#define CLOCK_INTENCLR_HFCLKSTARTED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: CLOCK_HFCLKRUN */
+/* Description: Task HFCLKSTART trigger status. */
+
+/* Bit 0 : Task HFCLKSTART trigger status. */
+#define CLOCK_HFCLKRUN_STATUS_Pos (0UL) /*!< Position of STATUS field. */
+#define CLOCK_HFCLKRUN_STATUS_Msk (0x1UL << CLOCK_HFCLKRUN_STATUS_Pos) /*!< Bit mask of STATUS field. */
+#define CLOCK_HFCLKRUN_STATUS_NotTriggered (0UL) /*!< Task HFCLKSTART has not been triggered. */
+#define CLOCK_HFCLKRUN_STATUS_Triggered (1UL) /*!< Task HFCLKSTART has been triggered. */
+
+/* Register: CLOCK_HFCLKSTAT */
+/* Description: High frequency clock status. */
+
+/* Bit 16 : State for the HFCLK. */
+#define CLOCK_HFCLKSTAT_STATE_Pos (16UL) /*!< Position of STATE field. */
+#define CLOCK_HFCLKSTAT_STATE_Msk (0x1UL << CLOCK_HFCLKSTAT_STATE_Pos) /*!< Bit mask of STATE field. */
+#define CLOCK_HFCLKSTAT_STATE_NotRunning (0UL) /*!< HFCLK clock not running. */
+#define CLOCK_HFCLKSTAT_STATE_Running (1UL) /*!< HFCLK clock running. */
+
+/* Bit 0 : Active clock source for the HF clock. */
+#define CLOCK_HFCLKSTAT_SRC_Pos (0UL) /*!< Position of SRC field. */
+#define CLOCK_HFCLKSTAT_SRC_Msk (0x1UL << CLOCK_HFCLKSTAT_SRC_Pos) /*!< Bit mask of SRC field. */
+#define CLOCK_HFCLKSTAT_SRC_RC (0UL) /*!< Internal 16MHz RC oscillator running and generating the HFCLK clock. */
+#define CLOCK_HFCLKSTAT_SRC_Xtal (1UL) /*!< External 16MHz/32MHz crystal oscillator running and generating the HFCLK clock. */
+
+/* Register: CLOCK_LFCLKRUN */
+/* Description: Task LFCLKSTART triggered status. */
+
+/* Bit 0 : Task LFCLKSTART triggered status. */
+#define CLOCK_LFCLKRUN_STATUS_Pos (0UL) /*!< Position of STATUS field. */
+#define CLOCK_LFCLKRUN_STATUS_Msk (0x1UL << CLOCK_LFCLKRUN_STATUS_Pos) /*!< Bit mask of STATUS field. */
+#define CLOCK_LFCLKRUN_STATUS_NotTriggered (0UL) /*!< Task LFCLKSTART has not been triggered. */
+#define CLOCK_LFCLKRUN_STATUS_Triggered (1UL) /*!< Task LFCLKSTART has been triggered. */
+
+/* Register: CLOCK_LFCLKSTAT */
+/* Description: Low frequency clock status. */
+
+/* Bit 16 : State for the LF clock. */
+#define CLOCK_LFCLKSTAT_STATE_Pos (16UL) /*!< Position of STATE field. */
+#define CLOCK_LFCLKSTAT_STATE_Msk (0x1UL << CLOCK_LFCLKSTAT_STATE_Pos) /*!< Bit mask of STATE field. */
+#define CLOCK_LFCLKSTAT_STATE_NotRunning (0UL) /*!< LFCLK clock not running. */
+#define CLOCK_LFCLKSTAT_STATE_Running (1UL) /*!< LFCLK clock running. */
+
+/* Bits 1..0 : Active clock source for the LF clock. */
+#define CLOCK_LFCLKSTAT_SRC_Pos (0UL) /*!< Position of SRC field. */
+#define CLOCK_LFCLKSTAT_SRC_Msk (0x3UL << CLOCK_LFCLKSTAT_SRC_Pos) /*!< Bit mask of SRC field. */
+#define CLOCK_LFCLKSTAT_SRC_RC (0UL) /*!< Internal 32KiHz RC oscillator running and generating the LFCLK clock. */
+#define CLOCK_LFCLKSTAT_SRC_Xtal (1UL) /*!< External 32KiHz crystal oscillator running and generating the LFCLK clock. */
+#define CLOCK_LFCLKSTAT_SRC_Synth (2UL) /*!< Internal 32KiHz synthesizer from the HFCLK running and generating the LFCLK clock. */
+
+/* Register: CLOCK_LFCLKSRCCOPY */
+/* Description: Clock source for the LFCLK clock, set when task LKCLKSTART is triggered. */
+
+/* Bits 1..0 : Clock source for the LFCLK clock, set when task LKCLKSTART is triggered. */
+#define CLOCK_LFCLKSRCCOPY_SRC_Pos (0UL) /*!< Position of SRC field. */
+#define CLOCK_LFCLKSRCCOPY_SRC_Msk (0x3UL << CLOCK_LFCLKSRCCOPY_SRC_Pos) /*!< Bit mask of SRC field. */
+#define CLOCK_LFCLKSRCCOPY_SRC_RC (0UL) /*!< Internal 32KiHz RC oscillator. */
+#define CLOCK_LFCLKSRCCOPY_SRC_Xtal (1UL) /*!< External 32KiHz crystal. */
+#define CLOCK_LFCLKSRCCOPY_SRC_Synth (2UL) /*!< Internal 32KiHz synthesizer from HFCLK system clock. */
+
+/* Register: CLOCK_LFCLKSRC */
+/* Description: Clock source for the LFCLK clock. */
+
+/* Bits 1..0 : Clock source. */
+#define CLOCK_LFCLKSRC_SRC_Pos (0UL) /*!< Position of SRC field. */
+#define CLOCK_LFCLKSRC_SRC_Msk (0x3UL << CLOCK_LFCLKSRC_SRC_Pos) /*!< Bit mask of SRC field. */
+#define CLOCK_LFCLKSRC_SRC_RC (0UL) /*!< Internal 32KiHz RC oscillator. */
+#define CLOCK_LFCLKSRC_SRC_Xtal (1UL) /*!< External 32KiHz crystal. */
+#define CLOCK_LFCLKSRC_SRC_Synth (2UL) /*!< Internal 32KiHz synthesizer from HFCLK system clock. */
+
+/* Register: CLOCK_CTIV */
+/* Description: Calibration timer interval. */
+
+/* Bits 6..0 : Calibration timer interval in 0.25s resolution. */
+#define CLOCK_CTIV_CTIV_Pos (0UL) /*!< Position of CTIV field. */
+#define CLOCK_CTIV_CTIV_Msk (0x7FUL << CLOCK_CTIV_CTIV_Pos) /*!< Bit mask of CTIV field. */
+
+/* Register: CLOCK_XTALFREQ */
+/* Description: Crystal frequency. */
+
+/* Bits 7..0 : External Xtal frequency selection. */
+#define CLOCK_XTALFREQ_XTALFREQ_Pos (0UL) /*!< Position of XTALFREQ field. */
+#define CLOCK_XTALFREQ_XTALFREQ_Msk (0xFFUL << CLOCK_XTALFREQ_XTALFREQ_Pos) /*!< Bit mask of XTALFREQ field. */
+#define CLOCK_XTALFREQ_XTALFREQ_32MHz (0x00UL) /*!< 32MHz xtal is used as source for the HFCLK oscillator. */
+#define CLOCK_XTALFREQ_XTALFREQ_16MHz (0xFFUL) /*!< 16MHz xtal is used as source for the HFCLK oscillator. */
+
+
+/* Peripheral: ECB */
+/* Description: AES ECB Mode Encryption. */
+
+/* Register: ECB_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 1 : Enable interrupt on ERRORECB event. */
+#define ECB_INTENSET_ERRORECB_Pos (1UL) /*!< Position of ERRORECB field. */
+#define ECB_INTENSET_ERRORECB_Msk (0x1UL << ECB_INTENSET_ERRORECB_Pos) /*!< Bit mask of ERRORECB field. */
+#define ECB_INTENSET_ERRORECB_Disabled (0UL) /*!< Interrupt disabled. */
+#define ECB_INTENSET_ERRORECB_Enabled (1UL) /*!< Interrupt enabled. */
+#define ECB_INTENSET_ERRORECB_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 0 : Enable interrupt on ENDECB event. */
+#define ECB_INTENSET_ENDECB_Pos (0UL) /*!< Position of ENDECB field. */
+#define ECB_INTENSET_ENDECB_Msk (0x1UL << ECB_INTENSET_ENDECB_Pos) /*!< Bit mask of ENDECB field. */
+#define ECB_INTENSET_ENDECB_Disabled (0UL) /*!< Interrupt disabled. */
+#define ECB_INTENSET_ENDECB_Enabled (1UL) /*!< Interrupt enabled. */
+#define ECB_INTENSET_ENDECB_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: ECB_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 1 : Disable interrupt on ERRORECB event. */
+#define ECB_INTENCLR_ERRORECB_Pos (1UL) /*!< Position of ERRORECB field. */
+#define ECB_INTENCLR_ERRORECB_Msk (0x1UL << ECB_INTENCLR_ERRORECB_Pos) /*!< Bit mask of ERRORECB field. */
+#define ECB_INTENCLR_ERRORECB_Disabled (0UL) /*!< Interrupt disabled. */
+#define ECB_INTENCLR_ERRORECB_Enabled (1UL) /*!< Interrupt enabled. */
+#define ECB_INTENCLR_ERRORECB_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 0 : Disable interrupt on ENDECB event. */
+#define ECB_INTENCLR_ENDECB_Pos (0UL) /*!< Position of ENDECB field. */
+#define ECB_INTENCLR_ENDECB_Msk (0x1UL << ECB_INTENCLR_ENDECB_Pos) /*!< Bit mask of ENDECB field. */
+#define ECB_INTENCLR_ENDECB_Disabled (0UL) /*!< Interrupt disabled. */
+#define ECB_INTENCLR_ENDECB_Enabled (1UL) /*!< Interrupt enabled. */
+#define ECB_INTENCLR_ENDECB_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: ECB_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define ECB_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define ECB_POWER_POWER_Msk (0x1UL << ECB_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define ECB_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define ECB_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: FICR */
+/* Description: Factory Information Configuration. */
+
+/* Register: FICR_PPFC */
+/* Description: Pre-programmed factory code present. */
+
+/* Bits 7..0 : Pre-programmed factory code present. */
+#define FICR_PPFC_PPFC_Pos (0UL) /*!< Position of PPFC field. */
+#define FICR_PPFC_PPFC_Msk (0xFFUL << FICR_PPFC_PPFC_Pos) /*!< Bit mask of PPFC field. */
+#define FICR_PPFC_PPFC_Present (0x00UL) /*!< Present. */
+#define FICR_PPFC_PPFC_NotPresent (0xFFUL) /*!< Not present. */
+
+/* Register: FICR_CONFIGID */
+/* Description: Configuration identifier. */
+
+/* Bits 31..16 : Firmware Identification Number pre-loaded into the flash. */
+#define FICR_CONFIGID_FWID_Pos (16UL) /*!< Position of FWID field. */
+#define FICR_CONFIGID_FWID_Msk (0xFFFFUL << FICR_CONFIGID_FWID_Pos) /*!< Bit mask of FWID field. */
+
+/* Bits 15..0 : Hardware Identification Number. */
+#define FICR_CONFIGID_HWID_Pos (0UL) /*!< Position of HWID field. */
+#define FICR_CONFIGID_HWID_Msk (0xFFFFUL << FICR_CONFIGID_HWID_Pos) /*!< Bit mask of HWID field. */
+
+/* Register: FICR_DEVICEADDRTYPE */
+/* Description: Device address type. */
+
+/* Bit 0 : Device address type. */
+#define FICR_DEVICEADDRTYPE_DEVICEADDRTYPE_Pos (0UL) /*!< Position of DEVICEADDRTYPE field. */
+#define FICR_DEVICEADDRTYPE_DEVICEADDRTYPE_Msk (0x1UL << FICR_DEVICEADDRTYPE_DEVICEADDRTYPE_Pos) /*!< Bit mask of DEVICEADDRTYPE field. */
+#define FICR_DEVICEADDRTYPE_DEVICEADDRTYPE_Public (0UL) /*!< Public address. */
+#define FICR_DEVICEADDRTYPE_DEVICEADDRTYPE_Random (1UL) /*!< Random address. */
+
+/* Register: FICR_OVERRIDEEN */
+/* Description: Radio calibration override enable. */
+
+/* Bit 3 : Override default values for BLE_1Mbit mode. */
+#define FICR_OVERRIDEEN_BLE_1MBIT_Pos (3UL) /*!< Position of BLE_1MBIT field. */
+#define FICR_OVERRIDEEN_BLE_1MBIT_Msk (0x1UL << FICR_OVERRIDEEN_BLE_1MBIT_Pos) /*!< Bit mask of BLE_1MBIT field. */
+#define FICR_OVERRIDEEN_BLE_1MBIT_Override (0UL) /*!< Override the default values for BLE_1Mbit mode. */
+#define FICR_OVERRIDEEN_BLE_1MBIT_NotOverride (1UL) /*!< Do not override the default values for BLE_1Mbit mode. */
+
+/* Bit 0 : Override default values for NRF_1Mbit mode. */
+#define FICR_OVERRIDEEN_NRF_1MBIT_Pos (0UL) /*!< Position of NRF_1MBIT field. */
+#define FICR_OVERRIDEEN_NRF_1MBIT_Msk (0x1UL << FICR_OVERRIDEEN_NRF_1MBIT_Pos) /*!< Bit mask of NRF_1MBIT field. */
+#define FICR_OVERRIDEEN_NRF_1MBIT_Override (0UL) /*!< Override the default values for NRF_1Mbit mode. */
+#define FICR_OVERRIDEEN_NRF_1MBIT_NotOverride (1UL) /*!< Do not override the default values for NRF_1Mbit mode. */
+
+
+/* Peripheral: GPIO */
+/* Description: General purpose input and output. */
+
+/* Register: GPIO_OUT */
+/* Description: Write GPIO port. */
+
+/* Bit 31 : Pin 31. */
+#define GPIO_OUT_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_OUT_PIN31_Msk (0x1UL << GPIO_OUT_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_OUT_PIN31_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN31_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 30 : Pin 30. */
+#define GPIO_OUT_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_OUT_PIN30_Msk (0x1UL << GPIO_OUT_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_OUT_PIN30_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN30_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 29 : Pin 29. */
+#define GPIO_OUT_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_OUT_PIN29_Msk (0x1UL << GPIO_OUT_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_OUT_PIN29_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN29_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 28 : Pin 28. */
+#define GPIO_OUT_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_OUT_PIN28_Msk (0x1UL << GPIO_OUT_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_OUT_PIN28_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN28_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 27 : Pin 27. */
+#define GPIO_OUT_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_OUT_PIN27_Msk (0x1UL << GPIO_OUT_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_OUT_PIN27_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN27_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 26 : Pin 26. */
+#define GPIO_OUT_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_OUT_PIN26_Msk (0x1UL << GPIO_OUT_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_OUT_PIN26_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN26_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 25 : Pin 25. */
+#define GPIO_OUT_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_OUT_PIN25_Msk (0x1UL << GPIO_OUT_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_OUT_PIN25_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN25_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 24 : Pin 24. */
+#define GPIO_OUT_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_OUT_PIN24_Msk (0x1UL << GPIO_OUT_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_OUT_PIN24_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN24_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 23 : Pin 23. */
+#define GPIO_OUT_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_OUT_PIN23_Msk (0x1UL << GPIO_OUT_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_OUT_PIN23_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN23_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 22 : Pin 22. */
+#define GPIO_OUT_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_OUT_PIN22_Msk (0x1UL << GPIO_OUT_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_OUT_PIN22_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN22_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 21 : Pin 21. */
+#define GPIO_OUT_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_OUT_PIN21_Msk (0x1UL << GPIO_OUT_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_OUT_PIN21_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN21_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 20 : Pin 20. */
+#define GPIO_OUT_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_OUT_PIN20_Msk (0x1UL << GPIO_OUT_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_OUT_PIN20_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN20_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 19 : Pin 19. */
+#define GPIO_OUT_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_OUT_PIN19_Msk (0x1UL << GPIO_OUT_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_OUT_PIN19_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN19_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 18 : Pin 18. */
+#define GPIO_OUT_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_OUT_PIN18_Msk (0x1UL << GPIO_OUT_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_OUT_PIN18_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN18_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 17 : Pin 17. */
+#define GPIO_OUT_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_OUT_PIN17_Msk (0x1UL << GPIO_OUT_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_OUT_PIN17_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN17_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 16 : Pin 16. */
+#define GPIO_OUT_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_OUT_PIN16_Msk (0x1UL << GPIO_OUT_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_OUT_PIN16_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN16_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 15 : Pin 15. */
+#define GPIO_OUT_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_OUT_PIN15_Msk (0x1UL << GPIO_OUT_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_OUT_PIN15_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN15_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 14 : Pin 14. */
+#define GPIO_OUT_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_OUT_PIN14_Msk (0x1UL << GPIO_OUT_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_OUT_PIN14_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN14_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 13 : Pin 13. */
+#define GPIO_OUT_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_OUT_PIN13_Msk (0x1UL << GPIO_OUT_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_OUT_PIN13_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN13_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 12 : Pin 12. */
+#define GPIO_OUT_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_OUT_PIN12_Msk (0x1UL << GPIO_OUT_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_OUT_PIN12_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN12_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 11 : Pin 11. */
+#define GPIO_OUT_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_OUT_PIN11_Msk (0x1UL << GPIO_OUT_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_OUT_PIN11_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN11_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 10 : Pin 10. */
+#define GPIO_OUT_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_OUT_PIN10_Msk (0x1UL << GPIO_OUT_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_OUT_PIN10_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN10_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 9 : Pin 9. */
+#define GPIO_OUT_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_OUT_PIN9_Msk (0x1UL << GPIO_OUT_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_OUT_PIN9_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN9_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 8 : Pin 8. */
+#define GPIO_OUT_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_OUT_PIN8_Msk (0x1UL << GPIO_OUT_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_OUT_PIN8_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN8_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 7 : Pin 7. */
+#define GPIO_OUT_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_OUT_PIN7_Msk (0x1UL << GPIO_OUT_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_OUT_PIN7_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN7_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 6 : Pin 6. */
+#define GPIO_OUT_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_OUT_PIN6_Msk (0x1UL << GPIO_OUT_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_OUT_PIN6_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN6_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 5 : Pin 5. */
+#define GPIO_OUT_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_OUT_PIN5_Msk (0x1UL << GPIO_OUT_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_OUT_PIN5_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN5_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 4 : Pin 4. */
+#define GPIO_OUT_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_OUT_PIN4_Msk (0x1UL << GPIO_OUT_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_OUT_PIN4_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN4_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 3 : Pin 3. */
+#define GPIO_OUT_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_OUT_PIN3_Msk (0x1UL << GPIO_OUT_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_OUT_PIN3_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN3_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 2 : Pin 2. */
+#define GPIO_OUT_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_OUT_PIN2_Msk (0x1UL << GPIO_OUT_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_OUT_PIN2_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN2_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 1 : Pin 1. */
+#define GPIO_OUT_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_OUT_PIN1_Msk (0x1UL << GPIO_OUT_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_OUT_PIN1_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN1_High (1UL) /*!< Pin driver is high. */
+
+/* Bit 0 : Pin 0. */
+#define GPIO_OUT_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_OUT_PIN0_Msk (0x1UL << GPIO_OUT_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_OUT_PIN0_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUT_PIN0_High (1UL) /*!< Pin driver is high. */
+
+/* Register: GPIO_OUTSET */
+/* Description: Set individual bits in GPIO port. */
+
+/* Bit 31 : Pin 31. */
+#define GPIO_OUTSET_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_OUTSET_PIN31_Msk (0x1UL << GPIO_OUTSET_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_OUTSET_PIN31_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN31_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN31_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 30 : Pin 30. */
+#define GPIO_OUTSET_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_OUTSET_PIN30_Msk (0x1UL << GPIO_OUTSET_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_OUTSET_PIN30_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN30_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN30_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 29 : Pin 29. */
+#define GPIO_OUTSET_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_OUTSET_PIN29_Msk (0x1UL << GPIO_OUTSET_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_OUTSET_PIN29_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN29_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN29_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 28 : Pin 28. */
+#define GPIO_OUTSET_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_OUTSET_PIN28_Msk (0x1UL << GPIO_OUTSET_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_OUTSET_PIN28_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN28_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN28_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 27 : Pin 27. */
+#define GPIO_OUTSET_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_OUTSET_PIN27_Msk (0x1UL << GPIO_OUTSET_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_OUTSET_PIN27_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN27_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN27_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 26 : Pin 26. */
+#define GPIO_OUTSET_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_OUTSET_PIN26_Msk (0x1UL << GPIO_OUTSET_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_OUTSET_PIN26_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN26_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN26_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 25 : Pin 25. */
+#define GPIO_OUTSET_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_OUTSET_PIN25_Msk (0x1UL << GPIO_OUTSET_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_OUTSET_PIN25_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN25_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN25_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 24 : Pin 24. */
+#define GPIO_OUTSET_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_OUTSET_PIN24_Msk (0x1UL << GPIO_OUTSET_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_OUTSET_PIN24_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN24_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN24_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 23 : Pin 23. */
+#define GPIO_OUTSET_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_OUTSET_PIN23_Msk (0x1UL << GPIO_OUTSET_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_OUTSET_PIN23_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN23_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN23_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 22 : Pin 22. */
+#define GPIO_OUTSET_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_OUTSET_PIN22_Msk (0x1UL << GPIO_OUTSET_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_OUTSET_PIN22_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN22_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN22_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 21 : Pin 21. */
+#define GPIO_OUTSET_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_OUTSET_PIN21_Msk (0x1UL << GPIO_OUTSET_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_OUTSET_PIN21_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN21_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN21_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 20 : Pin 20. */
+#define GPIO_OUTSET_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_OUTSET_PIN20_Msk (0x1UL << GPIO_OUTSET_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_OUTSET_PIN20_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN20_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN20_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 19 : Pin 19. */
+#define GPIO_OUTSET_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_OUTSET_PIN19_Msk (0x1UL << GPIO_OUTSET_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_OUTSET_PIN19_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN19_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN19_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 18 : Pin 18. */
+#define GPIO_OUTSET_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_OUTSET_PIN18_Msk (0x1UL << GPIO_OUTSET_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_OUTSET_PIN18_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN18_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN18_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 17 : Pin 17. */
+#define GPIO_OUTSET_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_OUTSET_PIN17_Msk (0x1UL << GPIO_OUTSET_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_OUTSET_PIN17_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN17_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN17_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 16 : Pin 16. */
+#define GPIO_OUTSET_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_OUTSET_PIN16_Msk (0x1UL << GPIO_OUTSET_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_OUTSET_PIN16_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN16_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN16_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 15 : Pin 15. */
+#define GPIO_OUTSET_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_OUTSET_PIN15_Msk (0x1UL << GPIO_OUTSET_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_OUTSET_PIN15_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN15_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN15_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 14 : Pin 14. */
+#define GPIO_OUTSET_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_OUTSET_PIN14_Msk (0x1UL << GPIO_OUTSET_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_OUTSET_PIN14_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN14_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN14_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 13 : Pin 13. */
+#define GPIO_OUTSET_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_OUTSET_PIN13_Msk (0x1UL << GPIO_OUTSET_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_OUTSET_PIN13_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN13_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN13_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 12 : Pin 12. */
+#define GPIO_OUTSET_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_OUTSET_PIN12_Msk (0x1UL << GPIO_OUTSET_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_OUTSET_PIN12_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN12_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN12_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 11 : Pin 11. */
+#define GPIO_OUTSET_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_OUTSET_PIN11_Msk (0x1UL << GPIO_OUTSET_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_OUTSET_PIN11_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN11_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN11_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 10 : Pin 10. */
+#define GPIO_OUTSET_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_OUTSET_PIN10_Msk (0x1UL << GPIO_OUTSET_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_OUTSET_PIN10_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN10_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN10_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 9 : Pin 9. */
+#define GPIO_OUTSET_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_OUTSET_PIN9_Msk (0x1UL << GPIO_OUTSET_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_OUTSET_PIN9_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN9_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN9_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 8 : Pin 8. */
+#define GPIO_OUTSET_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_OUTSET_PIN8_Msk (0x1UL << GPIO_OUTSET_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_OUTSET_PIN8_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN8_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN8_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 7 : Pin 7. */
+#define GPIO_OUTSET_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_OUTSET_PIN7_Msk (0x1UL << GPIO_OUTSET_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_OUTSET_PIN7_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN7_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN7_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 6 : Pin 6. */
+#define GPIO_OUTSET_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_OUTSET_PIN6_Msk (0x1UL << GPIO_OUTSET_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_OUTSET_PIN6_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN6_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN6_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 5 : Pin 5. */
+#define GPIO_OUTSET_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_OUTSET_PIN5_Msk (0x1UL << GPIO_OUTSET_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_OUTSET_PIN5_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN5_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN5_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 4 : Pin 4. */
+#define GPIO_OUTSET_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_OUTSET_PIN4_Msk (0x1UL << GPIO_OUTSET_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_OUTSET_PIN4_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN4_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN4_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 3 : Pin 3. */
+#define GPIO_OUTSET_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_OUTSET_PIN3_Msk (0x1UL << GPIO_OUTSET_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_OUTSET_PIN3_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN3_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN3_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 2 : Pin 2. */
+#define GPIO_OUTSET_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_OUTSET_PIN2_Msk (0x1UL << GPIO_OUTSET_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_OUTSET_PIN2_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN2_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN2_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 1 : Pin 1. */
+#define GPIO_OUTSET_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_OUTSET_PIN1_Msk (0x1UL << GPIO_OUTSET_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_OUTSET_PIN1_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN1_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN1_Set (1UL) /*!< Set pin driver high. */
+
+/* Bit 0 : Pin 0. */
+#define GPIO_OUTSET_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_OUTSET_PIN0_Msk (0x1UL << GPIO_OUTSET_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_OUTSET_PIN0_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTSET_PIN0_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTSET_PIN0_Set (1UL) /*!< Set pin driver high. */
+
+/* Register: GPIO_OUTCLR */
+/* Description: Clear individual bits in GPIO port. */
+
+/* Bit 31 : Pin 31. */
+#define GPIO_OUTCLR_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_OUTCLR_PIN31_Msk (0x1UL << GPIO_OUTCLR_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_OUTCLR_PIN31_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN31_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN31_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 30 : Pin 30. */
+#define GPIO_OUTCLR_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_OUTCLR_PIN30_Msk (0x1UL << GPIO_OUTCLR_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_OUTCLR_PIN30_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN30_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN30_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 29 : Pin 29. */
+#define GPIO_OUTCLR_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_OUTCLR_PIN29_Msk (0x1UL << GPIO_OUTCLR_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_OUTCLR_PIN29_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN29_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN29_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 28 : Pin 28. */
+#define GPIO_OUTCLR_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_OUTCLR_PIN28_Msk (0x1UL << GPIO_OUTCLR_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_OUTCLR_PIN28_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN28_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN28_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 27 : Pin 27. */
+#define GPIO_OUTCLR_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_OUTCLR_PIN27_Msk (0x1UL << GPIO_OUTCLR_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_OUTCLR_PIN27_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN27_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN27_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 26 : Pin 26. */
+#define GPIO_OUTCLR_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_OUTCLR_PIN26_Msk (0x1UL << GPIO_OUTCLR_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_OUTCLR_PIN26_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN26_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN26_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 25 : Pin 25. */
+#define GPIO_OUTCLR_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_OUTCLR_PIN25_Msk (0x1UL << GPIO_OUTCLR_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_OUTCLR_PIN25_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN25_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN25_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 24 : Pin 24. */
+#define GPIO_OUTCLR_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_OUTCLR_PIN24_Msk (0x1UL << GPIO_OUTCLR_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_OUTCLR_PIN24_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN24_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN24_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 23 : Pin 23. */
+#define GPIO_OUTCLR_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_OUTCLR_PIN23_Msk (0x1UL << GPIO_OUTCLR_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_OUTCLR_PIN23_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN23_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN23_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 22 : Pin 22. */
+#define GPIO_OUTCLR_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_OUTCLR_PIN22_Msk (0x1UL << GPIO_OUTCLR_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_OUTCLR_PIN22_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN22_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN22_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 21 : Pin 21. */
+#define GPIO_OUTCLR_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_OUTCLR_PIN21_Msk (0x1UL << GPIO_OUTCLR_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_OUTCLR_PIN21_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN21_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN21_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 20 : Pin 20. */
+#define GPIO_OUTCLR_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_OUTCLR_PIN20_Msk (0x1UL << GPIO_OUTCLR_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_OUTCLR_PIN20_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN20_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN20_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 19 : Pin 19. */
+#define GPIO_OUTCLR_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_OUTCLR_PIN19_Msk (0x1UL << GPIO_OUTCLR_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_OUTCLR_PIN19_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN19_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN19_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 18 : Pin 18. */
+#define GPIO_OUTCLR_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_OUTCLR_PIN18_Msk (0x1UL << GPIO_OUTCLR_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_OUTCLR_PIN18_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN18_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN18_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 17 : Pin 17. */
+#define GPIO_OUTCLR_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_OUTCLR_PIN17_Msk (0x1UL << GPIO_OUTCLR_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_OUTCLR_PIN17_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN17_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN17_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 16 : Pin 16. */
+#define GPIO_OUTCLR_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_OUTCLR_PIN16_Msk (0x1UL << GPIO_OUTCLR_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_OUTCLR_PIN16_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN16_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN16_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 15 : Pin 15. */
+#define GPIO_OUTCLR_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_OUTCLR_PIN15_Msk (0x1UL << GPIO_OUTCLR_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_OUTCLR_PIN15_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN15_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN15_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 14 : Pin 14. */
+#define GPIO_OUTCLR_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_OUTCLR_PIN14_Msk (0x1UL << GPIO_OUTCLR_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_OUTCLR_PIN14_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN14_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN14_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 13 : Pin 13. */
+#define GPIO_OUTCLR_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_OUTCLR_PIN13_Msk (0x1UL << GPIO_OUTCLR_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_OUTCLR_PIN13_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN13_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN13_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 12 : Pin 12. */
+#define GPIO_OUTCLR_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_OUTCLR_PIN12_Msk (0x1UL << GPIO_OUTCLR_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_OUTCLR_PIN12_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN12_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN12_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 11 : Pin 11. */
+#define GPIO_OUTCLR_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_OUTCLR_PIN11_Msk (0x1UL << GPIO_OUTCLR_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_OUTCLR_PIN11_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN11_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN11_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 10 : Pin 10. */
+#define GPIO_OUTCLR_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_OUTCLR_PIN10_Msk (0x1UL << GPIO_OUTCLR_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_OUTCLR_PIN10_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN10_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN10_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 9 : Pin 9. */
+#define GPIO_OUTCLR_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_OUTCLR_PIN9_Msk (0x1UL << GPIO_OUTCLR_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_OUTCLR_PIN9_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN9_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN9_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 8 : Pin 8. */
+#define GPIO_OUTCLR_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_OUTCLR_PIN8_Msk (0x1UL << GPIO_OUTCLR_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_OUTCLR_PIN8_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN8_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN8_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 7 : Pin 7. */
+#define GPIO_OUTCLR_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_OUTCLR_PIN7_Msk (0x1UL << GPIO_OUTCLR_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_OUTCLR_PIN7_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN7_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN7_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 6 : Pin 6. */
+#define GPIO_OUTCLR_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_OUTCLR_PIN6_Msk (0x1UL << GPIO_OUTCLR_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_OUTCLR_PIN6_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN6_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN6_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 5 : Pin 5. */
+#define GPIO_OUTCLR_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_OUTCLR_PIN5_Msk (0x1UL << GPIO_OUTCLR_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_OUTCLR_PIN5_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN5_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN5_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 4 : Pin 4. */
+#define GPIO_OUTCLR_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_OUTCLR_PIN4_Msk (0x1UL << GPIO_OUTCLR_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_OUTCLR_PIN4_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN4_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN4_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 3 : Pin 3. */
+#define GPIO_OUTCLR_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_OUTCLR_PIN3_Msk (0x1UL << GPIO_OUTCLR_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_OUTCLR_PIN3_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN3_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN3_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 2 : Pin 2. */
+#define GPIO_OUTCLR_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_OUTCLR_PIN2_Msk (0x1UL << GPIO_OUTCLR_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_OUTCLR_PIN2_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN2_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN2_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 1 : Pin 1. */
+#define GPIO_OUTCLR_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_OUTCLR_PIN1_Msk (0x1UL << GPIO_OUTCLR_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_OUTCLR_PIN1_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN1_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN1_Clear (1UL) /*!< Set pin driver low. */
+
+/* Bit 0 : Pin 0. */
+#define GPIO_OUTCLR_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_OUTCLR_PIN0_Msk (0x1UL << GPIO_OUTCLR_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_OUTCLR_PIN0_Low (0UL) /*!< Pin driver is low. */
+#define GPIO_OUTCLR_PIN0_High (1UL) /*!< Pin driver is high. */
+#define GPIO_OUTCLR_PIN0_Clear (1UL) /*!< Set pin driver low. */
+
+/* Register: GPIO_IN */
+/* Description: Read GPIO port. */
+
+/* Bit 31 : Pin 31. */
+#define GPIO_IN_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_IN_PIN31_Msk (0x1UL << GPIO_IN_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_IN_PIN31_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN31_High (1UL) /*!< Pin input is high. */
+
+/* Bit 30 : Pin 30. */
+#define GPIO_IN_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_IN_PIN30_Msk (0x1UL << GPIO_IN_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_IN_PIN30_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN30_High (1UL) /*!< Pin input is high. */
+
+/* Bit 29 : Pin 29. */
+#define GPIO_IN_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_IN_PIN29_Msk (0x1UL << GPIO_IN_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_IN_PIN29_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN29_High (1UL) /*!< Pin input is high. */
+
+/* Bit 28 : Pin 28. */
+#define GPIO_IN_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_IN_PIN28_Msk (0x1UL << GPIO_IN_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_IN_PIN28_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN28_High (1UL) /*!< Pin input is high. */
+
+/* Bit 27 : Pin 27. */
+#define GPIO_IN_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_IN_PIN27_Msk (0x1UL << GPIO_IN_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_IN_PIN27_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN27_High (1UL) /*!< Pin input is high. */
+
+/* Bit 26 : Pin 26. */
+#define GPIO_IN_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_IN_PIN26_Msk (0x1UL << GPIO_IN_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_IN_PIN26_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN26_High (1UL) /*!< Pin input is high. */
+
+/* Bit 25 : Pin 25. */
+#define GPIO_IN_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_IN_PIN25_Msk (0x1UL << GPIO_IN_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_IN_PIN25_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN25_High (1UL) /*!< Pin input is high. */
+
+/* Bit 24 : Pin 24. */
+#define GPIO_IN_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_IN_PIN24_Msk (0x1UL << GPIO_IN_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_IN_PIN24_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN24_High (1UL) /*!< Pin input is high. */
+
+/* Bit 23 : Pin 23. */
+#define GPIO_IN_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_IN_PIN23_Msk (0x1UL << GPIO_IN_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_IN_PIN23_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN23_High (1UL) /*!< Pin input is high. */
+
+/* Bit 22 : Pin 22. */
+#define GPIO_IN_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_IN_PIN22_Msk (0x1UL << GPIO_IN_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_IN_PIN22_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN22_High (1UL) /*!< Pin input is high. */
+
+/* Bit 21 : Pin 21. */
+#define GPIO_IN_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_IN_PIN21_Msk (0x1UL << GPIO_IN_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_IN_PIN21_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN21_High (1UL) /*!< Pin input is high. */
+
+/* Bit 20 : Pin 20. */
+#define GPIO_IN_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_IN_PIN20_Msk (0x1UL << GPIO_IN_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_IN_PIN20_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN20_High (1UL) /*!< Pin input is high. */
+
+/* Bit 19 : Pin 19. */
+#define GPIO_IN_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_IN_PIN19_Msk (0x1UL << GPIO_IN_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_IN_PIN19_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN19_High (1UL) /*!< Pin input is high. */
+
+/* Bit 18 : Pin 18. */
+#define GPIO_IN_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_IN_PIN18_Msk (0x1UL << GPIO_IN_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_IN_PIN18_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN18_High (1UL) /*!< Pin input is high. */
+
+/* Bit 17 : Pin 17. */
+#define GPIO_IN_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_IN_PIN17_Msk (0x1UL << GPIO_IN_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_IN_PIN17_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN17_High (1UL) /*!< Pin input is high. */
+
+/* Bit 16 : Pin 16. */
+#define GPIO_IN_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_IN_PIN16_Msk (0x1UL << GPIO_IN_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_IN_PIN16_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN16_High (1UL) /*!< Pin input is high. */
+
+/* Bit 15 : Pin 15. */
+#define GPIO_IN_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_IN_PIN15_Msk (0x1UL << GPIO_IN_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_IN_PIN15_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN15_High (1UL) /*!< Pin input is high. */
+
+/* Bit 14 : Pin 14. */
+#define GPIO_IN_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_IN_PIN14_Msk (0x1UL << GPIO_IN_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_IN_PIN14_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN14_High (1UL) /*!< Pin input is high. */
+
+/* Bit 13 : Pin 13. */
+#define GPIO_IN_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_IN_PIN13_Msk (0x1UL << GPIO_IN_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_IN_PIN13_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN13_High (1UL) /*!< Pin input is high. */
+
+/* Bit 12 : Pin 12. */
+#define GPIO_IN_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_IN_PIN12_Msk (0x1UL << GPIO_IN_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_IN_PIN12_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN12_High (1UL) /*!< Pin input is high. */
+
+/* Bit 11 : Pin 11. */
+#define GPIO_IN_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_IN_PIN11_Msk (0x1UL << GPIO_IN_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_IN_PIN11_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN11_High (1UL) /*!< Pin input is high. */
+
+/* Bit 10 : Pin 10. */
+#define GPIO_IN_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_IN_PIN10_Msk (0x1UL << GPIO_IN_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_IN_PIN10_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN10_High (1UL) /*!< Pin input is high. */
+
+/* Bit 9 : Pin 9. */
+#define GPIO_IN_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_IN_PIN9_Msk (0x1UL << GPIO_IN_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_IN_PIN9_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN9_High (1UL) /*!< Pin input is high. */
+
+/* Bit 8 : Pin 8. */
+#define GPIO_IN_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_IN_PIN8_Msk (0x1UL << GPIO_IN_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_IN_PIN8_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN8_High (1UL) /*!< Pin input is high. */
+
+/* Bit 7 : Pin 7. */
+#define GPIO_IN_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_IN_PIN7_Msk (0x1UL << GPIO_IN_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_IN_PIN7_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN7_High (1UL) /*!< Pin input is high. */
+
+/* Bit 6 : Pin 6. */
+#define GPIO_IN_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_IN_PIN6_Msk (0x1UL << GPIO_IN_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_IN_PIN6_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN6_High (1UL) /*!< Pin input is high. */
+
+/* Bit 5 : Pin 5. */
+#define GPIO_IN_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_IN_PIN5_Msk (0x1UL << GPIO_IN_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_IN_PIN5_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN5_High (1UL) /*!< Pin input is high. */
+
+/* Bit 4 : Pin 4. */
+#define GPIO_IN_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_IN_PIN4_Msk (0x1UL << GPIO_IN_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_IN_PIN4_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN4_High (1UL) /*!< Pin input is high. */
+
+/* Bit 3 : Pin 3. */
+#define GPIO_IN_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_IN_PIN3_Msk (0x1UL << GPIO_IN_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_IN_PIN3_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN3_High (1UL) /*!< Pin input is high. */
+
+/* Bit 2 : Pin 2. */
+#define GPIO_IN_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_IN_PIN2_Msk (0x1UL << GPIO_IN_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_IN_PIN2_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN2_High (1UL) /*!< Pin input is high. */
+
+/* Bit 1 : Pin 1. */
+#define GPIO_IN_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_IN_PIN1_Msk (0x1UL << GPIO_IN_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_IN_PIN1_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN1_High (1UL) /*!< Pin input is high. */
+
+/* Bit 0 : Pin 0. */
+#define GPIO_IN_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_IN_PIN0_Msk (0x1UL << GPIO_IN_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_IN_PIN0_Low (0UL) /*!< Pin input is low. */
+#define GPIO_IN_PIN0_High (1UL) /*!< Pin input is high. */
+
+/* Register: GPIO_DIR */
+/* Description: Direction of GPIO pins. */
+
+/* Bit 31 : Pin 31. */
+#define GPIO_DIR_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_DIR_PIN31_Msk (0x1UL << GPIO_DIR_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_DIR_PIN31_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN31_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 30 : Pin 30. */
+#define GPIO_DIR_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_DIR_PIN30_Msk (0x1UL << GPIO_DIR_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_DIR_PIN30_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN30_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 29 : Pin 29. */
+#define GPIO_DIR_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_DIR_PIN29_Msk (0x1UL << GPIO_DIR_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_DIR_PIN29_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN29_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 28 : Pin 28. */
+#define GPIO_DIR_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_DIR_PIN28_Msk (0x1UL << GPIO_DIR_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_DIR_PIN28_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN28_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 27 : Pin 27. */
+#define GPIO_DIR_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_DIR_PIN27_Msk (0x1UL << GPIO_DIR_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_DIR_PIN27_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN27_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 26 : Pin 26. */
+#define GPIO_DIR_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_DIR_PIN26_Msk (0x1UL << GPIO_DIR_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_DIR_PIN26_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN26_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 25 : Pin 25. */
+#define GPIO_DIR_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_DIR_PIN25_Msk (0x1UL << GPIO_DIR_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_DIR_PIN25_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN25_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 24 : Pin 24. */
+#define GPIO_DIR_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_DIR_PIN24_Msk (0x1UL << GPIO_DIR_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_DIR_PIN24_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN24_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 23 : Pin 23. */
+#define GPIO_DIR_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_DIR_PIN23_Msk (0x1UL << GPIO_DIR_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_DIR_PIN23_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN23_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 22 : Pin 22. */
+#define GPIO_DIR_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_DIR_PIN22_Msk (0x1UL << GPIO_DIR_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_DIR_PIN22_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN22_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 21 : Pin 21. */
+#define GPIO_DIR_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_DIR_PIN21_Msk (0x1UL << GPIO_DIR_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_DIR_PIN21_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN21_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 20 : Pin 20. */
+#define GPIO_DIR_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_DIR_PIN20_Msk (0x1UL << GPIO_DIR_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_DIR_PIN20_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN20_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 19 : Pin 19. */
+#define GPIO_DIR_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_DIR_PIN19_Msk (0x1UL << GPIO_DIR_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_DIR_PIN19_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN19_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 18 : Pin 18. */
+#define GPIO_DIR_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_DIR_PIN18_Msk (0x1UL << GPIO_DIR_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_DIR_PIN18_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN18_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 17 : Pin 17. */
+#define GPIO_DIR_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_DIR_PIN17_Msk (0x1UL << GPIO_DIR_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_DIR_PIN17_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN17_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 16 : Pin 16. */
+#define GPIO_DIR_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_DIR_PIN16_Msk (0x1UL << GPIO_DIR_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_DIR_PIN16_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN16_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 15 : Pin 15. */
+#define GPIO_DIR_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_DIR_PIN15_Msk (0x1UL << GPIO_DIR_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_DIR_PIN15_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN15_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 14 : Pin 14. */
+#define GPIO_DIR_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_DIR_PIN14_Msk (0x1UL << GPIO_DIR_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_DIR_PIN14_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN14_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 13 : Pin 13. */
+#define GPIO_DIR_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_DIR_PIN13_Msk (0x1UL << GPIO_DIR_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_DIR_PIN13_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN13_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 12 : Pin 12. */
+#define GPIO_DIR_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_DIR_PIN12_Msk (0x1UL << GPIO_DIR_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_DIR_PIN12_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN12_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 11 : Pin 11. */
+#define GPIO_DIR_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_DIR_PIN11_Msk (0x1UL << GPIO_DIR_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_DIR_PIN11_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN11_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 10 : Pin 10. */
+#define GPIO_DIR_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_DIR_PIN10_Msk (0x1UL << GPIO_DIR_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_DIR_PIN10_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN10_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 9 : Pin 9. */
+#define GPIO_DIR_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_DIR_PIN9_Msk (0x1UL << GPIO_DIR_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_DIR_PIN9_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN9_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 8 : Pin 8. */
+#define GPIO_DIR_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_DIR_PIN8_Msk (0x1UL << GPIO_DIR_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_DIR_PIN8_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN8_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 7 : Pin 7. */
+#define GPIO_DIR_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_DIR_PIN7_Msk (0x1UL << GPIO_DIR_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_DIR_PIN7_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN7_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 6 : Pin 6. */
+#define GPIO_DIR_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_DIR_PIN6_Msk (0x1UL << GPIO_DIR_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_DIR_PIN6_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN6_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 5 : Pin 5. */
+#define GPIO_DIR_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_DIR_PIN5_Msk (0x1UL << GPIO_DIR_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_DIR_PIN5_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN5_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 4 : Pin 4. */
+#define GPIO_DIR_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_DIR_PIN4_Msk (0x1UL << GPIO_DIR_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_DIR_PIN4_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN4_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 3 : Pin 3. */
+#define GPIO_DIR_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_DIR_PIN3_Msk (0x1UL << GPIO_DIR_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_DIR_PIN3_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN3_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 2 : Pin 2. */
+#define GPIO_DIR_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_DIR_PIN2_Msk (0x1UL << GPIO_DIR_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_DIR_PIN2_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN2_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 1 : Pin 1. */
+#define GPIO_DIR_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_DIR_PIN1_Msk (0x1UL << GPIO_DIR_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_DIR_PIN1_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN1_Output (1UL) /*!< Pin set as output. */
+
+/* Bit 0 : Pin 0. */
+#define GPIO_DIR_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_DIR_PIN0_Msk (0x1UL << GPIO_DIR_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_DIR_PIN0_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIR_PIN0_Output (1UL) /*!< Pin set as output. */
+
+/* Register: GPIO_DIRSET */
+/* Description: DIR set register. */
+
+/* Bit 31 : Set as output pin 31. */
+#define GPIO_DIRSET_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_DIRSET_PIN31_Msk (0x1UL << GPIO_DIRSET_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_DIRSET_PIN31_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN31_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN31_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 30 : Set as output pin 30. */
+#define GPIO_DIRSET_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_DIRSET_PIN30_Msk (0x1UL << GPIO_DIRSET_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_DIRSET_PIN30_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN30_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN30_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 29 : Set as output pin 29. */
+#define GPIO_DIRSET_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_DIRSET_PIN29_Msk (0x1UL << GPIO_DIRSET_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_DIRSET_PIN29_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN29_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN29_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 28 : Set as output pin 28. */
+#define GPIO_DIRSET_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_DIRSET_PIN28_Msk (0x1UL << GPIO_DIRSET_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_DIRSET_PIN28_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN28_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN28_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 27 : Set as output pin 27. */
+#define GPIO_DIRSET_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_DIRSET_PIN27_Msk (0x1UL << GPIO_DIRSET_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_DIRSET_PIN27_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN27_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN27_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 26 : Set as output pin 26. */
+#define GPIO_DIRSET_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_DIRSET_PIN26_Msk (0x1UL << GPIO_DIRSET_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_DIRSET_PIN26_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN26_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN26_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 25 : Set as output pin 25. */
+#define GPIO_DIRSET_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_DIRSET_PIN25_Msk (0x1UL << GPIO_DIRSET_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_DIRSET_PIN25_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN25_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN25_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 24 : Set as output pin 24. */
+#define GPIO_DIRSET_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_DIRSET_PIN24_Msk (0x1UL << GPIO_DIRSET_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_DIRSET_PIN24_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN24_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN24_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 23 : Set as output pin 23. */
+#define GPIO_DIRSET_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_DIRSET_PIN23_Msk (0x1UL << GPIO_DIRSET_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_DIRSET_PIN23_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN23_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN23_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 22 : Set as output pin 22. */
+#define GPIO_DIRSET_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_DIRSET_PIN22_Msk (0x1UL << GPIO_DIRSET_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_DIRSET_PIN22_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN22_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN22_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 21 : Set as output pin 21. */
+#define GPIO_DIRSET_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_DIRSET_PIN21_Msk (0x1UL << GPIO_DIRSET_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_DIRSET_PIN21_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN21_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN21_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 20 : Set as output pin 20. */
+#define GPIO_DIRSET_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_DIRSET_PIN20_Msk (0x1UL << GPIO_DIRSET_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_DIRSET_PIN20_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN20_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN20_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 19 : Set as output pin 19. */
+#define GPIO_DIRSET_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_DIRSET_PIN19_Msk (0x1UL << GPIO_DIRSET_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_DIRSET_PIN19_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN19_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN19_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 18 : Set as output pin 18. */
+#define GPIO_DIRSET_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_DIRSET_PIN18_Msk (0x1UL << GPIO_DIRSET_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_DIRSET_PIN18_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN18_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN18_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 17 : Set as output pin 17. */
+#define GPIO_DIRSET_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_DIRSET_PIN17_Msk (0x1UL << GPIO_DIRSET_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_DIRSET_PIN17_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN17_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN17_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 16 : Set as output pin 16. */
+#define GPIO_DIRSET_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_DIRSET_PIN16_Msk (0x1UL << GPIO_DIRSET_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_DIRSET_PIN16_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN16_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN16_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 15 : Set as output pin 15. */
+#define GPIO_DIRSET_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_DIRSET_PIN15_Msk (0x1UL << GPIO_DIRSET_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_DIRSET_PIN15_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN15_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN15_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 14 : Set as output pin 14. */
+#define GPIO_DIRSET_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_DIRSET_PIN14_Msk (0x1UL << GPIO_DIRSET_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_DIRSET_PIN14_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN14_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN14_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 13 : Set as output pin 13. */
+#define GPIO_DIRSET_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_DIRSET_PIN13_Msk (0x1UL << GPIO_DIRSET_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_DIRSET_PIN13_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN13_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN13_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 12 : Set as output pin 12. */
+#define GPIO_DIRSET_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_DIRSET_PIN12_Msk (0x1UL << GPIO_DIRSET_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_DIRSET_PIN12_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN12_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN12_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 11 : Set as output pin 11. */
+#define GPIO_DIRSET_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_DIRSET_PIN11_Msk (0x1UL << GPIO_DIRSET_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_DIRSET_PIN11_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN11_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN11_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 10 : Set as output pin 10. */
+#define GPIO_DIRSET_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_DIRSET_PIN10_Msk (0x1UL << GPIO_DIRSET_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_DIRSET_PIN10_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN10_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN10_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 9 : Set as output pin 9. */
+#define GPIO_DIRSET_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_DIRSET_PIN9_Msk (0x1UL << GPIO_DIRSET_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_DIRSET_PIN9_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN9_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN9_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 8 : Set as output pin 8. */
+#define GPIO_DIRSET_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_DIRSET_PIN8_Msk (0x1UL << GPIO_DIRSET_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_DIRSET_PIN8_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN8_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN8_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 7 : Set as output pin 7. */
+#define GPIO_DIRSET_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_DIRSET_PIN7_Msk (0x1UL << GPIO_DIRSET_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_DIRSET_PIN7_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN7_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN7_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 6 : Set as output pin 6. */
+#define GPIO_DIRSET_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_DIRSET_PIN6_Msk (0x1UL << GPIO_DIRSET_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_DIRSET_PIN6_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN6_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN6_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 5 : Set as output pin 5. */
+#define GPIO_DIRSET_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_DIRSET_PIN5_Msk (0x1UL << GPIO_DIRSET_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_DIRSET_PIN5_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN5_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN5_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 4 : Set as output pin 4. */
+#define GPIO_DIRSET_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_DIRSET_PIN4_Msk (0x1UL << GPIO_DIRSET_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_DIRSET_PIN4_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN4_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN4_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 3 : Set as output pin 3. */
+#define GPIO_DIRSET_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_DIRSET_PIN3_Msk (0x1UL << GPIO_DIRSET_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_DIRSET_PIN3_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN3_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN3_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 2 : Set as output pin 2. */
+#define GPIO_DIRSET_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_DIRSET_PIN2_Msk (0x1UL << GPIO_DIRSET_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_DIRSET_PIN2_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN2_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN2_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 1 : Set as output pin 1. */
+#define GPIO_DIRSET_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_DIRSET_PIN1_Msk (0x1UL << GPIO_DIRSET_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_DIRSET_PIN1_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN1_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN1_Set (1UL) /*!< Set pin as output. */
+
+/* Bit 0 : Set as output pin 0. */
+#define GPIO_DIRSET_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_DIRSET_PIN0_Msk (0x1UL << GPIO_DIRSET_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_DIRSET_PIN0_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRSET_PIN0_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRSET_PIN0_Set (1UL) /*!< Set pin as output. */
+
+/* Register: GPIO_DIRCLR */
+/* Description: DIR clear register. */
+
+/* Bit 31 : Set as input pin 31. */
+#define GPIO_DIRCLR_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_DIRCLR_PIN31_Msk (0x1UL << GPIO_DIRCLR_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_DIRCLR_PIN31_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN31_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN31_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 30 : Set as input pin 30. */
+#define GPIO_DIRCLR_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_DIRCLR_PIN30_Msk (0x1UL << GPIO_DIRCLR_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_DIRCLR_PIN30_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN30_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN30_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 29 : Set as input pin 29. */
+#define GPIO_DIRCLR_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_DIRCLR_PIN29_Msk (0x1UL << GPIO_DIRCLR_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_DIRCLR_PIN29_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN29_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN29_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 28 : Set as input pin 28. */
+#define GPIO_DIRCLR_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_DIRCLR_PIN28_Msk (0x1UL << GPIO_DIRCLR_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_DIRCLR_PIN28_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN28_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN28_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 27 : Set as input pin 27. */
+#define GPIO_DIRCLR_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_DIRCLR_PIN27_Msk (0x1UL << GPIO_DIRCLR_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_DIRCLR_PIN27_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN27_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN27_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 26 : Set as input pin 26. */
+#define GPIO_DIRCLR_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_DIRCLR_PIN26_Msk (0x1UL << GPIO_DIRCLR_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_DIRCLR_PIN26_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN26_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN26_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 25 : Set as input pin 25. */
+#define GPIO_DIRCLR_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_DIRCLR_PIN25_Msk (0x1UL << GPIO_DIRCLR_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_DIRCLR_PIN25_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN25_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN25_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 24 : Set as input pin 24. */
+#define GPIO_DIRCLR_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_DIRCLR_PIN24_Msk (0x1UL << GPIO_DIRCLR_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_DIRCLR_PIN24_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN24_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN24_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 23 : Set as input pin 23. */
+#define GPIO_DIRCLR_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_DIRCLR_PIN23_Msk (0x1UL << GPIO_DIRCLR_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_DIRCLR_PIN23_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN23_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN23_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 22 : Set as input pin 22. */
+#define GPIO_DIRCLR_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_DIRCLR_PIN22_Msk (0x1UL << GPIO_DIRCLR_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_DIRCLR_PIN22_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN22_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN22_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 21 : Set as input pin 21. */
+#define GPIO_DIRCLR_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_DIRCLR_PIN21_Msk (0x1UL << GPIO_DIRCLR_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_DIRCLR_PIN21_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN21_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN21_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 20 : Set as input pin 20. */
+#define GPIO_DIRCLR_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_DIRCLR_PIN20_Msk (0x1UL << GPIO_DIRCLR_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_DIRCLR_PIN20_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN20_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN20_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 19 : Set as input pin 19. */
+#define GPIO_DIRCLR_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_DIRCLR_PIN19_Msk (0x1UL << GPIO_DIRCLR_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_DIRCLR_PIN19_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN19_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN19_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 18 : Set as input pin 18. */
+#define GPIO_DIRCLR_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_DIRCLR_PIN18_Msk (0x1UL << GPIO_DIRCLR_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_DIRCLR_PIN18_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN18_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN18_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 17 : Set as input pin 17. */
+#define GPIO_DIRCLR_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_DIRCLR_PIN17_Msk (0x1UL << GPIO_DIRCLR_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_DIRCLR_PIN17_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN17_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN17_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 16 : Set as input pin 16. */
+#define GPIO_DIRCLR_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_DIRCLR_PIN16_Msk (0x1UL << GPIO_DIRCLR_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_DIRCLR_PIN16_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN16_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN16_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 15 : Set as input pin 15. */
+#define GPIO_DIRCLR_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_DIRCLR_PIN15_Msk (0x1UL << GPIO_DIRCLR_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_DIRCLR_PIN15_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN15_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN15_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 14 : Set as input pin 14. */
+#define GPIO_DIRCLR_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_DIRCLR_PIN14_Msk (0x1UL << GPIO_DIRCLR_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_DIRCLR_PIN14_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN14_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN14_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 13 : Set as input pin 13. */
+#define GPIO_DIRCLR_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_DIRCLR_PIN13_Msk (0x1UL << GPIO_DIRCLR_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_DIRCLR_PIN13_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN13_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN13_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 12 : Set as input pin 12. */
+#define GPIO_DIRCLR_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_DIRCLR_PIN12_Msk (0x1UL << GPIO_DIRCLR_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_DIRCLR_PIN12_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN12_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN12_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 11 : Set as input pin 11. */
+#define GPIO_DIRCLR_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_DIRCLR_PIN11_Msk (0x1UL << GPIO_DIRCLR_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_DIRCLR_PIN11_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN11_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN11_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 10 : Set as input pin 10. */
+#define GPIO_DIRCLR_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_DIRCLR_PIN10_Msk (0x1UL << GPIO_DIRCLR_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_DIRCLR_PIN10_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN10_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN10_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 9 : Set as input pin 9. */
+#define GPIO_DIRCLR_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_DIRCLR_PIN9_Msk (0x1UL << GPIO_DIRCLR_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_DIRCLR_PIN9_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN9_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN9_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 8 : Set as input pin 8. */
+#define GPIO_DIRCLR_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_DIRCLR_PIN8_Msk (0x1UL << GPIO_DIRCLR_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_DIRCLR_PIN8_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN8_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN8_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 7 : Set as input pin 7. */
+#define GPIO_DIRCLR_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_DIRCLR_PIN7_Msk (0x1UL << GPIO_DIRCLR_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_DIRCLR_PIN7_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN7_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN7_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 6 : Set as input pin 6. */
+#define GPIO_DIRCLR_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_DIRCLR_PIN6_Msk (0x1UL << GPIO_DIRCLR_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_DIRCLR_PIN6_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN6_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN6_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 5 : Set as input pin 5. */
+#define GPIO_DIRCLR_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_DIRCLR_PIN5_Msk (0x1UL << GPIO_DIRCLR_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_DIRCLR_PIN5_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN5_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN5_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 4 : Set as input pin 4. */
+#define GPIO_DIRCLR_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_DIRCLR_PIN4_Msk (0x1UL << GPIO_DIRCLR_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_DIRCLR_PIN4_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN4_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN4_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 3 : Set as input pin 3. */
+#define GPIO_DIRCLR_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_DIRCLR_PIN3_Msk (0x1UL << GPIO_DIRCLR_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_DIRCLR_PIN3_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN3_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN3_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 2 : Set as input pin 2. */
+#define GPIO_DIRCLR_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_DIRCLR_PIN2_Msk (0x1UL << GPIO_DIRCLR_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_DIRCLR_PIN2_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN2_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN2_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 1 : Set as input pin 1. */
+#define GPIO_DIRCLR_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_DIRCLR_PIN1_Msk (0x1UL << GPIO_DIRCLR_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_DIRCLR_PIN1_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN1_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN1_Clear (1UL) /*!< Set pin as input. */
+
+/* Bit 0 : Set as input pin 0. */
+#define GPIO_DIRCLR_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_DIRCLR_PIN0_Msk (0x1UL << GPIO_DIRCLR_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_DIRCLR_PIN0_Input (0UL) /*!< Pin set as input. */
+#define GPIO_DIRCLR_PIN0_Output (1UL) /*!< Pin set as output. */
+#define GPIO_DIRCLR_PIN0_Clear (1UL) /*!< Set pin as input. */
+
+/* Register: GPIO_PIN_CNF */
+/* Description: Configuration of GPIO pins. */
+
+/* Bits 17..16 : Pin sensing mechanism. */
+#define GPIO_PIN_CNF_SENSE_Pos (16UL) /*!< Position of SENSE field. */
+#define GPIO_PIN_CNF_SENSE_Msk (0x3UL << GPIO_PIN_CNF_SENSE_Pos) /*!< Bit mask of SENSE field. */
+#define GPIO_PIN_CNF_SENSE_Disabled (0x00UL) /*!< Disabled. */
+#define GPIO_PIN_CNF_SENSE_High (0x02UL) /*!< Wakeup on high level. */
+#define GPIO_PIN_CNF_SENSE_Low (0x03UL) /*!< Wakeup on low level. */
+
+/* Bits 10..8 : Drive configuration. */
+#define GPIO_PIN_CNF_DRIVE_Pos (8UL) /*!< Position of DRIVE field. */
+#define GPIO_PIN_CNF_DRIVE_Msk (0x7UL << GPIO_PIN_CNF_DRIVE_Pos) /*!< Bit mask of DRIVE field. */
+#define GPIO_PIN_CNF_DRIVE_S0S1 (0x00UL) /*!< Standard '0', Standard '1'. */
+#define GPIO_PIN_CNF_DRIVE_H0S1 (0x01UL) /*!< High '0', Standard '1'. */
+#define GPIO_PIN_CNF_DRIVE_S0H1 (0x02UL) /*!< Standard '0', High '1'. */
+#define GPIO_PIN_CNF_DRIVE_H0H1 (0x03UL) /*!< High '0', High '1'. */
+#define GPIO_PIN_CNF_DRIVE_D0S1 (0x04UL) /*!< Disconnected '0', Standard '1'. */
+#define GPIO_PIN_CNF_DRIVE_D0H1 (0x05UL) /*!< Disconnected '0', High '1'. */
+#define GPIO_PIN_CNF_DRIVE_S0D1 (0x06UL) /*!< Standard '0', Disconnected '1'. */
+#define GPIO_PIN_CNF_DRIVE_H0D1 (0x07UL) /*!< High '0', Disconnected '1'. */
+
+/* Bits 3..2 : Pull-up or -down configuration. */
+#define GPIO_PIN_CNF_PULL_Pos (2UL) /*!< Position of PULL field. */
+#define GPIO_PIN_CNF_PULL_Msk (0x3UL << GPIO_PIN_CNF_PULL_Pos) /*!< Bit mask of PULL field. */
+#define GPIO_PIN_CNF_PULL_Disabled (0x00UL) /*!< No pull. */
+#define GPIO_PIN_CNF_PULL_Pulldown (0x01UL) /*!< Pulldown on pin. */
+#define GPIO_PIN_CNF_PULL_Pullup (0x03UL) /*!< Pullup on pin. */
+
+/* Bit 1 : Connect or disconnect input path. */
+#define GPIO_PIN_CNF_INPUT_Pos (1UL) /*!< Position of INPUT field. */
+#define GPIO_PIN_CNF_INPUT_Msk (0x1UL << GPIO_PIN_CNF_INPUT_Pos) /*!< Bit mask of INPUT field. */
+#define GPIO_PIN_CNF_INPUT_Connect (0UL) /*!< Connect input pin. */
+#define GPIO_PIN_CNF_INPUT_Disconnect (1UL) /*!< Disconnect input pin. */
+
+/* Bit 0 : Pin direction. */
+#define GPIO_PIN_CNF_DIR_Pos (0UL) /*!< Position of DIR field. */
+#define GPIO_PIN_CNF_DIR_Msk (0x1UL << GPIO_PIN_CNF_DIR_Pos) /*!< Bit mask of DIR field. */
+#define GPIO_PIN_CNF_DIR_Input (0UL) /*!< Configure pin as an input pin. */
+#define GPIO_PIN_CNF_DIR_Output (1UL) /*!< Configure pin as an output pin. */
+
+
+/* Peripheral: GPIOTE */
+/* Description: GPIO tasks and events. */
+
+/* Register: GPIOTE_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 31 : Enable interrupt on PORT event. */
+#define GPIOTE_INTENSET_PORT_Pos (31UL) /*!< Position of PORT field. */
+#define GPIOTE_INTENSET_PORT_Msk (0x1UL << GPIOTE_INTENSET_PORT_Pos) /*!< Bit mask of PORT field. */
+#define GPIOTE_INTENSET_PORT_Disabled (0UL) /*!< Interrupt disabled. */
+#define GPIOTE_INTENSET_PORT_Enabled (1UL) /*!< Interrupt enabled. */
+#define GPIOTE_INTENSET_PORT_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 3 : Enable interrupt on IN[3] event. */
+#define GPIOTE_INTENSET_IN3_Pos (3UL) /*!< Position of IN3 field. */
+#define GPIOTE_INTENSET_IN3_Msk (0x1UL << GPIOTE_INTENSET_IN3_Pos) /*!< Bit mask of IN3 field. */
+#define GPIOTE_INTENSET_IN3_Disabled (0UL) /*!< Interrupt disabled. */
+#define GPIOTE_INTENSET_IN3_Enabled (1UL) /*!< Interrupt enabled. */
+#define GPIOTE_INTENSET_IN3_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 2 : Enable interrupt on IN[2] event. */
+#define GPIOTE_INTENSET_IN2_Pos (2UL) /*!< Position of IN2 field. */
+#define GPIOTE_INTENSET_IN2_Msk (0x1UL << GPIOTE_INTENSET_IN2_Pos) /*!< Bit mask of IN2 field. */
+#define GPIOTE_INTENSET_IN2_Disabled (0UL) /*!< Interrupt disabled. */
+#define GPIOTE_INTENSET_IN2_Enabled (1UL) /*!< Interrupt enabled. */
+#define GPIOTE_INTENSET_IN2_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on IN[1] event. */
+#define GPIOTE_INTENSET_IN1_Pos (1UL) /*!< Position of IN1 field. */
+#define GPIOTE_INTENSET_IN1_Msk (0x1UL << GPIOTE_INTENSET_IN1_Pos) /*!< Bit mask of IN1 field. */
+#define GPIOTE_INTENSET_IN1_Disabled (0UL) /*!< Interrupt disabled. */
+#define GPIOTE_INTENSET_IN1_Enabled (1UL) /*!< Interrupt enabled. */
+#define GPIOTE_INTENSET_IN1_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 0 : Enable interrupt on IN[0] event. */
+#define GPIOTE_INTENSET_IN0_Pos (0UL) /*!< Position of IN0 field. */
+#define GPIOTE_INTENSET_IN0_Msk (0x1UL << GPIOTE_INTENSET_IN0_Pos) /*!< Bit mask of IN0 field. */
+#define GPIOTE_INTENSET_IN0_Disabled (0UL) /*!< Interrupt disabled. */
+#define GPIOTE_INTENSET_IN0_Enabled (1UL) /*!< Interrupt enabled. */
+#define GPIOTE_INTENSET_IN0_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: GPIOTE_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 31 : Disable interrupt on PORT event. */
+#define GPIOTE_INTENCLR_PORT_Pos (31UL) /*!< Position of PORT field. */
+#define GPIOTE_INTENCLR_PORT_Msk (0x1UL << GPIOTE_INTENCLR_PORT_Pos) /*!< Bit mask of PORT field. */
+#define GPIOTE_INTENCLR_PORT_Disabled (0UL) /*!< Interrupt disabled. */
+#define GPIOTE_INTENCLR_PORT_Enabled (1UL) /*!< Interrupt enabled. */
+#define GPIOTE_INTENCLR_PORT_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 3 : Disable interrupt on IN[3] event. */
+#define GPIOTE_INTENCLR_IN3_Pos (3UL) /*!< Position of IN3 field. */
+#define GPIOTE_INTENCLR_IN3_Msk (0x1UL << GPIOTE_INTENCLR_IN3_Pos) /*!< Bit mask of IN3 field. */
+#define GPIOTE_INTENCLR_IN3_Disabled (0UL) /*!< Interrupt disabled. */
+#define GPIOTE_INTENCLR_IN3_Enabled (1UL) /*!< Interrupt enabled. */
+#define GPIOTE_INTENCLR_IN3_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 2 : Disable interrupt on IN[2] event. */
+#define GPIOTE_INTENCLR_IN2_Pos (2UL) /*!< Position of IN2 field. */
+#define GPIOTE_INTENCLR_IN2_Msk (0x1UL << GPIOTE_INTENCLR_IN2_Pos) /*!< Bit mask of IN2 field. */
+#define GPIOTE_INTENCLR_IN2_Disabled (0UL) /*!< Interrupt disabled. */
+#define GPIOTE_INTENCLR_IN2_Enabled (1UL) /*!< Interrupt enabled. */
+#define GPIOTE_INTENCLR_IN2_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on IN[1] event. */
+#define GPIOTE_INTENCLR_IN1_Pos (1UL) /*!< Position of IN1 field. */
+#define GPIOTE_INTENCLR_IN1_Msk (0x1UL << GPIOTE_INTENCLR_IN1_Pos) /*!< Bit mask of IN1 field. */
+#define GPIOTE_INTENCLR_IN1_Disabled (0UL) /*!< Interrupt disabled. */
+#define GPIOTE_INTENCLR_IN1_Enabled (1UL) /*!< Interrupt enabled. */
+#define GPIOTE_INTENCLR_IN1_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 0 : Disable interrupt on IN[0] event. */
+#define GPIOTE_INTENCLR_IN0_Pos (0UL) /*!< Position of IN0 field. */
+#define GPIOTE_INTENCLR_IN0_Msk (0x1UL << GPIOTE_INTENCLR_IN0_Pos) /*!< Bit mask of IN0 field. */
+#define GPIOTE_INTENCLR_IN0_Disabled (0UL) /*!< Interrupt disabled. */
+#define GPIOTE_INTENCLR_IN0_Enabled (1UL) /*!< Interrupt enabled. */
+#define GPIOTE_INTENCLR_IN0_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: GPIOTE_CONFIG */
+/* Description: Channel configuration registers. */
+
+/* Bit 20 : Initial value of the output when the GPIOTE channel is configured as a Task. */
+#define GPIOTE_CONFIG_OUTINIT_Pos (20UL) /*!< Position of OUTINIT field. */
+#define GPIOTE_CONFIG_OUTINIT_Msk (0x1UL << GPIOTE_CONFIG_OUTINIT_Pos) /*!< Bit mask of OUTINIT field. */
+#define GPIOTE_CONFIG_OUTINIT_Low (0UL) /*!< Initial low output when in task mode. */
+#define GPIOTE_CONFIG_OUTINIT_High (1UL) /*!< Initial high output when in task mode. */
+
+/* Bits 17..16 : Effects on output when in Task mode, or events on input that generates an event. */
+#define GPIOTE_CONFIG_POLARITY_Pos (16UL) /*!< Position of POLARITY field. */
+#define GPIOTE_CONFIG_POLARITY_Msk (0x3UL << GPIOTE_CONFIG_POLARITY_Pos) /*!< Bit mask of POLARITY field. */
+#define GPIOTE_CONFIG_POLARITY_None (0x00UL) /*!< No task or event. */
+#define GPIOTE_CONFIG_POLARITY_LoToHi (0x01UL) /*!< Low to high. */
+#define GPIOTE_CONFIG_POLARITY_HiToLo (0x02UL) /*!< High to low. */
+#define GPIOTE_CONFIG_POLARITY_Toggle (0x03UL) /*!< Toggle. */
+
+/* Bits 12..8 : Pin select. */
+#define GPIOTE_CONFIG_PSEL_Pos (8UL) /*!< Position of PSEL field. */
+#define GPIOTE_CONFIG_PSEL_Msk (0x1FUL << GPIOTE_CONFIG_PSEL_Pos) /*!< Bit mask of PSEL field. */
+
+/* Bits 1..0 : Mode */
+#define GPIOTE_CONFIG_MODE_Pos (0UL) /*!< Position of MODE field. */
+#define GPIOTE_CONFIG_MODE_Msk (0x3UL << GPIOTE_CONFIG_MODE_Pos) /*!< Bit mask of MODE field. */
+#define GPIOTE_CONFIG_MODE_Disabled (0x00UL) /*!< Disabled. */
+#define GPIOTE_CONFIG_MODE_Event (0x01UL) /*!< Channel configure in event mode. */
+#define GPIOTE_CONFIG_MODE_Task (0x03UL) /*!< Channel configure in task mode. */
+
+/* Register: GPIOTE_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define GPIOTE_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define GPIOTE_POWER_POWER_Msk (0x1UL << GPIOTE_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define GPIOTE_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define GPIOTE_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: LPCOMP */
+/* Description: Low power comparator. */
+
+/* Register: LPCOMP_SHORTS */
+/* Description: Shortcuts for the LPCOMP. */
+
+/* Bit 4 : Shortcut between CROSS event and STOP task. */
+#define LPCOMP_SHORTS_CROSS_STOP_Pos (4UL) /*!< Position of CROSS_STOP field. */
+#define LPCOMP_SHORTS_CROSS_STOP_Msk (0x1UL << LPCOMP_SHORTS_CROSS_STOP_Pos) /*!< Bit mask of CROSS_STOP field. */
+#define LPCOMP_SHORTS_CROSS_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define LPCOMP_SHORTS_CROSS_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 3 : Shortcut between UP event and STOP task. */
+#define LPCOMP_SHORTS_UP_STOP_Pos (3UL) /*!< Position of UP_STOP field. */
+#define LPCOMP_SHORTS_UP_STOP_Msk (0x1UL << LPCOMP_SHORTS_UP_STOP_Pos) /*!< Bit mask of UP_STOP field. */
+#define LPCOMP_SHORTS_UP_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define LPCOMP_SHORTS_UP_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 2 : Shortcut between DOWN event and STOP task. */
+#define LPCOMP_SHORTS_DOWN_STOP_Pos (2UL) /*!< Position of DOWN_STOP field. */
+#define LPCOMP_SHORTS_DOWN_STOP_Msk (0x1UL << LPCOMP_SHORTS_DOWN_STOP_Pos) /*!< Bit mask of DOWN_STOP field. */
+#define LPCOMP_SHORTS_DOWN_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define LPCOMP_SHORTS_DOWN_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 1 : Shortcut between RADY event and STOP task. */
+#define LPCOMP_SHORTS_READY_STOP_Pos (1UL) /*!< Position of READY_STOP field. */
+#define LPCOMP_SHORTS_READY_STOP_Msk (0x1UL << LPCOMP_SHORTS_READY_STOP_Pos) /*!< Bit mask of READY_STOP field. */
+#define LPCOMP_SHORTS_READY_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define LPCOMP_SHORTS_READY_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 0 : Shortcut between READY event and SAMPLE task. */
+#define LPCOMP_SHORTS_READY_SAMPLE_Pos (0UL) /*!< Position of READY_SAMPLE field. */
+#define LPCOMP_SHORTS_READY_SAMPLE_Msk (0x1UL << LPCOMP_SHORTS_READY_SAMPLE_Pos) /*!< Bit mask of READY_SAMPLE field. */
+#define LPCOMP_SHORTS_READY_SAMPLE_Disabled (0UL) /*!< Shortcut disabled. */
+#define LPCOMP_SHORTS_READY_SAMPLE_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Register: LPCOMP_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 3 : Enable interrupt on CROSS event. */
+#define LPCOMP_INTENSET_CROSS_Pos (3UL) /*!< Position of CROSS field. */
+#define LPCOMP_INTENSET_CROSS_Msk (0x1UL << LPCOMP_INTENSET_CROSS_Pos) /*!< Bit mask of CROSS field. */
+#define LPCOMP_INTENSET_CROSS_Disabled (0UL) /*!< Interrupt disabled. */
+#define LPCOMP_INTENSET_CROSS_Enabled (1UL) /*!< Interrupt enabled. */
+#define LPCOMP_INTENSET_CROSS_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 2 : Enable interrupt on UP event. */
+#define LPCOMP_INTENSET_UP_Pos (2UL) /*!< Position of UP field. */
+#define LPCOMP_INTENSET_UP_Msk (0x1UL << LPCOMP_INTENSET_UP_Pos) /*!< Bit mask of UP field. */
+#define LPCOMP_INTENSET_UP_Disabled (0UL) /*!< Interrupt disabled. */
+#define LPCOMP_INTENSET_UP_Enabled (1UL) /*!< Interrupt enabled. */
+#define LPCOMP_INTENSET_UP_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on DOWN event. */
+#define LPCOMP_INTENSET_DOWN_Pos (1UL) /*!< Position of DOWN field. */
+#define LPCOMP_INTENSET_DOWN_Msk (0x1UL << LPCOMP_INTENSET_DOWN_Pos) /*!< Bit mask of DOWN field. */
+#define LPCOMP_INTENSET_DOWN_Disabled (0UL) /*!< Interrupt disabled. */
+#define LPCOMP_INTENSET_DOWN_Enabled (1UL) /*!< Interrupt enabled. */
+#define LPCOMP_INTENSET_DOWN_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 0 : Enable interrupt on READY event. */
+#define LPCOMP_INTENSET_READY_Pos (0UL) /*!< Position of READY field. */
+#define LPCOMP_INTENSET_READY_Msk (0x1UL << LPCOMP_INTENSET_READY_Pos) /*!< Bit mask of READY field. */
+#define LPCOMP_INTENSET_READY_Disabled (0UL) /*!< Interrupt disabled. */
+#define LPCOMP_INTENSET_READY_Enabled (1UL) /*!< Interrupt enabled. */
+#define LPCOMP_INTENSET_READY_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: LPCOMP_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 3 : Disable interrupt on CROSS event. */
+#define LPCOMP_INTENCLR_CROSS_Pos (3UL) /*!< Position of CROSS field. */
+#define LPCOMP_INTENCLR_CROSS_Msk (0x1UL << LPCOMP_INTENCLR_CROSS_Pos) /*!< Bit mask of CROSS field. */
+#define LPCOMP_INTENCLR_CROSS_Disabled (0UL) /*!< Interrupt disabled. */
+#define LPCOMP_INTENCLR_CROSS_Enabled (1UL) /*!< Interrupt enabled. */
+#define LPCOMP_INTENCLR_CROSS_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 2 : Disable interrupt on UP event. */
+#define LPCOMP_INTENCLR_UP_Pos (2UL) /*!< Position of UP field. */
+#define LPCOMP_INTENCLR_UP_Msk (0x1UL << LPCOMP_INTENCLR_UP_Pos) /*!< Bit mask of UP field. */
+#define LPCOMP_INTENCLR_UP_Disabled (0UL) /*!< Interrupt disabled. */
+#define LPCOMP_INTENCLR_UP_Enabled (1UL) /*!< Interrupt enabled. */
+#define LPCOMP_INTENCLR_UP_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on DOWN event. */
+#define LPCOMP_INTENCLR_DOWN_Pos (1UL) /*!< Position of DOWN field. */
+#define LPCOMP_INTENCLR_DOWN_Msk (0x1UL << LPCOMP_INTENCLR_DOWN_Pos) /*!< Bit mask of DOWN field. */
+#define LPCOMP_INTENCLR_DOWN_Disabled (0UL) /*!< Interrupt disabled. */
+#define LPCOMP_INTENCLR_DOWN_Enabled (1UL) /*!< Interrupt enabled. */
+#define LPCOMP_INTENCLR_DOWN_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 0 : Disable interrupt on READY event. */
+#define LPCOMP_INTENCLR_READY_Pos (0UL) /*!< Position of READY field. */
+#define LPCOMP_INTENCLR_READY_Msk (0x1UL << LPCOMP_INTENCLR_READY_Pos) /*!< Bit mask of READY field. */
+#define LPCOMP_INTENCLR_READY_Disabled (0UL) /*!< Interrupt disabled. */
+#define LPCOMP_INTENCLR_READY_Enabled (1UL) /*!< Interrupt enabled. */
+#define LPCOMP_INTENCLR_READY_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: LPCOMP_RESULT */
+/* Description: Result of last compare. */
+
+/* Bit 0 : Result of last compare. Decision point SAMPLE task. */
+#define LPCOMP_RESULT_RESULT_Pos (0UL) /*!< Position of RESULT field. */
+#define LPCOMP_RESULT_RESULT_Msk (0x1UL << LPCOMP_RESULT_RESULT_Pos) /*!< Bit mask of RESULT field. */
+#define LPCOMP_RESULT_RESULT_Bellow (0UL) /*!< Input voltage is bellow the reference threshold. */
+#define LPCOMP_RESULT_RESULT_Above (1UL) /*!< Input voltage is above the reference threshold. */
+
+/* Register: LPCOMP_ENABLE */
+/* Description: Enable the LPCOMP. */
+
+/* Bits 1..0 : Enable or disable LPCOMP. */
+#define LPCOMP_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define LPCOMP_ENABLE_ENABLE_Msk (0x3UL << LPCOMP_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define LPCOMP_ENABLE_ENABLE_Disabled (0x00UL) /*!< Disabled LPCOMP. */
+#define LPCOMP_ENABLE_ENABLE_Enabled (0x01UL) /*!< Enable LPCOMP. */
+
+/* Register: LPCOMP_PSEL */
+/* Description: Input pin select. */
+
+/* Bits 2..0 : Analog input pin select. */
+#define LPCOMP_PSEL_PSEL_Pos (0UL) /*!< Position of PSEL field. */
+#define LPCOMP_PSEL_PSEL_Msk (0x7UL << LPCOMP_PSEL_PSEL_Pos) /*!< Bit mask of PSEL field. */
+#define LPCOMP_PSEL_PSEL_AnalogInput0 (0UL) /*!< Use analog input 0 as analog input. */
+#define LPCOMP_PSEL_PSEL_AnalogInput1 (1UL) /*!< Use analog input 1 as analog input. */
+#define LPCOMP_PSEL_PSEL_AnalogInput2 (2UL) /*!< Use analog input 2 as analog input. */
+#define LPCOMP_PSEL_PSEL_AnalogInput3 (3UL) /*!< Use analog input 3 as analog input. */
+#define LPCOMP_PSEL_PSEL_AnalogInput4 (4UL) /*!< Use analog input 4 as analog input. */
+#define LPCOMP_PSEL_PSEL_AnalogInput5 (5UL) /*!< Use analog input 5 as analog input. */
+#define LPCOMP_PSEL_PSEL_AnalogInput6 (6UL) /*!< Use analog input 6 as analog input. */
+#define LPCOMP_PSEL_PSEL_AnalogInput7 (7UL) /*!< Use analog input 7 as analog input. */
+
+/* Register: LPCOMP_REFSEL */
+/* Description: Reference select. */
+
+/* Bits 2..0 : Reference select. */
+#define LPCOMP_REFSEL_REFSEL_Pos (0UL) /*!< Position of REFSEL field. */
+#define LPCOMP_REFSEL_REFSEL_Msk (0x7UL << LPCOMP_REFSEL_REFSEL_Pos) /*!< Bit mask of REFSEL field. */
+#define LPCOMP_REFSEL_REFSEL_SupplyOneEighthPrescaling (0UL) /*!< Use supply with a 1/8 prescaler as reference. */
+#define LPCOMP_REFSEL_REFSEL_SupplyTwoEighthsPrescaling (1UL) /*!< Use supply with a 2/8 prescaler as reference. */
+#define LPCOMP_REFSEL_REFSEL_SupplyThreeEighthsPrescaling (2UL) /*!< Use supply with a 3/8 prescaler as reference. */
+#define LPCOMP_REFSEL_REFSEL_SupplyFourEighthsPrescaling (3UL) /*!< Use supply with a 4/8 prescaler as reference. */
+#define LPCOMP_REFSEL_REFSEL_SupplyFiveEighthsPrescaling (4UL) /*!< Use supply with a 5/8 prescaler as reference. */
+#define LPCOMP_REFSEL_REFSEL_SupplySixEighthsPrescaling (5UL) /*!< Use supply with a 6/8 prescaler as reference. */
+#define LPCOMP_REFSEL_REFSEL_SupplySevenEighthsPrescaling (6UL) /*!< Use supply with a 7/8 prescaler as reference. */
+#define LPCOMP_REFSEL_REFSEL_ARef (7UL) /*!< Use external analog reference as reference. */
+
+/* Register: LPCOMP_EXTREFSEL */
+/* Description: External reference select. */
+
+/* Bit 0 : External analog reference pin selection. */
+#define LPCOMP_EXTREFSEL_EXTREFSEL_Pos (0UL) /*!< Position of EXTREFSEL field. */
+#define LPCOMP_EXTREFSEL_EXTREFSEL_Msk (0x1UL << LPCOMP_EXTREFSEL_EXTREFSEL_Pos) /*!< Bit mask of EXTREFSEL field. */
+#define LPCOMP_EXTREFSEL_EXTREFSEL_AnalogReference0 (0UL) /*!< Use analog reference 0 as reference. */
+#define LPCOMP_EXTREFSEL_EXTREFSEL_AnalogReference1 (1UL) /*!< Use analog reference 1 as reference. */
+
+/* Register: LPCOMP_ANADETECT */
+/* Description: Analog detect configuration. */
+
+/* Bits 1..0 : Analog detect configuration. */
+#define LPCOMP_ANADETECT_ANADETECT_Pos (0UL) /*!< Position of ANADETECT field. */
+#define LPCOMP_ANADETECT_ANADETECT_Msk (0x3UL << LPCOMP_ANADETECT_ANADETECT_Pos) /*!< Bit mask of ANADETECT field. */
+#define LPCOMP_ANADETECT_ANADETECT_Cross (0UL) /*!< Generate ANADETEC on crossing, both upwards and downwards crossing. */
+#define LPCOMP_ANADETECT_ANADETECT_Up (1UL) /*!< Generate ANADETEC on upwards crossing only. */
+#define LPCOMP_ANADETECT_ANADETECT_Down (2UL) /*!< Generate ANADETEC on downwards crossing only. */
+
+/* Register: LPCOMP_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define LPCOMP_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define LPCOMP_POWER_POWER_Msk (0x1UL << LPCOMP_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define LPCOMP_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define LPCOMP_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: MPU */
+/* Description: Memory Protection Unit. */
+
+/* Register: MPU_PERR0 */
+/* Description: Configuration of peripherals in mpu regions. */
+
+/* Bit 31 : PPI region configuration. */
+#define MPU_PERR0_PPI_Pos (31UL) /*!< Position of PPI field. */
+#define MPU_PERR0_PPI_Msk (0x1UL << MPU_PERR0_PPI_Pos) /*!< Bit mask of PPI field. */
+#define MPU_PERR0_PPI_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_PPI_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 30 : NVMC region configuration. */
+#define MPU_PERR0_NVMC_Pos (30UL) /*!< Position of NVMC field. */
+#define MPU_PERR0_NVMC_Msk (0x1UL << MPU_PERR0_NVMC_Pos) /*!< Bit mask of NVMC field. */
+#define MPU_PERR0_NVMC_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_NVMC_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 19 : LPCOMP region configuration. */
+#define MPU_PERR0_LPCOMP_Pos (19UL) /*!< Position of LPCOMP field. */
+#define MPU_PERR0_LPCOMP_Msk (0x1UL << MPU_PERR0_LPCOMP_Pos) /*!< Bit mask of LPCOMP field. */
+#define MPU_PERR0_LPCOMP_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_LPCOMP_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 18 : QDEC region configuration. */
+#define MPU_PERR0_QDEC_Pos (18UL) /*!< Position of QDEC field. */
+#define MPU_PERR0_QDEC_Msk (0x1UL << MPU_PERR0_QDEC_Pos) /*!< Bit mask of QDEC field. */
+#define MPU_PERR0_QDEC_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_QDEC_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 17 : RTC1 region configuration. */
+#define MPU_PERR0_RTC1_Pos (17UL) /*!< Position of RTC1 field. */
+#define MPU_PERR0_RTC1_Msk (0x1UL << MPU_PERR0_RTC1_Pos) /*!< Bit mask of RTC1 field. */
+#define MPU_PERR0_RTC1_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_RTC1_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 16 : WDT region configuration. */
+#define MPU_PERR0_WDT_Pos (16UL) /*!< Position of WDT field. */
+#define MPU_PERR0_WDT_Msk (0x1UL << MPU_PERR0_WDT_Pos) /*!< Bit mask of WDT field. */
+#define MPU_PERR0_WDT_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_WDT_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 15 : CCM and AAR region configuration. */
+#define MPU_PERR0_CCM_AAR_Pos (15UL) /*!< Position of CCM_AAR field. */
+#define MPU_PERR0_CCM_AAR_Msk (0x1UL << MPU_PERR0_CCM_AAR_Pos) /*!< Bit mask of CCM_AAR field. */
+#define MPU_PERR0_CCM_AAR_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_CCM_AAR_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 14 : ECB region configuration. */
+#define MPU_PERR0_ECB_Pos (14UL) /*!< Position of ECB field. */
+#define MPU_PERR0_ECB_Msk (0x1UL << MPU_PERR0_ECB_Pos) /*!< Bit mask of ECB field. */
+#define MPU_PERR0_ECB_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_ECB_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 13 : RNG region configuration. */
+#define MPU_PERR0_RNG_Pos (13UL) /*!< Position of RNG field. */
+#define MPU_PERR0_RNG_Msk (0x1UL << MPU_PERR0_RNG_Pos) /*!< Bit mask of RNG field. */
+#define MPU_PERR0_RNG_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_RNG_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 12 : TEMP region configuration. */
+#define MPU_PERR0_TEMP_Pos (12UL) /*!< Position of TEMP field. */
+#define MPU_PERR0_TEMP_Msk (0x1UL << MPU_PERR0_TEMP_Pos) /*!< Bit mask of TEMP field. */
+#define MPU_PERR0_TEMP_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_TEMP_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 11 : RTC0 region configuration. */
+#define MPU_PERR0_RTC0_Pos (11UL) /*!< Position of RTC0 field. */
+#define MPU_PERR0_RTC0_Msk (0x1UL << MPU_PERR0_RTC0_Pos) /*!< Bit mask of RTC0 field. */
+#define MPU_PERR0_RTC0_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_RTC0_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 10 : TIMER2 region configuration. */
+#define MPU_PERR0_TIMER2_Pos (10UL) /*!< Position of TIMER2 field. */
+#define MPU_PERR0_TIMER2_Msk (0x1UL << MPU_PERR0_TIMER2_Pos) /*!< Bit mask of TIMER2 field. */
+#define MPU_PERR0_TIMER2_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_TIMER2_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 9 : TIMER1 region configuration. */
+#define MPU_PERR0_TIMER1_Pos (9UL) /*!< Position of TIMER1 field. */
+#define MPU_PERR0_TIMER1_Msk (0x1UL << MPU_PERR0_TIMER1_Pos) /*!< Bit mask of TIMER1 field. */
+#define MPU_PERR0_TIMER1_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_TIMER1_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 8 : TIMER0 region configuration. */
+#define MPU_PERR0_TIMER0_Pos (8UL) /*!< Position of TIMER0 field. */
+#define MPU_PERR0_TIMER0_Msk (0x1UL << MPU_PERR0_TIMER0_Pos) /*!< Bit mask of TIMER0 field. */
+#define MPU_PERR0_TIMER0_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_TIMER0_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 7 : ADC region configuration. */
+#define MPU_PERR0_ADC_Pos (7UL) /*!< Position of ADC field. */
+#define MPU_PERR0_ADC_Msk (0x1UL << MPU_PERR0_ADC_Pos) /*!< Bit mask of ADC field. */
+#define MPU_PERR0_ADC_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_ADC_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 6 : GPIOTE region configuration. */
+#define MPU_PERR0_GPIOTE_Pos (6UL) /*!< Position of GPIOTE field. */
+#define MPU_PERR0_GPIOTE_Msk (0x1UL << MPU_PERR0_GPIOTE_Pos) /*!< Bit mask of GPIOTE field. */
+#define MPU_PERR0_GPIOTE_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_GPIOTE_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 4 : SPI1 and TWI1 region configuration. */
+#define MPU_PERR0_SPI1_TWI1_Pos (4UL) /*!< Position of SPI1_TWI1 field. */
+#define MPU_PERR0_SPI1_TWI1_Msk (0x1UL << MPU_PERR0_SPI1_TWI1_Pos) /*!< Bit mask of SPI1_TWI1 field. */
+#define MPU_PERR0_SPI1_TWI1_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_SPI1_TWI1_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 3 : SPI0 and TWI0 region configuration. */
+#define MPU_PERR0_SPI0_TWI0_Pos (3UL) /*!< Position of SPI0_TWI0 field. */
+#define MPU_PERR0_SPI0_TWI0_Msk (0x1UL << MPU_PERR0_SPI0_TWI0_Pos) /*!< Bit mask of SPI0_TWI0 field. */
+#define MPU_PERR0_SPI0_TWI0_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_SPI0_TWI0_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 2 : UART0 region configuration. */
+#define MPU_PERR0_UART0_Pos (2UL) /*!< Position of UART0 field. */
+#define MPU_PERR0_UART0_Msk (0x1UL << MPU_PERR0_UART0_Pos) /*!< Bit mask of UART0 field. */
+#define MPU_PERR0_UART0_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_UART0_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 1 : RADIO region configuration. */
+#define MPU_PERR0_RADIO_Pos (1UL) /*!< Position of RADIO field. */
+#define MPU_PERR0_RADIO_Msk (0x1UL << MPU_PERR0_RADIO_Pos) /*!< Bit mask of RADIO field. */
+#define MPU_PERR0_RADIO_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_RADIO_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Bit 0 : POWER_CLOCK region configuration. */
+#define MPU_PERR0_POWER_CLOCK_Pos (0UL) /*!< Position of POWER_CLOCK field. */
+#define MPU_PERR0_POWER_CLOCK_Msk (0x1UL << MPU_PERR0_POWER_CLOCK_Pos) /*!< Bit mask of POWER_CLOCK field. */
+#define MPU_PERR0_POWER_CLOCK_InRegion1 (0UL) /*!< Peripheral configured in region 1. */
+#define MPU_PERR0_POWER_CLOCK_InRegion0 (1UL) /*!< Peripheral configured in region 0. */
+
+/* Register: MPU_PROTENSET0 */
+/* Description: Erase and write protection bit enable set register. */
+
+/* Bit 31 : Protection enable for region 31. */
+#define MPU_PROTENSET0_PROTREG31_Pos (31UL) /*!< Position of PROTREG31 field. */
+#define MPU_PROTENSET0_PROTREG31_Msk (0x1UL << MPU_PROTENSET0_PROTREG31_Pos) /*!< Bit mask of PROTREG31 field. */
+#define MPU_PROTENSET0_PROTREG31_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG31_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG31_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 30 : Protection enable for region 30. */
+#define MPU_PROTENSET0_PROTREG30_Pos (30UL) /*!< Position of PROTREG30 field. */
+#define MPU_PROTENSET0_PROTREG30_Msk (0x1UL << MPU_PROTENSET0_PROTREG30_Pos) /*!< Bit mask of PROTREG30 field. */
+#define MPU_PROTENSET0_PROTREG30_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG30_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG30_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 29 : Protection enable for region 29. */
+#define MPU_PROTENSET0_PROTREG29_Pos (29UL) /*!< Position of PROTREG29 field. */
+#define MPU_PROTENSET0_PROTREG29_Msk (0x1UL << MPU_PROTENSET0_PROTREG29_Pos) /*!< Bit mask of PROTREG29 field. */
+#define MPU_PROTENSET0_PROTREG29_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG29_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG29_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 28 : Protection enable for region 28. */
+#define MPU_PROTENSET0_PROTREG28_Pos (28UL) /*!< Position of PROTREG28 field. */
+#define MPU_PROTENSET0_PROTREG28_Msk (0x1UL << MPU_PROTENSET0_PROTREG28_Pos) /*!< Bit mask of PROTREG28 field. */
+#define MPU_PROTENSET0_PROTREG28_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG28_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG28_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 27 : Protection enable for region 27. */
+#define MPU_PROTENSET0_PROTREG27_Pos (27UL) /*!< Position of PROTREG27 field. */
+#define MPU_PROTENSET0_PROTREG27_Msk (0x1UL << MPU_PROTENSET0_PROTREG27_Pos) /*!< Bit mask of PROTREG27 field. */
+#define MPU_PROTENSET0_PROTREG27_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG27_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG27_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 26 : Protection enable for region 26. */
+#define MPU_PROTENSET0_PROTREG26_Pos (26UL) /*!< Position of PROTREG26 field. */
+#define MPU_PROTENSET0_PROTREG26_Msk (0x1UL << MPU_PROTENSET0_PROTREG26_Pos) /*!< Bit mask of PROTREG26 field. */
+#define MPU_PROTENSET0_PROTREG26_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG26_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG26_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 25 : Protection enable for region 25. */
+#define MPU_PROTENSET0_PROTREG25_Pos (25UL) /*!< Position of PROTREG25 field. */
+#define MPU_PROTENSET0_PROTREG25_Msk (0x1UL << MPU_PROTENSET0_PROTREG25_Pos) /*!< Bit mask of PROTREG25 field. */
+#define MPU_PROTENSET0_PROTREG25_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG25_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG25_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 24 : Protection enable for region 24. */
+#define MPU_PROTENSET0_PROTREG24_Pos (24UL) /*!< Position of PROTREG24 field. */
+#define MPU_PROTENSET0_PROTREG24_Msk (0x1UL << MPU_PROTENSET0_PROTREG24_Pos) /*!< Bit mask of PROTREG24 field. */
+#define MPU_PROTENSET0_PROTREG24_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG24_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG24_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 23 : Protection enable for region 23. */
+#define MPU_PROTENSET0_PROTREG23_Pos (23UL) /*!< Position of PROTREG23 field. */
+#define MPU_PROTENSET0_PROTREG23_Msk (0x1UL << MPU_PROTENSET0_PROTREG23_Pos) /*!< Bit mask of PROTREG23 field. */
+#define MPU_PROTENSET0_PROTREG23_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG23_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG23_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 22 : Protection enable for region 22. */
+#define MPU_PROTENSET0_PROTREG22_Pos (22UL) /*!< Position of PROTREG22 field. */
+#define MPU_PROTENSET0_PROTREG22_Msk (0x1UL << MPU_PROTENSET0_PROTREG22_Pos) /*!< Bit mask of PROTREG22 field. */
+#define MPU_PROTENSET0_PROTREG22_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG22_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG22_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 21 : Protection enable for region 21. */
+#define MPU_PROTENSET0_PROTREG21_Pos (21UL) /*!< Position of PROTREG21 field. */
+#define MPU_PROTENSET0_PROTREG21_Msk (0x1UL << MPU_PROTENSET0_PROTREG21_Pos) /*!< Bit mask of PROTREG21 field. */
+#define MPU_PROTENSET0_PROTREG21_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG21_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG21_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 20 : Protection enable for region 20. */
+#define MPU_PROTENSET0_PROTREG20_Pos (20UL) /*!< Position of PROTREG20 field. */
+#define MPU_PROTENSET0_PROTREG20_Msk (0x1UL << MPU_PROTENSET0_PROTREG20_Pos) /*!< Bit mask of PROTREG20 field. */
+#define MPU_PROTENSET0_PROTREG20_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG20_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG20_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 19 : Protection enable for region 19. */
+#define MPU_PROTENSET0_PROTREG19_Pos (19UL) /*!< Position of PROTREG19 field. */
+#define MPU_PROTENSET0_PROTREG19_Msk (0x1UL << MPU_PROTENSET0_PROTREG19_Pos) /*!< Bit mask of PROTREG19 field. */
+#define MPU_PROTENSET0_PROTREG19_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG19_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG19_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 18 : Protection enable for region 18. */
+#define MPU_PROTENSET0_PROTREG18_Pos (18UL) /*!< Position of PROTREG18 field. */
+#define MPU_PROTENSET0_PROTREG18_Msk (0x1UL << MPU_PROTENSET0_PROTREG18_Pos) /*!< Bit mask of PROTREG18 field. */
+#define MPU_PROTENSET0_PROTREG18_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG18_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG18_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 17 : Protection enable for region 17. */
+#define MPU_PROTENSET0_PROTREG17_Pos (17UL) /*!< Position of PROTREG17 field. */
+#define MPU_PROTENSET0_PROTREG17_Msk (0x1UL << MPU_PROTENSET0_PROTREG17_Pos) /*!< Bit mask of PROTREG17 field. */
+#define MPU_PROTENSET0_PROTREG17_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG17_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG17_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 16 : Protection enable for region 16. */
+#define MPU_PROTENSET0_PROTREG16_Pos (16UL) /*!< Position of PROTREG16 field. */
+#define MPU_PROTENSET0_PROTREG16_Msk (0x1UL << MPU_PROTENSET0_PROTREG16_Pos) /*!< Bit mask of PROTREG16 field. */
+#define MPU_PROTENSET0_PROTREG16_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG16_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG16_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 15 : Protection enable for region 15. */
+#define MPU_PROTENSET0_PROTREG15_Pos (15UL) /*!< Position of PROTREG15 field. */
+#define MPU_PROTENSET0_PROTREG15_Msk (0x1UL << MPU_PROTENSET0_PROTREG15_Pos) /*!< Bit mask of PROTREG15 field. */
+#define MPU_PROTENSET0_PROTREG15_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG15_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG15_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 14 : Protection enable for region 14. */
+#define MPU_PROTENSET0_PROTREG14_Pos (14UL) /*!< Position of PROTREG14 field. */
+#define MPU_PROTENSET0_PROTREG14_Msk (0x1UL << MPU_PROTENSET0_PROTREG14_Pos) /*!< Bit mask of PROTREG14 field. */
+#define MPU_PROTENSET0_PROTREG14_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG14_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG14_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 13 : Protection enable for region 13. */
+#define MPU_PROTENSET0_PROTREG13_Pos (13UL) /*!< Position of PROTREG13 field. */
+#define MPU_PROTENSET0_PROTREG13_Msk (0x1UL << MPU_PROTENSET0_PROTREG13_Pos) /*!< Bit mask of PROTREG13 field. */
+#define MPU_PROTENSET0_PROTREG13_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG13_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG13_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 12 : Protection enable for region 12. */
+#define MPU_PROTENSET0_PROTREG12_Pos (12UL) /*!< Position of PROTREG12 field. */
+#define MPU_PROTENSET0_PROTREG12_Msk (0x1UL << MPU_PROTENSET0_PROTREG12_Pos) /*!< Bit mask of PROTREG12 field. */
+#define MPU_PROTENSET0_PROTREG12_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG12_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG12_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 11 : Protection enable for region 11. */
+#define MPU_PROTENSET0_PROTREG11_Pos (11UL) /*!< Position of PROTREG11 field. */
+#define MPU_PROTENSET0_PROTREG11_Msk (0x1UL << MPU_PROTENSET0_PROTREG11_Pos) /*!< Bit mask of PROTREG11 field. */
+#define MPU_PROTENSET0_PROTREG11_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG11_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG11_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 10 : Protection enable for region 10. */
+#define MPU_PROTENSET0_PROTREG10_Pos (10UL) /*!< Position of PROTREG10 field. */
+#define MPU_PROTENSET0_PROTREG10_Msk (0x1UL << MPU_PROTENSET0_PROTREG10_Pos) /*!< Bit mask of PROTREG10 field. */
+#define MPU_PROTENSET0_PROTREG10_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG10_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG10_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 9 : Protection enable for region 9. */
+#define MPU_PROTENSET0_PROTREG9_Pos (9UL) /*!< Position of PROTREG9 field. */
+#define MPU_PROTENSET0_PROTREG9_Msk (0x1UL << MPU_PROTENSET0_PROTREG9_Pos) /*!< Bit mask of PROTREG9 field. */
+#define MPU_PROTENSET0_PROTREG9_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG9_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG9_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 8 : Protection enable for region 8. */
+#define MPU_PROTENSET0_PROTREG8_Pos (8UL) /*!< Position of PROTREG8 field. */
+#define MPU_PROTENSET0_PROTREG8_Msk (0x1UL << MPU_PROTENSET0_PROTREG8_Pos) /*!< Bit mask of PROTREG8 field. */
+#define MPU_PROTENSET0_PROTREG8_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG8_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG8_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 7 : Protection enable for region 7. */
+#define MPU_PROTENSET0_PROTREG7_Pos (7UL) /*!< Position of PROTREG7 field. */
+#define MPU_PROTENSET0_PROTREG7_Msk (0x1UL << MPU_PROTENSET0_PROTREG7_Pos) /*!< Bit mask of PROTREG7 field. */
+#define MPU_PROTENSET0_PROTREG7_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG7_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG7_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 6 : Protection enable for region 6. */
+#define MPU_PROTENSET0_PROTREG6_Pos (6UL) /*!< Position of PROTREG6 field. */
+#define MPU_PROTENSET0_PROTREG6_Msk (0x1UL << MPU_PROTENSET0_PROTREG6_Pos) /*!< Bit mask of PROTREG6 field. */
+#define MPU_PROTENSET0_PROTREG6_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG6_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG6_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 5 : Protection enable for region 5. */
+#define MPU_PROTENSET0_PROTREG5_Pos (5UL) /*!< Position of PROTREG5 field. */
+#define MPU_PROTENSET0_PROTREG5_Msk (0x1UL << MPU_PROTENSET0_PROTREG5_Pos) /*!< Bit mask of PROTREG5 field. */
+#define MPU_PROTENSET0_PROTREG5_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG5_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG5_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 4 : Protection enable for region 4. */
+#define MPU_PROTENSET0_PROTREG4_Pos (4UL) /*!< Position of PROTREG4 field. */
+#define MPU_PROTENSET0_PROTREG4_Msk (0x1UL << MPU_PROTENSET0_PROTREG4_Pos) /*!< Bit mask of PROTREG4 field. */
+#define MPU_PROTENSET0_PROTREG4_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG4_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG4_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 3 : Protection enable for region 3. */
+#define MPU_PROTENSET0_PROTREG3_Pos (3UL) /*!< Position of PROTREG3 field. */
+#define MPU_PROTENSET0_PROTREG3_Msk (0x1UL << MPU_PROTENSET0_PROTREG3_Pos) /*!< Bit mask of PROTREG3 field. */
+#define MPU_PROTENSET0_PROTREG3_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG3_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG3_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 2 : Protection enable for region 2. */
+#define MPU_PROTENSET0_PROTREG2_Pos (2UL) /*!< Position of PROTREG2 field. */
+#define MPU_PROTENSET0_PROTREG2_Msk (0x1UL << MPU_PROTENSET0_PROTREG2_Pos) /*!< Bit mask of PROTREG2 field. */
+#define MPU_PROTENSET0_PROTREG2_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG2_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG2_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 1 : Protection enable for region 1. */
+#define MPU_PROTENSET0_PROTREG1_Pos (1UL) /*!< Position of PROTREG1 field. */
+#define MPU_PROTENSET0_PROTREG1_Msk (0x1UL << MPU_PROTENSET0_PROTREG1_Pos) /*!< Bit mask of PROTREG1 field. */
+#define MPU_PROTENSET0_PROTREG1_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG1_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG1_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 0 : Protection enable for region 0. */
+#define MPU_PROTENSET0_PROTREG0_Pos (0UL) /*!< Position of PROTREG0 field. */
+#define MPU_PROTENSET0_PROTREG0_Msk (0x1UL << MPU_PROTENSET0_PROTREG0_Pos) /*!< Bit mask of PROTREG0 field. */
+#define MPU_PROTENSET0_PROTREG0_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET0_PROTREG0_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET0_PROTREG0_Set (1UL) /*!< Enable protection on write. */
+
+/* Register: MPU_PROTENSET1 */
+/* Description: Erase and write protection bit enable set register. */
+
+/* Bit 31 : Protection enable for region 63. */
+#define MPU_PROTENSET1_PROTREG63_Pos (31UL) /*!< Position of PROTREG63 field. */
+#define MPU_PROTENSET1_PROTREG63_Msk (0x1UL << MPU_PROTENSET1_PROTREG63_Pos) /*!< Bit mask of PROTREG63 field. */
+#define MPU_PROTENSET1_PROTREG63_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG63_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG63_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 30 : Protection enable for region 62. */
+#define MPU_PROTENSET1_PROTREG62_Pos (30UL) /*!< Position of PROTREG62 field. */
+#define MPU_PROTENSET1_PROTREG62_Msk (0x1UL << MPU_PROTENSET1_PROTREG62_Pos) /*!< Bit mask of PROTREG62 field. */
+#define MPU_PROTENSET1_PROTREG62_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG62_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG62_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 29 : Protection enable for region 61. */
+#define MPU_PROTENSET1_PROTREG61_Pos (29UL) /*!< Position of PROTREG61 field. */
+#define MPU_PROTENSET1_PROTREG61_Msk (0x1UL << MPU_PROTENSET1_PROTREG61_Pos) /*!< Bit mask of PROTREG61 field. */
+#define MPU_PROTENSET1_PROTREG61_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG61_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG61_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 28 : Protection enable for region 60. */
+#define MPU_PROTENSET1_PROTREG60_Pos (28UL) /*!< Position of PROTREG60 field. */
+#define MPU_PROTENSET1_PROTREG60_Msk (0x1UL << MPU_PROTENSET1_PROTREG60_Pos) /*!< Bit mask of PROTREG60 field. */
+#define MPU_PROTENSET1_PROTREG60_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG60_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG60_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 27 : Protection enable for region 59. */
+#define MPU_PROTENSET1_PROTREG59_Pos (27UL) /*!< Position of PROTREG59 field. */
+#define MPU_PROTENSET1_PROTREG59_Msk (0x1UL << MPU_PROTENSET1_PROTREG59_Pos) /*!< Bit mask of PROTREG59 field. */
+#define MPU_PROTENSET1_PROTREG59_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG59_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG59_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 26 : Protection enable for region 58. */
+#define MPU_PROTENSET1_PROTREG58_Pos (26UL) /*!< Position of PROTREG58 field. */
+#define MPU_PROTENSET1_PROTREG58_Msk (0x1UL << MPU_PROTENSET1_PROTREG58_Pos) /*!< Bit mask of PROTREG58 field. */
+#define MPU_PROTENSET1_PROTREG58_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG58_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG58_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 25 : Protection enable for region 57. */
+#define MPU_PROTENSET1_PROTREG57_Pos (25UL) /*!< Position of PROTREG57 field. */
+#define MPU_PROTENSET1_PROTREG57_Msk (0x1UL << MPU_PROTENSET1_PROTREG57_Pos) /*!< Bit mask of PROTREG57 field. */
+#define MPU_PROTENSET1_PROTREG57_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG57_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG57_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 24 : Protection enable for region 56. */
+#define MPU_PROTENSET1_PROTREG56_Pos (24UL) /*!< Position of PROTREG56 field. */
+#define MPU_PROTENSET1_PROTREG56_Msk (0x1UL << MPU_PROTENSET1_PROTREG56_Pos) /*!< Bit mask of PROTREG56 field. */
+#define MPU_PROTENSET1_PROTREG56_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG56_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG56_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 23 : Protection enable for region 55. */
+#define MPU_PROTENSET1_PROTREG55_Pos (23UL) /*!< Position of PROTREG55 field. */
+#define MPU_PROTENSET1_PROTREG55_Msk (0x1UL << MPU_PROTENSET1_PROTREG55_Pos) /*!< Bit mask of PROTREG55 field. */
+#define MPU_PROTENSET1_PROTREG55_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG55_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG55_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 22 : Protection enable for region 54. */
+#define MPU_PROTENSET1_PROTREG54_Pos (22UL) /*!< Position of PROTREG54 field. */
+#define MPU_PROTENSET1_PROTREG54_Msk (0x1UL << MPU_PROTENSET1_PROTREG54_Pos) /*!< Bit mask of PROTREG54 field. */
+#define MPU_PROTENSET1_PROTREG54_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG54_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG54_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 21 : Protection enable for region 53. */
+#define MPU_PROTENSET1_PROTREG53_Pos (21UL) /*!< Position of PROTREG53 field. */
+#define MPU_PROTENSET1_PROTREG53_Msk (0x1UL << MPU_PROTENSET1_PROTREG53_Pos) /*!< Bit mask of PROTREG53 field. */
+#define MPU_PROTENSET1_PROTREG53_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG53_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG53_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 20 : Protection enable for region 52. */
+#define MPU_PROTENSET1_PROTREG52_Pos (20UL) /*!< Position of PROTREG52 field. */
+#define MPU_PROTENSET1_PROTREG52_Msk (0x1UL << MPU_PROTENSET1_PROTREG52_Pos) /*!< Bit mask of PROTREG52 field. */
+#define MPU_PROTENSET1_PROTREG52_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG52_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG52_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 19 : Protection enable for region 51. */
+#define MPU_PROTENSET1_PROTREG51_Pos (19UL) /*!< Position of PROTREG51 field. */
+#define MPU_PROTENSET1_PROTREG51_Msk (0x1UL << MPU_PROTENSET1_PROTREG51_Pos) /*!< Bit mask of PROTREG51 field. */
+#define MPU_PROTENSET1_PROTREG51_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG51_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG51_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 18 : Protection enable for region 50. */
+#define MPU_PROTENSET1_PROTREG50_Pos (18UL) /*!< Position of PROTREG50 field. */
+#define MPU_PROTENSET1_PROTREG50_Msk (0x1UL << MPU_PROTENSET1_PROTREG50_Pos) /*!< Bit mask of PROTREG50 field. */
+#define MPU_PROTENSET1_PROTREG50_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG50_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG50_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 17 : Protection enable for region 49. */
+#define MPU_PROTENSET1_PROTREG49_Pos (17UL) /*!< Position of PROTREG49 field. */
+#define MPU_PROTENSET1_PROTREG49_Msk (0x1UL << MPU_PROTENSET1_PROTREG49_Pos) /*!< Bit mask of PROTREG49 field. */
+#define MPU_PROTENSET1_PROTREG49_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG49_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG49_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 16 : Protection enable for region 48. */
+#define MPU_PROTENSET1_PROTREG48_Pos (16UL) /*!< Position of PROTREG48 field. */
+#define MPU_PROTENSET1_PROTREG48_Msk (0x1UL << MPU_PROTENSET1_PROTREG48_Pos) /*!< Bit mask of PROTREG48 field. */
+#define MPU_PROTENSET1_PROTREG48_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG48_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG48_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 15 : Protection enable for region 47. */
+#define MPU_PROTENSET1_PROTREG47_Pos (15UL) /*!< Position of PROTREG47 field. */
+#define MPU_PROTENSET1_PROTREG47_Msk (0x1UL << MPU_PROTENSET1_PROTREG47_Pos) /*!< Bit mask of PROTREG47 field. */
+#define MPU_PROTENSET1_PROTREG47_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG47_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG47_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 14 : Protection enable for region 46. */
+#define MPU_PROTENSET1_PROTREG46_Pos (14UL) /*!< Position of PROTREG46 field. */
+#define MPU_PROTENSET1_PROTREG46_Msk (0x1UL << MPU_PROTENSET1_PROTREG46_Pos) /*!< Bit mask of PROTREG46 field. */
+#define MPU_PROTENSET1_PROTREG46_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG46_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG46_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 13 : Protection enable for region 45. */
+#define MPU_PROTENSET1_PROTREG45_Pos (13UL) /*!< Position of PROTREG45 field. */
+#define MPU_PROTENSET1_PROTREG45_Msk (0x1UL << MPU_PROTENSET1_PROTREG45_Pos) /*!< Bit mask of PROTREG45 field. */
+#define MPU_PROTENSET1_PROTREG45_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG45_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG45_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 12 : Protection enable for region 44. */
+#define MPU_PROTENSET1_PROTREG44_Pos (12UL) /*!< Position of PROTREG44 field. */
+#define MPU_PROTENSET1_PROTREG44_Msk (0x1UL << MPU_PROTENSET1_PROTREG44_Pos) /*!< Bit mask of PROTREG44 field. */
+#define MPU_PROTENSET1_PROTREG44_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG44_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG44_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 11 : Protection enable for region 43. */
+#define MPU_PROTENSET1_PROTREG43_Pos (11UL) /*!< Position of PROTREG43 field. */
+#define MPU_PROTENSET1_PROTREG43_Msk (0x1UL << MPU_PROTENSET1_PROTREG43_Pos) /*!< Bit mask of PROTREG43 field. */
+#define MPU_PROTENSET1_PROTREG43_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG43_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG43_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 10 : Protection enable for region 42. */
+#define MPU_PROTENSET1_PROTREG42_Pos (10UL) /*!< Position of PROTREG42 field. */
+#define MPU_PROTENSET1_PROTREG42_Msk (0x1UL << MPU_PROTENSET1_PROTREG42_Pos) /*!< Bit mask of PROTREG42 field. */
+#define MPU_PROTENSET1_PROTREG42_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG42_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG42_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 9 : Protection enable for region 41. */
+#define MPU_PROTENSET1_PROTREG41_Pos (9UL) /*!< Position of PROTREG41 field. */
+#define MPU_PROTENSET1_PROTREG41_Msk (0x1UL << MPU_PROTENSET1_PROTREG41_Pos) /*!< Bit mask of PROTREG41 field. */
+#define MPU_PROTENSET1_PROTREG41_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG41_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG41_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 8 : Protection enable for region 40. */
+#define MPU_PROTENSET1_PROTREG40_Pos (8UL) /*!< Position of PROTREG40 field. */
+#define MPU_PROTENSET1_PROTREG40_Msk (0x1UL << MPU_PROTENSET1_PROTREG40_Pos) /*!< Bit mask of PROTREG40 field. */
+#define MPU_PROTENSET1_PROTREG40_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG40_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG40_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 7 : Protection enable for region 39. */
+#define MPU_PROTENSET1_PROTREG39_Pos (7UL) /*!< Position of PROTREG39 field. */
+#define MPU_PROTENSET1_PROTREG39_Msk (0x1UL << MPU_PROTENSET1_PROTREG39_Pos) /*!< Bit mask of PROTREG39 field. */
+#define MPU_PROTENSET1_PROTREG39_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG39_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG39_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 6 : Protection enable for region 38. */
+#define MPU_PROTENSET1_PROTREG38_Pos (6UL) /*!< Position of PROTREG38 field. */
+#define MPU_PROTENSET1_PROTREG38_Msk (0x1UL << MPU_PROTENSET1_PROTREG38_Pos) /*!< Bit mask of PROTREG38 field. */
+#define MPU_PROTENSET1_PROTREG38_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG38_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG38_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 5 : Protection enable for region 37. */
+#define MPU_PROTENSET1_PROTREG37_Pos (5UL) /*!< Position of PROTREG37 field. */
+#define MPU_PROTENSET1_PROTREG37_Msk (0x1UL << MPU_PROTENSET1_PROTREG37_Pos) /*!< Bit mask of PROTREG37 field. */
+#define MPU_PROTENSET1_PROTREG37_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG37_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG37_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 4 : Protection enable for region 36. */
+#define MPU_PROTENSET1_PROTREG36_Pos (4UL) /*!< Position of PROTREG36 field. */
+#define MPU_PROTENSET1_PROTREG36_Msk (0x1UL << MPU_PROTENSET1_PROTREG36_Pos) /*!< Bit mask of PROTREG36 field. */
+#define MPU_PROTENSET1_PROTREG36_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG36_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG36_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 3 : Protection enable for region 35. */
+#define MPU_PROTENSET1_PROTREG35_Pos (3UL) /*!< Position of PROTREG35 field. */
+#define MPU_PROTENSET1_PROTREG35_Msk (0x1UL << MPU_PROTENSET1_PROTREG35_Pos) /*!< Bit mask of PROTREG35 field. */
+#define MPU_PROTENSET1_PROTREG35_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG35_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG35_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 2 : Protection enable for region 34. */
+#define MPU_PROTENSET1_PROTREG34_Pos (2UL) /*!< Position of PROTREG34 field. */
+#define MPU_PROTENSET1_PROTREG34_Msk (0x1UL << MPU_PROTENSET1_PROTREG34_Pos) /*!< Bit mask of PROTREG34 field. */
+#define MPU_PROTENSET1_PROTREG34_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG34_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG34_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 1 : Protection enable for region 33. */
+#define MPU_PROTENSET1_PROTREG33_Pos (1UL) /*!< Position of PROTREG33 field. */
+#define MPU_PROTENSET1_PROTREG33_Msk (0x1UL << MPU_PROTENSET1_PROTREG33_Pos) /*!< Bit mask of PROTREG33 field. */
+#define MPU_PROTENSET1_PROTREG33_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG33_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG33_Set (1UL) /*!< Enable protection on write. */
+
+/* Bit 0 : Protection enable for region 32. */
+#define MPU_PROTENSET1_PROTREG32_Pos (0UL) /*!< Position of PROTREG32 field. */
+#define MPU_PROTENSET1_PROTREG32_Msk (0x1UL << MPU_PROTENSET1_PROTREG32_Pos) /*!< Bit mask of PROTREG32 field. */
+#define MPU_PROTENSET1_PROTREG32_Disabled (0UL) /*!< Protection disabled. */
+#define MPU_PROTENSET1_PROTREG32_Enabled (1UL) /*!< Protection enabled. */
+#define MPU_PROTENSET1_PROTREG32_Set (1UL) /*!< Enable protection on write. */
+
+/* Register: MPU_DISABLEINDEBUG */
+/* Description: Disable erase and write protection mechanism in debug mode. */
+
+/* Bit 0 : Disable protection mechanism in debug mode. */
+#define MPU_DISABLEINDEBUG_DISABLEINDEBUG_Pos (0UL) /*!< Position of DISABLEINDEBUG field. */
+#define MPU_DISABLEINDEBUG_DISABLEINDEBUG_Msk (0x1UL << MPU_DISABLEINDEBUG_DISABLEINDEBUG_Pos) /*!< Bit mask of DISABLEINDEBUG field. */
+#define MPU_DISABLEINDEBUG_DISABLEINDEBUG_Enabled (0UL) /*!< Protection enabled. */
+#define MPU_DISABLEINDEBUG_DISABLEINDEBUG_Disabled (1UL) /*!< Protection disabled. */
+
+/* Register: MPU_PROTBLOCKSIZE */
+/* Description: Erase and write protection block size. */
+
+/* Bits 1..0 : Erase and write protection block size. */
+#define MPU_PROTBLOCKSIZE_PROTBLOCKSIZE_Pos (0UL) /*!< Position of PROTBLOCKSIZE field. */
+#define MPU_PROTBLOCKSIZE_PROTBLOCKSIZE_Msk (0x3UL << MPU_PROTBLOCKSIZE_PROTBLOCKSIZE_Pos) /*!< Bit mask of PROTBLOCKSIZE field. */
+#define MPU_PROTBLOCKSIZE_PROTBLOCKSIZE_4k (0UL) /*!< Erase and write protection block size is 4k. */
+
+
+/* Peripheral: NVMC */
+/* Description: Non Volatile Memory Controller. */
+
+/* Register: NVMC_READY */
+/* Description: Ready flag. */
+
+/* Bit 0 : NVMC ready. */
+#define NVMC_READY_READY_Pos (0UL) /*!< Position of READY field. */
+#define NVMC_READY_READY_Msk (0x1UL << NVMC_READY_READY_Pos) /*!< Bit mask of READY field. */
+#define NVMC_READY_READY_Busy (0UL) /*!< NVMC is busy (on-going write or erase operation). */
+#define NVMC_READY_READY_Ready (1UL) /*!< NVMC is ready. */
+
+/* Register: NVMC_CONFIG */
+/* Description: Configuration register. */
+
+/* Bits 1..0 : Program write enable. */
+#define NVMC_CONFIG_WEN_Pos (0UL) /*!< Position of WEN field. */
+#define NVMC_CONFIG_WEN_Msk (0x3UL << NVMC_CONFIG_WEN_Pos) /*!< Bit mask of WEN field. */
+#define NVMC_CONFIG_WEN_Ren (0x00UL) /*!< Read only access. */
+#define NVMC_CONFIG_WEN_Wen (0x01UL) /*!< Write enabled. */
+#define NVMC_CONFIG_WEN_Een (0x02UL) /*!< Erase enabled. */
+
+/* Register: NVMC_ERASEALL */
+/* Description: Register for erasing all non-volatile user memory. */
+
+/* Bit 0 : Starts the erasing of all user NVM (code region 0/1 and UICR registers). */
+#define NVMC_ERASEALL_ERASEALL_Pos (0UL) /*!< Position of ERASEALL field. */
+#define NVMC_ERASEALL_ERASEALL_Msk (0x1UL << NVMC_ERASEALL_ERASEALL_Pos) /*!< Bit mask of ERASEALL field. */
+#define NVMC_ERASEALL_ERASEALL_NoOperation (0UL) /*!< No operation. */
+#define NVMC_ERASEALL_ERASEALL_Erase (1UL) /*!< Start chip erase. */
+
+/* Register: NVMC_ERASEUICR */
+/* Description: Register for start erasing User Information Congfiguration Registers. */
+
+/* Bit 0 : It can only be used when all contents of code region 1 are erased. */
+#define NVMC_ERASEUICR_ERASEUICR_Pos (0UL) /*!< Position of ERASEUICR field. */
+#define NVMC_ERASEUICR_ERASEUICR_Msk (0x1UL << NVMC_ERASEUICR_ERASEUICR_Pos) /*!< Bit mask of ERASEUICR field. */
+#define NVMC_ERASEUICR_ERASEUICR_NoOperation (0UL) /*!< No operation. */
+#define NVMC_ERASEUICR_ERASEUICR_Erase (1UL) /*!< Start UICR erase. */
+
+
+/* Peripheral: POWER */
+/* Description: Power Control. */
+
+/* Register: POWER_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 2 : Enable interrupt on POFWARN event. */
+#define POWER_INTENSET_POFWARN_Pos (2UL) /*!< Position of POFWARN field. */
+#define POWER_INTENSET_POFWARN_Msk (0x1UL << POWER_INTENSET_POFWARN_Pos) /*!< Bit mask of POFWARN field. */
+#define POWER_INTENSET_POFWARN_Disabled (0UL) /*!< Interrupt disabled. */
+#define POWER_INTENSET_POFWARN_Enabled (1UL) /*!< Interrupt enabled. */
+#define POWER_INTENSET_POFWARN_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: POWER_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 2 : Disable interrupt on POFWARN event. */
+#define POWER_INTENCLR_POFWARN_Pos (2UL) /*!< Position of POFWARN field. */
+#define POWER_INTENCLR_POFWARN_Msk (0x1UL << POWER_INTENCLR_POFWARN_Pos) /*!< Bit mask of POFWARN field. */
+#define POWER_INTENCLR_POFWARN_Disabled (0UL) /*!< Interrupt disabled. */
+#define POWER_INTENCLR_POFWARN_Enabled (1UL) /*!< Interrupt enabled. */
+#define POWER_INTENCLR_POFWARN_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: POWER_RESETREAS */
+/* Description: Reset reason. */
+
+/* Bit 18 : Reset from wake-up from OFF mode detected by entering into debug interface mode. */
+#define POWER_RESETREAS_DIF_Pos (18UL) /*!< Position of DIF field. */
+#define POWER_RESETREAS_DIF_Msk (0x1UL << POWER_RESETREAS_DIF_Pos) /*!< Bit mask of DIF field. */
+#define POWER_RESETREAS_DIF_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_DIF_Detected (1UL) /*!< Reset detected. */
+
+/* Bit 17 : Reset from wake-up from OFF mode detected by the use of ANADETECT signal from LPCOMP. */
+#define POWER_RESETREAS_LPCOMP_Pos (17UL) /*!< Position of LPCOMP field. */
+#define POWER_RESETREAS_LPCOMP_Msk (0x1UL << POWER_RESETREAS_LPCOMP_Pos) /*!< Bit mask of LPCOMP field. */
+#define POWER_RESETREAS_LPCOMP_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_LPCOMP_Detected (1UL) /*!< Reset detected. */
+
+/* Bit 16 : Reset from wake-up from OFF mode detected by the use of DETECT signal from GPIO. */
+#define POWER_RESETREAS_OFF_Pos (16UL) /*!< Position of OFF field. */
+#define POWER_RESETREAS_OFF_Msk (0x1UL << POWER_RESETREAS_OFF_Pos) /*!< Bit mask of OFF field. */
+#define POWER_RESETREAS_OFF_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_OFF_Detected (1UL) /*!< Reset detected. */
+
+/* Bit 3 : Reset from CPU lock-up detected. */
+#define POWER_RESETREAS_LOCKUP_Pos (3UL) /*!< Position of LOCKUP field. */
+#define POWER_RESETREAS_LOCKUP_Msk (0x1UL << POWER_RESETREAS_LOCKUP_Pos) /*!< Bit mask of LOCKUP field. */
+#define POWER_RESETREAS_LOCKUP_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_LOCKUP_Detected (1UL) /*!< Reset detected. */
+
+/* Bit 2 : Reset from AIRCR.SYSRESETREQ detected. */
+#define POWER_RESETREAS_SREQ_Pos (2UL) /*!< Position of SREQ field. */
+#define POWER_RESETREAS_SREQ_Msk (0x1UL << POWER_RESETREAS_SREQ_Pos) /*!< Bit mask of SREQ field. */
+#define POWER_RESETREAS_SREQ_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_SREQ_Detected (1UL) /*!< Reset detected. */
+
+/* Bit 1 : Reset from watchdog detected. */
+#define POWER_RESETREAS_DOG_Pos (1UL) /*!< Position of DOG field. */
+#define POWER_RESETREAS_DOG_Msk (0x1UL << POWER_RESETREAS_DOG_Pos) /*!< Bit mask of DOG field. */
+#define POWER_RESETREAS_DOG_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_DOG_Detected (1UL) /*!< Reset detected. */
+
+/* Bit 0 : Reset from pin-reset detected. */
+#define POWER_RESETREAS_RESETPIN_Pos (0UL) /*!< Position of RESETPIN field. */
+#define POWER_RESETREAS_RESETPIN_Msk (0x1UL << POWER_RESETREAS_RESETPIN_Pos) /*!< Bit mask of RESETPIN field. */
+#define POWER_RESETREAS_RESETPIN_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_RESETPIN_Detected (1UL) /*!< Reset detected. */
+
+/* Register: POWER_RAMSTATUS */
+/* Description: Ram status register. */
+
+/* Bit 3 : RAM block 3 status. */
+#define POWER_RAMSTATUS_RAMBLOCK3_Pos (3UL) /*!< Position of RAMBLOCK3 field. */
+#define POWER_RAMSTATUS_RAMBLOCK3_Msk (0x1UL << POWER_RAMSTATUS_RAMBLOCK3_Pos) /*!< Bit mask of RAMBLOCK3 field. */
+#define POWER_RAMSTATUS_RAMBLOCK3_Off (0UL) /*!< RAM block 3 is off or powering up. */
+#define POWER_RAMSTATUS_RAMBLOCK3_On (1UL) /*!< RAM block 3 is on. */
+
+/* Bit 2 : RAM block 2 status. */
+#define POWER_RAMSTATUS_RAMBLOCK2_Pos (2UL) /*!< Position of RAMBLOCK2 field. */
+#define POWER_RAMSTATUS_RAMBLOCK2_Msk (0x1UL << POWER_RAMSTATUS_RAMBLOCK2_Pos) /*!< Bit mask of RAMBLOCK2 field. */
+#define POWER_RAMSTATUS_RAMBLOCK2_Off (0UL) /*!< RAM block 2 is off or powering up. */
+#define POWER_RAMSTATUS_RAMBLOCK2_On (1UL) /*!< RAM block 2 is on. */
+
+/* Bit 1 : RAM block 1 status. */
+#define POWER_RAMSTATUS_RAMBLOCK1_Pos (1UL) /*!< Position of RAMBLOCK1 field. */
+#define POWER_RAMSTATUS_RAMBLOCK1_Msk (0x1UL << POWER_RAMSTATUS_RAMBLOCK1_Pos) /*!< Bit mask of RAMBLOCK1 field. */
+#define POWER_RAMSTATUS_RAMBLOCK1_Off (0UL) /*!< RAM block 1 is off or powering up. */
+#define POWER_RAMSTATUS_RAMBLOCK1_On (1UL) /*!< RAM block 1 is on. */
+
+/* Bit 0 : RAM block 0 status. */
+#define POWER_RAMSTATUS_RAMBLOCK0_Pos (0UL) /*!< Position of RAMBLOCK0 field. */
+#define POWER_RAMSTATUS_RAMBLOCK0_Msk (0x1UL << POWER_RAMSTATUS_RAMBLOCK0_Pos) /*!< Bit mask of RAMBLOCK0 field. */
+#define POWER_RAMSTATUS_RAMBLOCK0_Off (0UL) /*!< RAM block 0 is off or powering up. */
+#define POWER_RAMSTATUS_RAMBLOCK0_On (1UL) /*!< RAM block 0 is on. */
+
+/* Register: POWER_SYSTEMOFF */
+/* Description: System off register. */
+
+/* Bit 0 : Enter system off mode. */
+#define POWER_SYSTEMOFF_SYSTEMOFF_Pos (0UL) /*!< Position of SYSTEMOFF field. */
+#define POWER_SYSTEMOFF_SYSTEMOFF_Msk (0x1UL << POWER_SYSTEMOFF_SYSTEMOFF_Pos) /*!< Bit mask of SYSTEMOFF field. */
+#define POWER_SYSTEMOFF_SYSTEMOFF_Enter (1UL) /*!< Enter system off mode. */
+
+/* Register: POWER_POFCON */
+/* Description: Power failure configuration. */
+
+/* Bits 2..1 : Set threshold level. */
+#define POWER_POFCON_THRESHOLD_Pos (1UL) /*!< Position of THRESHOLD field. */
+#define POWER_POFCON_THRESHOLD_Msk (0x3UL << POWER_POFCON_THRESHOLD_Pos) /*!< Bit mask of THRESHOLD field. */
+#define POWER_POFCON_THRESHOLD_V21 (0x00UL) /*!< Set threshold to 2.1Volts. */
+#define POWER_POFCON_THRESHOLD_V23 (0x01UL) /*!< Set threshold to 2.3Volts. */
+#define POWER_POFCON_THRESHOLD_V25 (0x02UL) /*!< Set threshold to 2.5Volts. */
+#define POWER_POFCON_THRESHOLD_V27 (0x03UL) /*!< Set threshold to 2.7Volts. */
+
+/* Bit 0 : Power failure comparator enable. */
+#define POWER_POFCON_POF_Pos (0UL) /*!< Position of POF field. */
+#define POWER_POFCON_POF_Msk (0x1UL << POWER_POFCON_POF_Pos) /*!< Bit mask of POF field. */
+#define POWER_POFCON_POF_Disabled (0UL) /*!< Disabled. */
+#define POWER_POFCON_POF_Enabled (1UL) /*!< Enabled. */
+
+/* Register: POWER_GPREGRET */
+/* Description: General purpose retention register. This register is a retained register. */
+
+/* Bits 7..0 : General purpose retention register. */
+#define POWER_GPREGRET_GPREGRET_Pos (0UL) /*!< Position of GPREGRET field. */
+#define POWER_GPREGRET_GPREGRET_Msk (0xFFUL << POWER_GPREGRET_GPREGRET_Pos) /*!< Bit mask of GPREGRET field. */
+
+/* Register: POWER_RAMON */
+/* Description: Ram on/off. */
+
+/* Bit 17 : RAM block 1 behaviour in OFF mode. */
+#define POWER_RAMON_OFFRAM1_Pos (17UL) /*!< Position of OFFRAM1 field. */
+#define POWER_RAMON_OFFRAM1_Msk (0x1UL << POWER_RAMON_OFFRAM1_Pos) /*!< Bit mask of OFFRAM1 field. */
+#define POWER_RAMON_OFFRAM1_RAM1Off (0UL) /*!< RAM block 1 OFF in OFF mode. */
+#define POWER_RAMON_OFFRAM1_RAM1On (1UL) /*!< RAM block 1 ON in OFF mode. */
+
+/* Bit 16 : RAM block 0 behaviour in OFF mode. */
+#define POWER_RAMON_OFFRAM0_Pos (16UL) /*!< Position of OFFRAM0 field. */
+#define POWER_RAMON_OFFRAM0_Msk (0x1UL << POWER_RAMON_OFFRAM0_Pos) /*!< Bit mask of OFFRAM0 field. */
+#define POWER_RAMON_OFFRAM0_RAM0Off (0UL) /*!< RAM block 0 OFF in OFF mode. */
+#define POWER_RAMON_OFFRAM0_RAM0On (1UL) /*!< RAM block 0 ON in OFF mode. */
+
+/* Bit 1 : RAM block 1 behaviour in ON mode. */
+#define POWER_RAMON_ONRAM1_Pos (1UL) /*!< Position of ONRAM1 field. */
+#define POWER_RAMON_ONRAM1_Msk (0x1UL << POWER_RAMON_ONRAM1_Pos) /*!< Bit mask of ONRAM1 field. */
+#define POWER_RAMON_ONRAM1_RAM1Off (0UL) /*!< RAM block 1 OFF in ON mode. */
+#define POWER_RAMON_ONRAM1_RAM1On (1UL) /*!< RAM block 1 ON in ON mode. */
+
+/* Bit 0 : RAM block 0 behaviour in ON mode. */
+#define POWER_RAMON_ONRAM0_Pos (0UL) /*!< Position of ONRAM0 field. */
+#define POWER_RAMON_ONRAM0_Msk (0x1UL << POWER_RAMON_ONRAM0_Pos) /*!< Bit mask of ONRAM0 field. */
+#define POWER_RAMON_ONRAM0_RAM0Off (0UL) /*!< RAM block 0 OFF in ON mode. */
+#define POWER_RAMON_ONRAM0_RAM0On (1UL) /*!< RAM block 0 ON in ON mode. */
+
+/* Register: POWER_RESET */
+/* Description: Pin reset functionality configuration register. This register is a retained register. */
+
+/* Bit 0 : Enable or disable pin reset in debug interface mode. */
+#define POWER_RESET_RESET_Pos (0UL) /*!< Position of RESET field. */
+#define POWER_RESET_RESET_Msk (0x1UL << POWER_RESET_RESET_Pos) /*!< Bit mask of RESET field. */
+#define POWER_RESET_RESET_Disabled (0UL) /*!< Pin reset in debug interface mode disabled. */
+#define POWER_RESET_RESET_Enabled (1UL) /*!< Pin reset in debug interface mode enabled. */
+
+/* Register: POWER_RAMONB */
+/* Description: Ram on/off. */
+
+/* Bit 17 : RAM block 3 behaviour in OFF mode. */
+#define POWER_RAMONB_OFFRAM3_Pos (17UL) /*!< Position of OFFRAM3 field. */
+#define POWER_RAMONB_OFFRAM3_Msk (0x1UL << POWER_RAMONB_OFFRAM3_Pos) /*!< Bit mask of OFFRAM3 field. */
+#define POWER_RAMONB_OFFRAM3_RAM3Off (0UL) /*!< RAM block 3 OFF in OFF mode. */
+#define POWER_RAMONB_OFFRAM3_RAM3On (1UL) /*!< RAM block 3 ON in OFF mode. */
+
+/* Bit 16 : RAM block 2 behaviour in OFF mode. */
+#define POWER_RAMONB_OFFRAM2_Pos (16UL) /*!< Position of OFFRAM2 field. */
+#define POWER_RAMONB_OFFRAM2_Msk (0x1UL << POWER_RAMONB_OFFRAM2_Pos) /*!< Bit mask of OFFRAM2 field. */
+#define POWER_RAMONB_OFFRAM2_RAM2Off (0UL) /*!< RAM block 2 OFF in OFF mode. */
+#define POWER_RAMONB_OFFRAM2_RAM2On (1UL) /*!< RAM block 2 ON in OFF mode. */
+
+/* Bit 1 : RAM block 3 behaviour in ON mode. */
+#define POWER_RAMONB_ONRAM3_Pos (1UL) /*!< Position of ONRAM3 field. */
+#define POWER_RAMONB_ONRAM3_Msk (0x1UL << POWER_RAMONB_ONRAM3_Pos) /*!< Bit mask of ONRAM3 field. */
+#define POWER_RAMONB_ONRAM3_RAM3Off (0UL) /*!< RAM block 33 OFF in ON mode. */
+#define POWER_RAMONB_ONRAM3_RAM3On (1UL) /*!< RAM block 3 ON in ON mode. */
+
+/* Bit 0 : RAM block 2 behaviour in ON mode. */
+#define POWER_RAMONB_ONRAM2_Pos (0UL) /*!< Position of ONRAM2 field. */
+#define POWER_RAMONB_ONRAM2_Msk (0x1UL << POWER_RAMONB_ONRAM2_Pos) /*!< Bit mask of ONRAM2 field. */
+#define POWER_RAMONB_ONRAM2_RAM2Off (0UL) /*!< RAM block 2 OFF in ON mode. */
+#define POWER_RAMONB_ONRAM2_RAM2On (1UL) /*!< RAM block 2 ON in ON mode. */
+
+/* Register: POWER_DCDCEN */
+/* Description: DCDC converter enable configuration register. */
+
+/* Bit 0 : Enable DCDC converter. */
+#define POWER_DCDCEN_DCDCEN_Pos (0UL) /*!< Position of DCDCEN field. */
+#define POWER_DCDCEN_DCDCEN_Msk (0x1UL << POWER_DCDCEN_DCDCEN_Pos) /*!< Bit mask of DCDCEN field. */
+#define POWER_DCDCEN_DCDCEN_Disabled (0UL) /*!< DCDC converter disabled. */
+#define POWER_DCDCEN_DCDCEN_Enabled (1UL) /*!< DCDC converter enabled. */
+
+/* Register: POWER_DCDCFORCE */
+/* Description: DCDC power-up force register. */
+
+/* Bit 1 : DCDC power-up force on. */
+#define POWER_DCDCFORCE_FORCEON_Pos (1UL) /*!< Position of FORCEON field. */
+#define POWER_DCDCFORCE_FORCEON_Msk (0x1UL << POWER_DCDCFORCE_FORCEON_Pos) /*!< Bit mask of FORCEON field. */
+#define POWER_DCDCFORCE_FORCEON_NoForce (0UL) /*!< No force. */
+#define POWER_DCDCFORCE_FORCEON_Force (1UL) /*!< Force. */
+
+/* Bit 0 : DCDC power-up force off. */
+#define POWER_DCDCFORCE_FORCEOFF_Pos (0UL) /*!< Position of FORCEOFF field. */
+#define POWER_DCDCFORCE_FORCEOFF_Msk (0x1UL << POWER_DCDCFORCE_FORCEOFF_Pos) /*!< Bit mask of FORCEOFF field. */
+#define POWER_DCDCFORCE_FORCEOFF_NoForce (0UL) /*!< No force. */
+#define POWER_DCDCFORCE_FORCEOFF_Force (1UL) /*!< Force. */
+
+
+/* Peripheral: PPI */
+/* Description: PPI controller. */
+
+/* Register: PPI_CHEN */
+/* Description: Channel enable. */
+
+/* Bit 31 : Enable PPI channel 31. */
+#define PPI_CHEN_CH31_Pos (31UL) /*!< Position of CH31 field. */
+#define PPI_CHEN_CH31_Msk (0x1UL << PPI_CHEN_CH31_Pos) /*!< Bit mask of CH31 field. */
+#define PPI_CHEN_CH31_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH31_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 30 : Enable PPI channel 30. */
+#define PPI_CHEN_CH30_Pos (30UL) /*!< Position of CH30 field. */
+#define PPI_CHEN_CH30_Msk (0x1UL << PPI_CHEN_CH30_Pos) /*!< Bit mask of CH30 field. */
+#define PPI_CHEN_CH30_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH30_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 29 : Enable PPI channel 29. */
+#define PPI_CHEN_CH29_Pos (29UL) /*!< Position of CH29 field. */
+#define PPI_CHEN_CH29_Msk (0x1UL << PPI_CHEN_CH29_Pos) /*!< Bit mask of CH29 field. */
+#define PPI_CHEN_CH29_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH29_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 28 : Enable PPI channel 28. */
+#define PPI_CHEN_CH28_Pos (28UL) /*!< Position of CH28 field. */
+#define PPI_CHEN_CH28_Msk (0x1UL << PPI_CHEN_CH28_Pos) /*!< Bit mask of CH28 field. */
+#define PPI_CHEN_CH28_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH28_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 27 : Enable PPI channel 27. */
+#define PPI_CHEN_CH27_Pos (27UL) /*!< Position of CH27 field. */
+#define PPI_CHEN_CH27_Msk (0x1UL << PPI_CHEN_CH27_Pos) /*!< Bit mask of CH27 field. */
+#define PPI_CHEN_CH27_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH27_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 26 : Enable PPI channel 26. */
+#define PPI_CHEN_CH26_Pos (26UL) /*!< Position of CH26 field. */
+#define PPI_CHEN_CH26_Msk (0x1UL << PPI_CHEN_CH26_Pos) /*!< Bit mask of CH26 field. */
+#define PPI_CHEN_CH26_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH26_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 25 : Enable PPI channel 25. */
+#define PPI_CHEN_CH25_Pos (25UL) /*!< Position of CH25 field. */
+#define PPI_CHEN_CH25_Msk (0x1UL << PPI_CHEN_CH25_Pos) /*!< Bit mask of CH25 field. */
+#define PPI_CHEN_CH25_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH25_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 24 : Enable PPI channel 24. */
+#define PPI_CHEN_CH24_Pos (24UL) /*!< Position of CH24 field. */
+#define PPI_CHEN_CH24_Msk (0x1UL << PPI_CHEN_CH24_Pos) /*!< Bit mask of CH24 field. */
+#define PPI_CHEN_CH24_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH24_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 23 : Enable PPI channel 23. */
+#define PPI_CHEN_CH23_Pos (23UL) /*!< Position of CH23 field. */
+#define PPI_CHEN_CH23_Msk (0x1UL << PPI_CHEN_CH23_Pos) /*!< Bit mask of CH23 field. */
+#define PPI_CHEN_CH23_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH23_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 22 : Enable PPI channel 22. */
+#define PPI_CHEN_CH22_Pos (22UL) /*!< Position of CH22 field. */
+#define PPI_CHEN_CH22_Msk (0x1UL << PPI_CHEN_CH22_Pos) /*!< Bit mask of CH22 field. */
+#define PPI_CHEN_CH22_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH22_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 21 : Enable PPI channel 21. */
+#define PPI_CHEN_CH21_Pos (21UL) /*!< Position of CH21 field. */
+#define PPI_CHEN_CH21_Msk (0x1UL << PPI_CHEN_CH21_Pos) /*!< Bit mask of CH21 field. */
+#define PPI_CHEN_CH21_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH21_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 20 : Enable PPI channel 20. */
+#define PPI_CHEN_CH20_Pos (20UL) /*!< Position of CH20 field. */
+#define PPI_CHEN_CH20_Msk (0x1UL << PPI_CHEN_CH20_Pos) /*!< Bit mask of CH20 field. */
+#define PPI_CHEN_CH20_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH20_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 15 : Enable PPI channel 15. */
+#define PPI_CHEN_CH15_Pos (15UL) /*!< Position of CH15 field. */
+#define PPI_CHEN_CH15_Msk (0x1UL << PPI_CHEN_CH15_Pos) /*!< Bit mask of CH15 field. */
+#define PPI_CHEN_CH15_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH15_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 14 : Enable PPI channel 14. */
+#define PPI_CHEN_CH14_Pos (14UL) /*!< Position of CH14 field. */
+#define PPI_CHEN_CH14_Msk (0x1UL << PPI_CHEN_CH14_Pos) /*!< Bit mask of CH14 field. */
+#define PPI_CHEN_CH14_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH14_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 13 : Enable PPI channel 13. */
+#define PPI_CHEN_CH13_Pos (13UL) /*!< Position of CH13 field. */
+#define PPI_CHEN_CH13_Msk (0x1UL << PPI_CHEN_CH13_Pos) /*!< Bit mask of CH13 field. */
+#define PPI_CHEN_CH13_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH13_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 12 : Enable PPI channel 12. */
+#define PPI_CHEN_CH12_Pos (12UL) /*!< Position of CH12 field. */
+#define PPI_CHEN_CH12_Msk (0x1UL << PPI_CHEN_CH12_Pos) /*!< Bit mask of CH12 field. */
+#define PPI_CHEN_CH12_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH12_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 11 : Enable PPI channel 11. */
+#define PPI_CHEN_CH11_Pos (11UL) /*!< Position of CH11 field. */
+#define PPI_CHEN_CH11_Msk (0x1UL << PPI_CHEN_CH11_Pos) /*!< Bit mask of CH11 field. */
+#define PPI_CHEN_CH11_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH11_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 10 : Enable PPI channel 10. */
+#define PPI_CHEN_CH10_Pos (10UL) /*!< Position of CH10 field. */
+#define PPI_CHEN_CH10_Msk (0x1UL << PPI_CHEN_CH10_Pos) /*!< Bit mask of CH10 field. */
+#define PPI_CHEN_CH10_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH10_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 9 : Enable PPI channel 9. */
+#define PPI_CHEN_CH9_Pos (9UL) /*!< Position of CH9 field. */
+#define PPI_CHEN_CH9_Msk (0x1UL << PPI_CHEN_CH9_Pos) /*!< Bit mask of CH9 field. */
+#define PPI_CHEN_CH9_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH9_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 8 : Enable PPI channel 8. */
+#define PPI_CHEN_CH8_Pos (8UL) /*!< Position of CH8 field. */
+#define PPI_CHEN_CH8_Msk (0x1UL << PPI_CHEN_CH8_Pos) /*!< Bit mask of CH8 field. */
+#define PPI_CHEN_CH8_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH8_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 7 : Enable PPI channel 7. */
+#define PPI_CHEN_CH7_Pos (7UL) /*!< Position of CH7 field. */
+#define PPI_CHEN_CH7_Msk (0x1UL << PPI_CHEN_CH7_Pos) /*!< Bit mask of CH7 field. */
+#define PPI_CHEN_CH7_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH7_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 6 : Enable PPI channel 6. */
+#define PPI_CHEN_CH6_Pos (6UL) /*!< Position of CH6 field. */
+#define PPI_CHEN_CH6_Msk (0x1UL << PPI_CHEN_CH6_Pos) /*!< Bit mask of CH6 field. */
+#define PPI_CHEN_CH6_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH6_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 5 : Enable PPI channel 5. */
+#define PPI_CHEN_CH5_Pos (5UL) /*!< Position of CH5 field. */
+#define PPI_CHEN_CH5_Msk (0x1UL << PPI_CHEN_CH5_Pos) /*!< Bit mask of CH5 field. */
+#define PPI_CHEN_CH5_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH5_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 4 : Enable PPI channel 4. */
+#define PPI_CHEN_CH4_Pos (4UL) /*!< Position of CH4 field. */
+#define PPI_CHEN_CH4_Msk (0x1UL << PPI_CHEN_CH4_Pos) /*!< Bit mask of CH4 field. */
+#define PPI_CHEN_CH4_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH4_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 3 : Enable PPI channel 3. */
+#define PPI_CHEN_CH3_Pos (3UL) /*!< Position of CH3 field. */
+#define PPI_CHEN_CH3_Msk (0x1UL << PPI_CHEN_CH3_Pos) /*!< Bit mask of CH3 field. */
+#define PPI_CHEN_CH3_Disabled (0UL) /*!< Channel disabled */
+#define PPI_CHEN_CH3_Enabled (1UL) /*!< Channel enabled */
+
+/* Bit 2 : Enable PPI channel 2. */
+#define PPI_CHEN_CH2_Pos (2UL) /*!< Position of CH2 field. */
+#define PPI_CHEN_CH2_Msk (0x1UL << PPI_CHEN_CH2_Pos) /*!< Bit mask of CH2 field. */
+#define PPI_CHEN_CH2_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH2_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 1 : Enable PPI channel 1. */
+#define PPI_CHEN_CH1_Pos (1UL) /*!< Position of CH1 field. */
+#define PPI_CHEN_CH1_Msk (0x1UL << PPI_CHEN_CH1_Pos) /*!< Bit mask of CH1 field. */
+#define PPI_CHEN_CH1_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH1_Enabled (1UL) /*!< Channel enabled. */
+
+/* Bit 0 : Enable PPI channel 0. */
+#define PPI_CHEN_CH0_Pos (0UL) /*!< Position of CH0 field. */
+#define PPI_CHEN_CH0_Msk (0x1UL << PPI_CHEN_CH0_Pos) /*!< Bit mask of CH0 field. */
+#define PPI_CHEN_CH0_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHEN_CH0_Enabled (1UL) /*!< Channel enabled. */
+
+/* Register: PPI_CHENSET */
+/* Description: Channel enable set. */
+
+/* Bit 31 : Enable PPI channel 31. */
+#define PPI_CHENSET_CH31_Pos (31UL) /*!< Position of CH31 field. */
+#define PPI_CHENSET_CH31_Msk (0x1UL << PPI_CHENSET_CH31_Pos) /*!< Bit mask of CH31 field. */
+#define PPI_CHENSET_CH31_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH31_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH31_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 30 : Enable PPI channel 30. */
+#define PPI_CHENSET_CH30_Pos (30UL) /*!< Position of CH30 field. */
+#define PPI_CHENSET_CH30_Msk (0x1UL << PPI_CHENSET_CH30_Pos) /*!< Bit mask of CH30 field. */
+#define PPI_CHENSET_CH30_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH30_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH30_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 29 : Enable PPI channel 29. */
+#define PPI_CHENSET_CH29_Pos (29UL) /*!< Position of CH29 field. */
+#define PPI_CHENSET_CH29_Msk (0x1UL << PPI_CHENSET_CH29_Pos) /*!< Bit mask of CH29 field. */
+#define PPI_CHENSET_CH29_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH29_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH29_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 28 : Enable PPI channel 28. */
+#define PPI_CHENSET_CH28_Pos (28UL) /*!< Position of CH28 field. */
+#define PPI_CHENSET_CH28_Msk (0x1UL << PPI_CHENSET_CH28_Pos) /*!< Bit mask of CH28 field. */
+#define PPI_CHENSET_CH28_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH28_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH28_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 27 : Enable PPI channel 27. */
+#define PPI_CHENSET_CH27_Pos (27UL) /*!< Position of CH27 field. */
+#define PPI_CHENSET_CH27_Msk (0x1UL << PPI_CHENSET_CH27_Pos) /*!< Bit mask of CH27 field. */
+#define PPI_CHENSET_CH27_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH27_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH27_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 26 : Enable PPI channel 26. */
+#define PPI_CHENSET_CH26_Pos (26UL) /*!< Position of CH26 field. */
+#define PPI_CHENSET_CH26_Msk (0x1UL << PPI_CHENSET_CH26_Pos) /*!< Bit mask of CH26 field. */
+#define PPI_CHENSET_CH26_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH26_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH26_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 25 : Enable PPI channel 25. */
+#define PPI_CHENSET_CH25_Pos (25UL) /*!< Position of CH25 field. */
+#define PPI_CHENSET_CH25_Msk (0x1UL << PPI_CHENSET_CH25_Pos) /*!< Bit mask of CH25 field. */
+#define PPI_CHENSET_CH25_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH25_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH25_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 24 : Enable PPI channel 24. */
+#define PPI_CHENSET_CH24_Pos (24UL) /*!< Position of CH24 field. */
+#define PPI_CHENSET_CH24_Msk (0x1UL << PPI_CHENSET_CH24_Pos) /*!< Bit mask of CH24 field. */
+#define PPI_CHENSET_CH24_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH24_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH24_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 23 : Enable PPI channel 23. */
+#define PPI_CHENSET_CH23_Pos (23UL) /*!< Position of CH23 field. */
+#define PPI_CHENSET_CH23_Msk (0x1UL << PPI_CHENSET_CH23_Pos) /*!< Bit mask of CH23 field. */
+#define PPI_CHENSET_CH23_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH23_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH23_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 22 : Enable PPI channel 22. */
+#define PPI_CHENSET_CH22_Pos (22UL) /*!< Position of CH22 field. */
+#define PPI_CHENSET_CH22_Msk (0x1UL << PPI_CHENSET_CH22_Pos) /*!< Bit mask of CH22 field. */
+#define PPI_CHENSET_CH22_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH22_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH22_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 21 : Enable PPI channel 21. */
+#define PPI_CHENSET_CH21_Pos (21UL) /*!< Position of CH21 field. */
+#define PPI_CHENSET_CH21_Msk (0x1UL << PPI_CHENSET_CH21_Pos) /*!< Bit mask of CH21 field. */
+#define PPI_CHENSET_CH21_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH21_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH21_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 20 : Enable PPI channel 20. */
+#define PPI_CHENSET_CH20_Pos (20UL) /*!< Position of CH20 field. */
+#define PPI_CHENSET_CH20_Msk (0x1UL << PPI_CHENSET_CH20_Pos) /*!< Bit mask of CH20 field. */
+#define PPI_CHENSET_CH20_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH20_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH20_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 15 : Enable PPI channel 15. */
+#define PPI_CHENSET_CH15_Pos (15UL) /*!< Position of CH15 field. */
+#define PPI_CHENSET_CH15_Msk (0x1UL << PPI_CHENSET_CH15_Pos) /*!< Bit mask of CH15 field. */
+#define PPI_CHENSET_CH15_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH15_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH15_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 14 : Enable PPI channel 14. */
+#define PPI_CHENSET_CH14_Pos (14UL) /*!< Position of CH14 field. */
+#define PPI_CHENSET_CH14_Msk (0x1UL << PPI_CHENSET_CH14_Pos) /*!< Bit mask of CH14 field. */
+#define PPI_CHENSET_CH14_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH14_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH14_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 13 : Enable PPI channel 13. */
+#define PPI_CHENSET_CH13_Pos (13UL) /*!< Position of CH13 field. */
+#define PPI_CHENSET_CH13_Msk (0x1UL << PPI_CHENSET_CH13_Pos) /*!< Bit mask of CH13 field. */
+#define PPI_CHENSET_CH13_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH13_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH13_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 12 : Enable PPI channel 12. */
+#define PPI_CHENSET_CH12_Pos (12UL) /*!< Position of CH12 field. */
+#define PPI_CHENSET_CH12_Msk (0x1UL << PPI_CHENSET_CH12_Pos) /*!< Bit mask of CH12 field. */
+#define PPI_CHENSET_CH12_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH12_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH12_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 11 : Enable PPI channel 11. */
+#define PPI_CHENSET_CH11_Pos (11UL) /*!< Position of CH11 field. */
+#define PPI_CHENSET_CH11_Msk (0x1UL << PPI_CHENSET_CH11_Pos) /*!< Bit mask of CH11 field. */
+#define PPI_CHENSET_CH11_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH11_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH11_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 10 : Enable PPI channel 10. */
+#define PPI_CHENSET_CH10_Pos (10UL) /*!< Position of CH10 field. */
+#define PPI_CHENSET_CH10_Msk (0x1UL << PPI_CHENSET_CH10_Pos) /*!< Bit mask of CH10 field. */
+#define PPI_CHENSET_CH10_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH10_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH10_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 9 : Enable PPI channel 9. */
+#define PPI_CHENSET_CH9_Pos (9UL) /*!< Position of CH9 field. */
+#define PPI_CHENSET_CH9_Msk (0x1UL << PPI_CHENSET_CH9_Pos) /*!< Bit mask of CH9 field. */
+#define PPI_CHENSET_CH9_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH9_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH9_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 8 : Enable PPI channel 8. */
+#define PPI_CHENSET_CH8_Pos (8UL) /*!< Position of CH8 field. */
+#define PPI_CHENSET_CH8_Msk (0x1UL << PPI_CHENSET_CH8_Pos) /*!< Bit mask of CH8 field. */
+#define PPI_CHENSET_CH8_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH8_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH8_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 7 : Enable PPI channel 7. */
+#define PPI_CHENSET_CH7_Pos (7UL) /*!< Position of CH7 field. */
+#define PPI_CHENSET_CH7_Msk (0x1UL << PPI_CHENSET_CH7_Pos) /*!< Bit mask of CH7 field. */
+#define PPI_CHENSET_CH7_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH7_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH7_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 6 : Enable PPI channel 6. */
+#define PPI_CHENSET_CH6_Pos (6UL) /*!< Position of CH6 field. */
+#define PPI_CHENSET_CH6_Msk (0x1UL << PPI_CHENSET_CH6_Pos) /*!< Bit mask of CH6 field. */
+#define PPI_CHENSET_CH6_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH6_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH6_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 5 : Enable PPI channel 5. */
+#define PPI_CHENSET_CH5_Pos (5UL) /*!< Position of CH5 field. */
+#define PPI_CHENSET_CH5_Msk (0x1UL << PPI_CHENSET_CH5_Pos) /*!< Bit mask of CH5 field. */
+#define PPI_CHENSET_CH5_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH5_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH5_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 4 : Enable PPI channel 4. */
+#define PPI_CHENSET_CH4_Pos (4UL) /*!< Position of CH4 field. */
+#define PPI_CHENSET_CH4_Msk (0x1UL << PPI_CHENSET_CH4_Pos) /*!< Bit mask of CH4 field. */
+#define PPI_CHENSET_CH4_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH4_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH4_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 3 : Enable PPI channel 3. */
+#define PPI_CHENSET_CH3_Pos (3UL) /*!< Position of CH3 field. */
+#define PPI_CHENSET_CH3_Msk (0x1UL << PPI_CHENSET_CH3_Pos) /*!< Bit mask of CH3 field. */
+#define PPI_CHENSET_CH3_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH3_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH3_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 2 : Enable PPI channel 2. */
+#define PPI_CHENSET_CH2_Pos (2UL) /*!< Position of CH2 field. */
+#define PPI_CHENSET_CH2_Msk (0x1UL << PPI_CHENSET_CH2_Pos) /*!< Bit mask of CH2 field. */
+#define PPI_CHENSET_CH2_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH2_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH2_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 1 : Enable PPI channel 1. */
+#define PPI_CHENSET_CH1_Pos (1UL) /*!< Position of CH1 field. */
+#define PPI_CHENSET_CH1_Msk (0x1UL << PPI_CHENSET_CH1_Pos) /*!< Bit mask of CH1 field. */
+#define PPI_CHENSET_CH1_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH1_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH1_Set (1UL) /*!< Enable channel on write. */
+
+/* Bit 0 : Enable PPI channel 0. */
+#define PPI_CHENSET_CH0_Pos (0UL) /*!< Position of CH0 field. */
+#define PPI_CHENSET_CH0_Msk (0x1UL << PPI_CHENSET_CH0_Pos) /*!< Bit mask of CH0 field. */
+#define PPI_CHENSET_CH0_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENSET_CH0_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENSET_CH0_Set (1UL) /*!< Enable channel on write. */
+
+/* Register: PPI_CHENCLR */
+/* Description: Channel enable clear. */
+
+/* Bit 31 : Disable PPI channel 31. */
+#define PPI_CHENCLR_CH31_Pos (31UL) /*!< Position of CH31 field. */
+#define PPI_CHENCLR_CH31_Msk (0x1UL << PPI_CHENCLR_CH31_Pos) /*!< Bit mask of CH31 field. */
+#define PPI_CHENCLR_CH31_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH31_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH31_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 30 : Disable PPI channel 30. */
+#define PPI_CHENCLR_CH30_Pos (30UL) /*!< Position of CH30 field. */
+#define PPI_CHENCLR_CH30_Msk (0x1UL << PPI_CHENCLR_CH30_Pos) /*!< Bit mask of CH30 field. */
+#define PPI_CHENCLR_CH30_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH30_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH30_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 29 : Disable PPI channel 29. */
+#define PPI_CHENCLR_CH29_Pos (29UL) /*!< Position of CH29 field. */
+#define PPI_CHENCLR_CH29_Msk (0x1UL << PPI_CHENCLR_CH29_Pos) /*!< Bit mask of CH29 field. */
+#define PPI_CHENCLR_CH29_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH29_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH29_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 28 : Disable PPI channel 28. */
+#define PPI_CHENCLR_CH28_Pos (28UL) /*!< Position of CH28 field. */
+#define PPI_CHENCLR_CH28_Msk (0x1UL << PPI_CHENCLR_CH28_Pos) /*!< Bit mask of CH28 field. */
+#define PPI_CHENCLR_CH28_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH28_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH28_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 27 : Disable PPI channel 27. */
+#define PPI_CHENCLR_CH27_Pos (27UL) /*!< Position of CH27 field. */
+#define PPI_CHENCLR_CH27_Msk (0x1UL << PPI_CHENCLR_CH27_Pos) /*!< Bit mask of CH27 field. */
+#define PPI_CHENCLR_CH27_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH27_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH27_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 26 : Disable PPI channel 26. */
+#define PPI_CHENCLR_CH26_Pos (26UL) /*!< Position of CH26 field. */
+#define PPI_CHENCLR_CH26_Msk (0x1UL << PPI_CHENCLR_CH26_Pos) /*!< Bit mask of CH26 field. */
+#define PPI_CHENCLR_CH26_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH26_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH26_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 25 : Disable PPI channel 25. */
+#define PPI_CHENCLR_CH25_Pos (25UL) /*!< Position of CH25 field. */
+#define PPI_CHENCLR_CH25_Msk (0x1UL << PPI_CHENCLR_CH25_Pos) /*!< Bit mask of CH25 field. */
+#define PPI_CHENCLR_CH25_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH25_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH25_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 24 : Disable PPI channel 24. */
+#define PPI_CHENCLR_CH24_Pos (24UL) /*!< Position of CH24 field. */
+#define PPI_CHENCLR_CH24_Msk (0x1UL << PPI_CHENCLR_CH24_Pos) /*!< Bit mask of CH24 field. */
+#define PPI_CHENCLR_CH24_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH24_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH24_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 23 : Disable PPI channel 23. */
+#define PPI_CHENCLR_CH23_Pos (23UL) /*!< Position of CH23 field. */
+#define PPI_CHENCLR_CH23_Msk (0x1UL << PPI_CHENCLR_CH23_Pos) /*!< Bit mask of CH23 field. */
+#define PPI_CHENCLR_CH23_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH23_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH23_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 22 : Disable PPI channel 22. */
+#define PPI_CHENCLR_CH22_Pos (22UL) /*!< Position of CH22 field. */
+#define PPI_CHENCLR_CH22_Msk (0x1UL << PPI_CHENCLR_CH22_Pos) /*!< Bit mask of CH22 field. */
+#define PPI_CHENCLR_CH22_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH22_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH22_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 21 : Disable PPI channel 21. */
+#define PPI_CHENCLR_CH21_Pos (21UL) /*!< Position of CH21 field. */
+#define PPI_CHENCLR_CH21_Msk (0x1UL << PPI_CHENCLR_CH21_Pos) /*!< Bit mask of CH21 field. */
+#define PPI_CHENCLR_CH21_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH21_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH21_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 20 : Disable PPI channel 20. */
+#define PPI_CHENCLR_CH20_Pos (20UL) /*!< Position of CH20 field. */
+#define PPI_CHENCLR_CH20_Msk (0x1UL << PPI_CHENCLR_CH20_Pos) /*!< Bit mask of CH20 field. */
+#define PPI_CHENCLR_CH20_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH20_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH20_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 15 : Disable PPI channel 15. */
+#define PPI_CHENCLR_CH15_Pos (15UL) /*!< Position of CH15 field. */
+#define PPI_CHENCLR_CH15_Msk (0x1UL << PPI_CHENCLR_CH15_Pos) /*!< Bit mask of CH15 field. */
+#define PPI_CHENCLR_CH15_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH15_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH15_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 14 : Disable PPI channel 14. */
+#define PPI_CHENCLR_CH14_Pos (14UL) /*!< Position of CH14 field. */
+#define PPI_CHENCLR_CH14_Msk (0x1UL << PPI_CHENCLR_CH14_Pos) /*!< Bit mask of CH14 field. */
+#define PPI_CHENCLR_CH14_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH14_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH14_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 13 : Disable PPI channel 13. */
+#define PPI_CHENCLR_CH13_Pos (13UL) /*!< Position of CH13 field. */
+#define PPI_CHENCLR_CH13_Msk (0x1UL << PPI_CHENCLR_CH13_Pos) /*!< Bit mask of CH13 field. */
+#define PPI_CHENCLR_CH13_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH13_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH13_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 12 : Disable PPI channel 12. */
+#define PPI_CHENCLR_CH12_Pos (12UL) /*!< Position of CH12 field. */
+#define PPI_CHENCLR_CH12_Msk (0x1UL << PPI_CHENCLR_CH12_Pos) /*!< Bit mask of CH12 field. */
+#define PPI_CHENCLR_CH12_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH12_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH12_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 11 : Disable PPI channel 11. */
+#define PPI_CHENCLR_CH11_Pos (11UL) /*!< Position of CH11 field. */
+#define PPI_CHENCLR_CH11_Msk (0x1UL << PPI_CHENCLR_CH11_Pos) /*!< Bit mask of CH11 field. */
+#define PPI_CHENCLR_CH11_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH11_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH11_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 10 : Disable PPI channel 10. */
+#define PPI_CHENCLR_CH10_Pos (10UL) /*!< Position of CH10 field. */
+#define PPI_CHENCLR_CH10_Msk (0x1UL << PPI_CHENCLR_CH10_Pos) /*!< Bit mask of CH10 field. */
+#define PPI_CHENCLR_CH10_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH10_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH10_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 9 : Disable PPI channel 9. */
+#define PPI_CHENCLR_CH9_Pos (9UL) /*!< Position of CH9 field. */
+#define PPI_CHENCLR_CH9_Msk (0x1UL << PPI_CHENCLR_CH9_Pos) /*!< Bit mask of CH9 field. */
+#define PPI_CHENCLR_CH9_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH9_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH9_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 8 : Disable PPI channel 8. */
+#define PPI_CHENCLR_CH8_Pos (8UL) /*!< Position of CH8 field. */
+#define PPI_CHENCLR_CH8_Msk (0x1UL << PPI_CHENCLR_CH8_Pos) /*!< Bit mask of CH8 field. */
+#define PPI_CHENCLR_CH8_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH8_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH8_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 7 : Disable PPI channel 7. */
+#define PPI_CHENCLR_CH7_Pos (7UL) /*!< Position of CH7 field. */
+#define PPI_CHENCLR_CH7_Msk (0x1UL << PPI_CHENCLR_CH7_Pos) /*!< Bit mask of CH7 field. */
+#define PPI_CHENCLR_CH7_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH7_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH7_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 6 : Disable PPI channel 6. */
+#define PPI_CHENCLR_CH6_Pos (6UL) /*!< Position of CH6 field. */
+#define PPI_CHENCLR_CH6_Msk (0x1UL << PPI_CHENCLR_CH6_Pos) /*!< Bit mask of CH6 field. */
+#define PPI_CHENCLR_CH6_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH6_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH6_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 5 : Disable PPI channel 5. */
+#define PPI_CHENCLR_CH5_Pos (5UL) /*!< Position of CH5 field. */
+#define PPI_CHENCLR_CH5_Msk (0x1UL << PPI_CHENCLR_CH5_Pos) /*!< Bit mask of CH5 field. */
+#define PPI_CHENCLR_CH5_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH5_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH5_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 4 : Disable PPI channel 4. */
+#define PPI_CHENCLR_CH4_Pos (4UL) /*!< Position of CH4 field. */
+#define PPI_CHENCLR_CH4_Msk (0x1UL << PPI_CHENCLR_CH4_Pos) /*!< Bit mask of CH4 field. */
+#define PPI_CHENCLR_CH4_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH4_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH4_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 3 : Disable PPI channel 3. */
+#define PPI_CHENCLR_CH3_Pos (3UL) /*!< Position of CH3 field. */
+#define PPI_CHENCLR_CH3_Msk (0x1UL << PPI_CHENCLR_CH3_Pos) /*!< Bit mask of CH3 field. */
+#define PPI_CHENCLR_CH3_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH3_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH3_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 2 : Disable PPI channel 2. */
+#define PPI_CHENCLR_CH2_Pos (2UL) /*!< Position of CH2 field. */
+#define PPI_CHENCLR_CH2_Msk (0x1UL << PPI_CHENCLR_CH2_Pos) /*!< Bit mask of CH2 field. */
+#define PPI_CHENCLR_CH2_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH2_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH2_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 1 : Disable PPI channel 1. */
+#define PPI_CHENCLR_CH1_Pos (1UL) /*!< Position of CH1 field. */
+#define PPI_CHENCLR_CH1_Msk (0x1UL << PPI_CHENCLR_CH1_Pos) /*!< Bit mask of CH1 field. */
+#define PPI_CHENCLR_CH1_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH1_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH1_Clear (1UL) /*!< Disable channel on write. */
+
+/* Bit 0 : Disable PPI channel 0. */
+#define PPI_CHENCLR_CH0_Pos (0UL) /*!< Position of CH0 field. */
+#define PPI_CHENCLR_CH0_Msk (0x1UL << PPI_CHENCLR_CH0_Pos) /*!< Bit mask of CH0 field. */
+#define PPI_CHENCLR_CH0_Disabled (0UL) /*!< Channel disabled. */
+#define PPI_CHENCLR_CH0_Enabled (1UL) /*!< Channel enabled. */
+#define PPI_CHENCLR_CH0_Clear (1UL) /*!< Disable channel on write. */
+
+/* Register: PPI_CHG */
+/* Description: Channel group configuration. */
+
+/* Bit 31 : Include CH31 in channel group. */
+#define PPI_CHG_CH31_Pos (31UL) /*!< Position of CH31 field. */
+#define PPI_CHG_CH31_Msk (0x1UL << PPI_CHG_CH31_Pos) /*!< Bit mask of CH31 field. */
+#define PPI_CHG_CH31_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH31_Included (1UL) /*!< Channel included. */
+
+/* Bit 30 : Include CH30 in channel group. */
+#define PPI_CHG_CH30_Pos (30UL) /*!< Position of CH30 field. */
+#define PPI_CHG_CH30_Msk (0x1UL << PPI_CHG_CH30_Pos) /*!< Bit mask of CH30 field. */
+#define PPI_CHG_CH30_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH30_Included (1UL) /*!< Channel included. */
+
+/* Bit 29 : Include CH29 in channel group. */
+#define PPI_CHG_CH29_Pos (29UL) /*!< Position of CH29 field. */
+#define PPI_CHG_CH29_Msk (0x1UL << PPI_CHG_CH29_Pos) /*!< Bit mask of CH29 field. */
+#define PPI_CHG_CH29_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH29_Included (1UL) /*!< Channel included. */
+
+/* Bit 28 : Include CH28 in channel group. */
+#define PPI_CHG_CH28_Pos (28UL) /*!< Position of CH28 field. */
+#define PPI_CHG_CH28_Msk (0x1UL << PPI_CHG_CH28_Pos) /*!< Bit mask of CH28 field. */
+#define PPI_CHG_CH28_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH28_Included (1UL) /*!< Channel included. */
+
+/* Bit 27 : Include CH27 in channel group. */
+#define PPI_CHG_CH27_Pos (27UL) /*!< Position of CH27 field. */
+#define PPI_CHG_CH27_Msk (0x1UL << PPI_CHG_CH27_Pos) /*!< Bit mask of CH27 field. */
+#define PPI_CHG_CH27_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH27_Included (1UL) /*!< Channel included. */
+
+/* Bit 26 : Include CH26 in channel group. */
+#define PPI_CHG_CH26_Pos (26UL) /*!< Position of CH26 field. */
+#define PPI_CHG_CH26_Msk (0x1UL << PPI_CHG_CH26_Pos) /*!< Bit mask of CH26 field. */
+#define PPI_CHG_CH26_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH26_Included (1UL) /*!< Channel included. */
+
+/* Bit 25 : Include CH25 in channel group. */
+#define PPI_CHG_CH25_Pos (25UL) /*!< Position of CH25 field. */
+#define PPI_CHG_CH25_Msk (0x1UL << PPI_CHG_CH25_Pos) /*!< Bit mask of CH25 field. */
+#define PPI_CHG_CH25_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH25_Included (1UL) /*!< Channel included. */
+
+/* Bit 24 : Include CH24 in channel group. */
+#define PPI_CHG_CH24_Pos (24UL) /*!< Position of CH24 field. */
+#define PPI_CHG_CH24_Msk (0x1UL << PPI_CHG_CH24_Pos) /*!< Bit mask of CH24 field. */
+#define PPI_CHG_CH24_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH24_Included (1UL) /*!< Channel included. */
+
+/* Bit 23 : Include CH23 in channel group. */
+#define PPI_CHG_CH23_Pos (23UL) /*!< Position of CH23 field. */
+#define PPI_CHG_CH23_Msk (0x1UL << PPI_CHG_CH23_Pos) /*!< Bit mask of CH23 field. */
+#define PPI_CHG_CH23_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH23_Included (1UL) /*!< Channel included. */
+
+/* Bit 22 : Include CH22 in channel group. */
+#define PPI_CHG_CH22_Pos (22UL) /*!< Position of CH22 field. */
+#define PPI_CHG_CH22_Msk (0x1UL << PPI_CHG_CH22_Pos) /*!< Bit mask of CH22 field. */
+#define PPI_CHG_CH22_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH22_Included (1UL) /*!< Channel included. */
+
+/* Bit 21 : Include CH21 in channel group. */
+#define PPI_CHG_CH21_Pos (21UL) /*!< Position of CH21 field. */
+#define PPI_CHG_CH21_Msk (0x1UL << PPI_CHG_CH21_Pos) /*!< Bit mask of CH21 field. */
+#define PPI_CHG_CH21_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH21_Included (1UL) /*!< Channel included. */
+
+/* Bit 20 : Include CH20 in channel group. */
+#define PPI_CHG_CH20_Pos (20UL) /*!< Position of CH20 field. */
+#define PPI_CHG_CH20_Msk (0x1UL << PPI_CHG_CH20_Pos) /*!< Bit mask of CH20 field. */
+#define PPI_CHG_CH20_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH20_Included (1UL) /*!< Channel included. */
+
+/* Bit 15 : Include CH15 in channel group. */
+#define PPI_CHG_CH15_Pos (15UL) /*!< Position of CH15 field. */
+#define PPI_CHG_CH15_Msk (0x1UL << PPI_CHG_CH15_Pos) /*!< Bit mask of CH15 field. */
+#define PPI_CHG_CH15_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH15_Included (1UL) /*!< Channel included. */
+
+/* Bit 14 : Include CH14 in channel group. */
+#define PPI_CHG_CH14_Pos (14UL) /*!< Position of CH14 field. */
+#define PPI_CHG_CH14_Msk (0x1UL << PPI_CHG_CH14_Pos) /*!< Bit mask of CH14 field. */
+#define PPI_CHG_CH14_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH14_Included (1UL) /*!< Channel included. */
+
+/* Bit 13 : Include CH13 in channel group. */
+#define PPI_CHG_CH13_Pos (13UL) /*!< Position of CH13 field. */
+#define PPI_CHG_CH13_Msk (0x1UL << PPI_CHG_CH13_Pos) /*!< Bit mask of CH13 field. */
+#define PPI_CHG_CH13_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH13_Included (1UL) /*!< Channel included. */
+
+/* Bit 12 : Include CH12 in channel group. */
+#define PPI_CHG_CH12_Pos (12UL) /*!< Position of CH12 field. */
+#define PPI_CHG_CH12_Msk (0x1UL << PPI_CHG_CH12_Pos) /*!< Bit mask of CH12 field. */
+#define PPI_CHG_CH12_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH12_Included (1UL) /*!< Channel included. */
+
+/* Bit 11 : Include CH11 in channel group. */
+#define PPI_CHG_CH11_Pos (11UL) /*!< Position of CH11 field. */
+#define PPI_CHG_CH11_Msk (0x1UL << PPI_CHG_CH11_Pos) /*!< Bit mask of CH11 field. */
+#define PPI_CHG_CH11_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH11_Included (1UL) /*!< Channel included. */
+
+/* Bit 10 : Include CH10 in channel group. */
+#define PPI_CHG_CH10_Pos (10UL) /*!< Position of CH10 field. */
+#define PPI_CHG_CH10_Msk (0x1UL << PPI_CHG_CH10_Pos) /*!< Bit mask of CH10 field. */
+#define PPI_CHG_CH10_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH10_Included (1UL) /*!< Channel included. */
+
+/* Bit 9 : Include CH9 in channel group. */
+#define PPI_CHG_CH9_Pos (9UL) /*!< Position of CH9 field. */
+#define PPI_CHG_CH9_Msk (0x1UL << PPI_CHG_CH9_Pos) /*!< Bit mask of CH9 field. */
+#define PPI_CHG_CH9_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH9_Included (1UL) /*!< Channel included. */
+
+/* Bit 8 : Include CH8 in channel group. */
+#define PPI_CHG_CH8_Pos (8UL) /*!< Position of CH8 field. */
+#define PPI_CHG_CH8_Msk (0x1UL << PPI_CHG_CH8_Pos) /*!< Bit mask of CH8 field. */
+#define PPI_CHG_CH8_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH8_Included (1UL) /*!< Channel included. */
+
+/* Bit 7 : Include CH7 in channel group. */
+#define PPI_CHG_CH7_Pos (7UL) /*!< Position of CH7 field. */
+#define PPI_CHG_CH7_Msk (0x1UL << PPI_CHG_CH7_Pos) /*!< Bit mask of CH7 field. */
+#define PPI_CHG_CH7_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH7_Included (1UL) /*!< Channel included. */
+
+/* Bit 6 : Include CH6 in channel group. */
+#define PPI_CHG_CH6_Pos (6UL) /*!< Position of CH6 field. */
+#define PPI_CHG_CH6_Msk (0x1UL << PPI_CHG_CH6_Pos) /*!< Bit mask of CH6 field. */
+#define PPI_CHG_CH6_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH6_Included (1UL) /*!< Channel included. */
+
+/* Bit 5 : Include CH5 in channel group. */
+#define PPI_CHG_CH5_Pos (5UL) /*!< Position of CH5 field. */
+#define PPI_CHG_CH5_Msk (0x1UL << PPI_CHG_CH5_Pos) /*!< Bit mask of CH5 field. */
+#define PPI_CHG_CH5_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH5_Included (1UL) /*!< Channel included. */
+
+/* Bit 4 : Include CH4 in channel group. */
+#define PPI_CHG_CH4_Pos (4UL) /*!< Position of CH4 field. */
+#define PPI_CHG_CH4_Msk (0x1UL << PPI_CHG_CH4_Pos) /*!< Bit mask of CH4 field. */
+#define PPI_CHG_CH4_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH4_Included (1UL) /*!< Channel included. */
+
+/* Bit 3 : Include CH3 in channel group. */
+#define PPI_CHG_CH3_Pos (3UL) /*!< Position of CH3 field. */
+#define PPI_CHG_CH3_Msk (0x1UL << PPI_CHG_CH3_Pos) /*!< Bit mask of CH3 field. */
+#define PPI_CHG_CH3_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH3_Included (1UL) /*!< Channel included. */
+
+/* Bit 2 : Include CH2 in channel group. */
+#define PPI_CHG_CH2_Pos (2UL) /*!< Position of CH2 field. */
+#define PPI_CHG_CH2_Msk (0x1UL << PPI_CHG_CH2_Pos) /*!< Bit mask of CH2 field. */
+#define PPI_CHG_CH2_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH2_Included (1UL) /*!< Channel included. */
+
+/* Bit 1 : Include CH1 in channel group. */
+#define PPI_CHG_CH1_Pos (1UL) /*!< Position of CH1 field. */
+#define PPI_CHG_CH1_Msk (0x1UL << PPI_CHG_CH1_Pos) /*!< Bit mask of CH1 field. */
+#define PPI_CHG_CH1_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH1_Included (1UL) /*!< Channel included. */
+
+/* Bit 0 : Include CH0 in channel group. */
+#define PPI_CHG_CH0_Pos (0UL) /*!< Position of CH0 field. */
+#define PPI_CHG_CH0_Msk (0x1UL << PPI_CHG_CH0_Pos) /*!< Bit mask of CH0 field. */
+#define PPI_CHG_CH0_Excluded (0UL) /*!< Channel excluded. */
+#define PPI_CHG_CH0_Included (1UL) /*!< Channel included. */
+
+
+/* Peripheral: QDEC */
+/* Description: Rotary decoder. */
+
+/* Register: QDEC_SHORTS */
+/* Description: Shortcuts for the QDEC. */
+
+/* Bit 1 : Shortcut between SAMPLERDY event and STOP task. */
+#define QDEC_SHORTS_SAMPLERDY_STOP_Pos (1UL) /*!< Position of SAMPLERDY_STOP field. */
+#define QDEC_SHORTS_SAMPLERDY_STOP_Msk (0x1UL << QDEC_SHORTS_SAMPLERDY_STOP_Pos) /*!< Bit mask of SAMPLERDY_STOP field. */
+#define QDEC_SHORTS_SAMPLERDY_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define QDEC_SHORTS_SAMPLERDY_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 0 : Shortcut between REPORTRDY event and READCLRACC task. */
+#define QDEC_SHORTS_REPORTRDY_READCLRACC_Pos (0UL) /*!< Position of REPORTRDY_READCLRACC field. */
+#define QDEC_SHORTS_REPORTRDY_READCLRACC_Msk (0x1UL << QDEC_SHORTS_REPORTRDY_READCLRACC_Pos) /*!< Bit mask of REPORTRDY_READCLRACC field. */
+#define QDEC_SHORTS_REPORTRDY_READCLRACC_Disabled (0UL) /*!< Shortcut disabled. */
+#define QDEC_SHORTS_REPORTRDY_READCLRACC_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Register: QDEC_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 2 : Enable interrupt on ACCOF event. */
+#define QDEC_INTENSET_ACCOF_Pos (2UL) /*!< Position of ACCOF field. */
+#define QDEC_INTENSET_ACCOF_Msk (0x1UL << QDEC_INTENSET_ACCOF_Pos) /*!< Bit mask of ACCOF field. */
+#define QDEC_INTENSET_ACCOF_Disabled (0UL) /*!< Interrupt disabled. */
+#define QDEC_INTENSET_ACCOF_Enabled (1UL) /*!< Interrupt enabled. */
+#define QDEC_INTENSET_ACCOF_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on REPORTRDY event. */
+#define QDEC_INTENSET_REPORTRDY_Pos (1UL) /*!< Position of REPORTRDY field. */
+#define QDEC_INTENSET_REPORTRDY_Msk (0x1UL << QDEC_INTENSET_REPORTRDY_Pos) /*!< Bit mask of REPORTRDY field. */
+#define QDEC_INTENSET_REPORTRDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define QDEC_INTENSET_REPORTRDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define QDEC_INTENSET_REPORTRDY_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 0 : Enable interrupt on SAMPLERDY event. */
+#define QDEC_INTENSET_SAMPLERDY_Pos (0UL) /*!< Position of SAMPLERDY field. */
+#define QDEC_INTENSET_SAMPLERDY_Msk (0x1UL << QDEC_INTENSET_SAMPLERDY_Pos) /*!< Bit mask of SAMPLERDY field. */
+#define QDEC_INTENSET_SAMPLERDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define QDEC_INTENSET_SAMPLERDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define QDEC_INTENSET_SAMPLERDY_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: QDEC_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 2 : Disable interrupt on ACCOF event. */
+#define QDEC_INTENCLR_ACCOF_Pos (2UL) /*!< Position of ACCOF field. */
+#define QDEC_INTENCLR_ACCOF_Msk (0x1UL << QDEC_INTENCLR_ACCOF_Pos) /*!< Bit mask of ACCOF field. */
+#define QDEC_INTENCLR_ACCOF_Disabled (0UL) /*!< Interrupt disabled. */
+#define QDEC_INTENCLR_ACCOF_Enabled (1UL) /*!< Interrupt enabled. */
+#define QDEC_INTENCLR_ACCOF_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on REPORTRDY event. */
+#define QDEC_INTENCLR_REPORTRDY_Pos (1UL) /*!< Position of REPORTRDY field. */
+#define QDEC_INTENCLR_REPORTRDY_Msk (0x1UL << QDEC_INTENCLR_REPORTRDY_Pos) /*!< Bit mask of REPORTRDY field. */
+#define QDEC_INTENCLR_REPORTRDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define QDEC_INTENCLR_REPORTRDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define QDEC_INTENCLR_REPORTRDY_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 0 : Disable interrupt on SAMPLERDY event. */
+#define QDEC_INTENCLR_SAMPLERDY_Pos (0UL) /*!< Position of SAMPLERDY field. */
+#define QDEC_INTENCLR_SAMPLERDY_Msk (0x1UL << QDEC_INTENCLR_SAMPLERDY_Pos) /*!< Bit mask of SAMPLERDY field. */
+#define QDEC_INTENCLR_SAMPLERDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define QDEC_INTENCLR_SAMPLERDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define QDEC_INTENCLR_SAMPLERDY_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: QDEC_ENABLE */
+/* Description: Enable the QDEC. */
+
+/* Bit 0 : Enable or disable QDEC. */
+#define QDEC_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define QDEC_ENABLE_ENABLE_Msk (0x1UL << QDEC_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define QDEC_ENABLE_ENABLE_Disabled (0UL) /*!< Disabled QDEC. */
+#define QDEC_ENABLE_ENABLE_Enabled (1UL) /*!< Enable QDEC. */
+
+/* Register: QDEC_LEDPOL */
+/* Description: LED output pin polarity. */
+
+/* Bit 0 : LED output pin polarity. */
+#define QDEC_LEDPOL_LEDPOL_Pos (0UL) /*!< Position of LEDPOL field. */
+#define QDEC_LEDPOL_LEDPOL_Msk (0x1UL << QDEC_LEDPOL_LEDPOL_Pos) /*!< Bit mask of LEDPOL field. */
+#define QDEC_LEDPOL_LEDPOL_ActiveLow (0UL) /*!< LED output is active low. */
+#define QDEC_LEDPOL_LEDPOL_ActiveHigh (1UL) /*!< LED output is active high. */
+
+/* Register: QDEC_SAMPLEPER */
+/* Description: Sample period. */
+
+/* Bits 2..0 : Sample period. */
+#define QDEC_SAMPLEPER_SAMPLEPER_Pos (0UL) /*!< Position of SAMPLEPER field. */
+#define QDEC_SAMPLEPER_SAMPLEPER_Msk (0x7UL << QDEC_SAMPLEPER_SAMPLEPER_Pos) /*!< Bit mask of SAMPLEPER field. */
+#define QDEC_SAMPLEPER_SAMPLEPER_128us (0x00UL) /*!< 128us sample period. */
+#define QDEC_SAMPLEPER_SAMPLEPER_256us (0x01UL) /*!< 256us sample period. */
+#define QDEC_SAMPLEPER_SAMPLEPER_512us (0x02UL) /*!< 512us sample period. */
+#define QDEC_SAMPLEPER_SAMPLEPER_1024us (0x03UL) /*!< 1024us sample period. */
+#define QDEC_SAMPLEPER_SAMPLEPER_2048us (0x04UL) /*!< 2048us sample period. */
+#define QDEC_SAMPLEPER_SAMPLEPER_4096us (0x05UL) /*!< 4096us sample period. */
+#define QDEC_SAMPLEPER_SAMPLEPER_8192us (0x06UL) /*!< 8192us sample period. */
+#define QDEC_SAMPLEPER_SAMPLEPER_16384us (0x07UL) /*!< 16384us sample period. */
+
+/* Register: QDEC_SAMPLE */
+/* Description: Motion sample value. */
+
+/* Bits 31..0 : Last sample taken in compliment to 2. */
+#define QDEC_SAMPLE_SAMPLE_Pos (0UL) /*!< Position of SAMPLE field. */
+#define QDEC_SAMPLE_SAMPLE_Msk (0xFFFFFFFFUL << QDEC_SAMPLE_SAMPLE_Pos) /*!< Bit mask of SAMPLE field. */
+
+/* Register: QDEC_REPORTPER */
+/* Description: Number of samples to generate an EVENT_REPORTRDY. */
+
+/* Bits 2..0 : Number of samples to generate an EVENT_REPORTRDY. */
+#define QDEC_REPORTPER_REPORTPER_Pos (0UL) /*!< Position of REPORTPER field. */
+#define QDEC_REPORTPER_REPORTPER_Msk (0x7UL << QDEC_REPORTPER_REPORTPER_Pos) /*!< Bit mask of REPORTPER field. */
+#define QDEC_REPORTPER_REPORTPER_10Smpl (0x00UL) /*!< 10 samples per report. */
+#define QDEC_REPORTPER_REPORTPER_40Smpl (0x01UL) /*!< 40 samples per report. */
+#define QDEC_REPORTPER_REPORTPER_80Smpl (0x02UL) /*!< 80 samples per report. */
+#define QDEC_REPORTPER_REPORTPER_120Smpl (0x03UL) /*!< 120 samples per report. */
+#define QDEC_REPORTPER_REPORTPER_160Smpl (0x04UL) /*!< 160 samples per report. */
+#define QDEC_REPORTPER_REPORTPER_200Smpl (0x05UL) /*!< 200 samples per report. */
+#define QDEC_REPORTPER_REPORTPER_240Smpl (0x06UL) /*!< 240 samples per report. */
+#define QDEC_REPORTPER_REPORTPER_280Smpl (0x07UL) /*!< 280 samples per report. */
+
+/* Register: QDEC_DBFEN */
+/* Description: Enable debouncer input filters. */
+
+/* Bit 0 : Enable debounce input filters. */
+#define QDEC_DBFEN_DBFEN_Pos (0UL) /*!< Position of DBFEN field. */
+#define QDEC_DBFEN_DBFEN_Msk (0x1UL << QDEC_DBFEN_DBFEN_Pos) /*!< Bit mask of DBFEN field. */
+#define QDEC_DBFEN_DBFEN_Disabled (0UL) /*!< Debounce input filters disabled. */
+#define QDEC_DBFEN_DBFEN_Enabled (1UL) /*!< Debounce input filters enabled. */
+
+/* Register: QDEC_LEDPRE */
+/* Description: Time LED is switched ON before the sample. */
+
+/* Bits 8..0 : Period in us the LED in switched on prior to sampling. */
+#define QDEC_LEDPRE_LEDPRE_Pos (0UL) /*!< Position of LEDPRE field. */
+#define QDEC_LEDPRE_LEDPRE_Msk (0x1FFUL << QDEC_LEDPRE_LEDPRE_Pos) /*!< Bit mask of LEDPRE field. */
+
+/* Register: QDEC_ACCDBL */
+/* Description: Accumulated double (error) transitions register. */
+
+/* Bits 3..0 : Accumulated double (error) transitions. */
+#define QDEC_ACCDBL_ACCDBL_Pos (0UL) /*!< Position of ACCDBL field. */
+#define QDEC_ACCDBL_ACCDBL_Msk (0xFUL << QDEC_ACCDBL_ACCDBL_Pos) /*!< Bit mask of ACCDBL field. */
+
+/* Register: QDEC_ACCDBLREAD */
+/* Description: Snapshot of ACCDBL register. Value generated by the TASKS_READCLEACC task. */
+
+/* Bits 3..0 : Snapshot of accumulated double (error) transitions. */
+#define QDEC_ACCDBLREAD_ACCDBLREAD_Pos (0UL) /*!< Position of ACCDBLREAD field. */
+#define QDEC_ACCDBLREAD_ACCDBLREAD_Msk (0xFUL << QDEC_ACCDBLREAD_ACCDBLREAD_Pos) /*!< Bit mask of ACCDBLREAD field. */
+
+/* Register: QDEC_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define QDEC_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define QDEC_POWER_POWER_Msk (0x1UL << QDEC_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define QDEC_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define QDEC_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: RADIO */
+/* Description: The radio. */
+
+/* Register: RADIO_SHORTS */
+/* Description: Shortcuts for the radio. */
+
+/* Bit 8 : Shortcut between DISABLED event and RSSISTOP task. */
+#define RADIO_SHORTS_DISABLED_RSSISTOP_Pos (8UL) /*!< Position of DISABLED_RSSISTOP field. */
+#define RADIO_SHORTS_DISABLED_RSSISTOP_Msk (0x1UL << RADIO_SHORTS_DISABLED_RSSISTOP_Pos) /*!< Bit mask of DISABLED_RSSISTOP field. */
+#define RADIO_SHORTS_DISABLED_RSSISTOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define RADIO_SHORTS_DISABLED_RSSISTOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 6 : Shortcut between ADDRESS event and BCSTART task. */
+#define RADIO_SHORTS_ADDRESS_BCSTART_Pos (6UL) /*!< Position of ADDRESS_BCSTART field. */
+#define RADIO_SHORTS_ADDRESS_BCSTART_Msk (0x1UL << RADIO_SHORTS_ADDRESS_BCSTART_Pos) /*!< Bit mask of ADDRESS_BCSTART field. */
+#define RADIO_SHORTS_ADDRESS_BCSTART_Disabled (0UL) /*!< Shortcut disabled. */
+#define RADIO_SHORTS_ADDRESS_BCSTART_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 5 : Shortcut between END event and START task. */
+#define RADIO_SHORTS_END_START_Pos (5UL) /*!< Position of END_START field. */
+#define RADIO_SHORTS_END_START_Msk (0x1UL << RADIO_SHORTS_END_START_Pos) /*!< Bit mask of END_START field. */
+#define RADIO_SHORTS_END_START_Disabled (0UL) /*!< Shortcut disabled. */
+#define RADIO_SHORTS_END_START_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 4 : Shortcut between ADDRESS event and RSSISTART task. */
+#define RADIO_SHORTS_ADDRESS_RSSISTART_Pos (4UL) /*!< Position of ADDRESS_RSSISTART field. */
+#define RADIO_SHORTS_ADDRESS_RSSISTART_Msk (0x1UL << RADIO_SHORTS_ADDRESS_RSSISTART_Pos) /*!< Bit mask of ADDRESS_RSSISTART field. */
+#define RADIO_SHORTS_ADDRESS_RSSISTART_Disabled (0UL) /*!< Shortcut disabled. */
+#define RADIO_SHORTS_ADDRESS_RSSISTART_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 3 : Shortcut between DISABLED event and RXEN task. */
+#define RADIO_SHORTS_DISABLED_RXEN_Pos (3UL) /*!< Position of DISABLED_RXEN field. */
+#define RADIO_SHORTS_DISABLED_RXEN_Msk (0x1UL << RADIO_SHORTS_DISABLED_RXEN_Pos) /*!< Bit mask of DISABLED_RXEN field. */
+#define RADIO_SHORTS_DISABLED_RXEN_Disabled (0UL) /*!< Shortcut disabled. */
+#define RADIO_SHORTS_DISABLED_RXEN_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 2 : Shortcut between DISABLED event and TXEN task.  */
+#define RADIO_SHORTS_DISABLED_TXEN_Pos (2UL) /*!< Position of DISABLED_TXEN field. */
+#define RADIO_SHORTS_DISABLED_TXEN_Msk (0x1UL << RADIO_SHORTS_DISABLED_TXEN_Pos) /*!< Bit mask of DISABLED_TXEN field. */
+#define RADIO_SHORTS_DISABLED_TXEN_Disabled (0UL) /*!< Shortcut disabled. */
+#define RADIO_SHORTS_DISABLED_TXEN_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 1 : Shortcut between END event and DISABLE task. */
+#define RADIO_SHORTS_END_DISABLE_Pos (1UL) /*!< Position of END_DISABLE field. */
+#define RADIO_SHORTS_END_DISABLE_Msk (0x1UL << RADIO_SHORTS_END_DISABLE_Pos) /*!< Bit mask of END_DISABLE field. */
+#define RADIO_SHORTS_END_DISABLE_Disabled (0UL) /*!< Shortcut disabled. */
+#define RADIO_SHORTS_END_DISABLE_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 0 : Shortcut between READY event and START task. */
+#define RADIO_SHORTS_READY_START_Pos (0UL) /*!< Position of READY_START field. */
+#define RADIO_SHORTS_READY_START_Msk (0x1UL << RADIO_SHORTS_READY_START_Pos) /*!< Bit mask of READY_START field. */
+#define RADIO_SHORTS_READY_START_Disabled (0UL) /*!< Shortcut disabled. */
+#define RADIO_SHORTS_READY_START_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Register: RADIO_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 10 : Enable interrupt on BCMATCH event. */
+#define RADIO_INTENSET_BCMATCH_Pos (10UL) /*!< Position of BCMATCH field. */
+#define RADIO_INTENSET_BCMATCH_Msk (0x1UL << RADIO_INTENSET_BCMATCH_Pos) /*!< Bit mask of BCMATCH field. */
+#define RADIO_INTENSET_BCMATCH_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENSET_BCMATCH_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENSET_BCMATCH_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 7 : Enable interrupt on RSSIEND event. */
+#define RADIO_INTENSET_RSSIEND_Pos (7UL) /*!< Position of RSSIEND field. */
+#define RADIO_INTENSET_RSSIEND_Msk (0x1UL << RADIO_INTENSET_RSSIEND_Pos) /*!< Bit mask of RSSIEND field. */
+#define RADIO_INTENSET_RSSIEND_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENSET_RSSIEND_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENSET_RSSIEND_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 6 : Enable interrupt on DEVMISS event. */
+#define RADIO_INTENSET_DEVMISS_Pos (6UL) /*!< Position of DEVMISS field. */
+#define RADIO_INTENSET_DEVMISS_Msk (0x1UL << RADIO_INTENSET_DEVMISS_Pos) /*!< Bit mask of DEVMISS field. */
+#define RADIO_INTENSET_DEVMISS_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENSET_DEVMISS_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENSET_DEVMISS_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 5 : Enable interrupt on DEVMATCH event. */
+#define RADIO_INTENSET_DEVMATCH_Pos (5UL) /*!< Position of DEVMATCH field. */
+#define RADIO_INTENSET_DEVMATCH_Msk (0x1UL << RADIO_INTENSET_DEVMATCH_Pos) /*!< Bit mask of DEVMATCH field. */
+#define RADIO_INTENSET_DEVMATCH_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENSET_DEVMATCH_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENSET_DEVMATCH_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 4 : Enable interrupt on DISABLED event. */
+#define RADIO_INTENSET_DISABLED_Pos (4UL) /*!< Position of DISABLED field. */
+#define RADIO_INTENSET_DISABLED_Msk (0x1UL << RADIO_INTENSET_DISABLED_Pos) /*!< Bit mask of DISABLED field. */
+#define RADIO_INTENSET_DISABLED_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENSET_DISABLED_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENSET_DISABLED_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 3 : Enable interrupt on END event. */
+#define RADIO_INTENSET_END_Pos (3UL) /*!< Position of END field. */
+#define RADIO_INTENSET_END_Msk (0x1UL << RADIO_INTENSET_END_Pos) /*!< Bit mask of END field. */
+#define RADIO_INTENSET_END_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENSET_END_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENSET_END_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 2 : Enable interrupt on PAYLOAD event. */
+#define RADIO_INTENSET_PAYLOAD_Pos (2UL) /*!< Position of PAYLOAD field. */
+#define RADIO_INTENSET_PAYLOAD_Msk (0x1UL << RADIO_INTENSET_PAYLOAD_Pos) /*!< Bit mask of PAYLOAD field. */
+#define RADIO_INTENSET_PAYLOAD_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENSET_PAYLOAD_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENSET_PAYLOAD_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on ADDRESS event. */
+#define RADIO_INTENSET_ADDRESS_Pos (1UL) /*!< Position of ADDRESS field. */
+#define RADIO_INTENSET_ADDRESS_Msk (0x1UL << RADIO_INTENSET_ADDRESS_Pos) /*!< Bit mask of ADDRESS field. */
+#define RADIO_INTENSET_ADDRESS_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENSET_ADDRESS_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENSET_ADDRESS_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 0 : Enable interrupt on READY event. */
+#define RADIO_INTENSET_READY_Pos (0UL) /*!< Position of READY field. */
+#define RADIO_INTENSET_READY_Msk (0x1UL << RADIO_INTENSET_READY_Pos) /*!< Bit mask of READY field. */
+#define RADIO_INTENSET_READY_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENSET_READY_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENSET_READY_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: RADIO_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 10 : Disable interrupt on BCMATCH event. */
+#define RADIO_INTENCLR_BCMATCH_Pos (10UL) /*!< Position of BCMATCH field. */
+#define RADIO_INTENCLR_BCMATCH_Msk (0x1UL << RADIO_INTENCLR_BCMATCH_Pos) /*!< Bit mask of BCMATCH field. */
+#define RADIO_INTENCLR_BCMATCH_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENCLR_BCMATCH_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENCLR_BCMATCH_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 7 : Disable interrupt on RSSIEND event. */
+#define RADIO_INTENCLR_RSSIEND_Pos (7UL) /*!< Position of RSSIEND field. */
+#define RADIO_INTENCLR_RSSIEND_Msk (0x1UL << RADIO_INTENCLR_RSSIEND_Pos) /*!< Bit mask of RSSIEND field. */
+#define RADIO_INTENCLR_RSSIEND_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENCLR_RSSIEND_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENCLR_RSSIEND_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 6 : Disable interrupt on DEVMISS event. */
+#define RADIO_INTENCLR_DEVMISS_Pos (6UL) /*!< Position of DEVMISS field. */
+#define RADIO_INTENCLR_DEVMISS_Msk (0x1UL << RADIO_INTENCLR_DEVMISS_Pos) /*!< Bit mask of DEVMISS field. */
+#define RADIO_INTENCLR_DEVMISS_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENCLR_DEVMISS_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENCLR_DEVMISS_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 5 : Disable interrupt on DEVMATCH event. */
+#define RADIO_INTENCLR_DEVMATCH_Pos (5UL) /*!< Position of DEVMATCH field. */
+#define RADIO_INTENCLR_DEVMATCH_Msk (0x1UL << RADIO_INTENCLR_DEVMATCH_Pos) /*!< Bit mask of DEVMATCH field. */
+#define RADIO_INTENCLR_DEVMATCH_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENCLR_DEVMATCH_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENCLR_DEVMATCH_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 4 : Disable interrupt on DISABLED event. */
+#define RADIO_INTENCLR_DISABLED_Pos (4UL) /*!< Position of DISABLED field. */
+#define RADIO_INTENCLR_DISABLED_Msk (0x1UL << RADIO_INTENCLR_DISABLED_Pos) /*!< Bit mask of DISABLED field. */
+#define RADIO_INTENCLR_DISABLED_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENCLR_DISABLED_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENCLR_DISABLED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 3 : Disable interrupt on END event. */
+#define RADIO_INTENCLR_END_Pos (3UL) /*!< Position of END field. */
+#define RADIO_INTENCLR_END_Msk (0x1UL << RADIO_INTENCLR_END_Pos) /*!< Bit mask of END field. */
+#define RADIO_INTENCLR_END_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENCLR_END_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENCLR_END_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 2 : Disable interrupt on PAYLOAD event. */
+#define RADIO_INTENCLR_PAYLOAD_Pos (2UL) /*!< Position of PAYLOAD field. */
+#define RADIO_INTENCLR_PAYLOAD_Msk (0x1UL << RADIO_INTENCLR_PAYLOAD_Pos) /*!< Bit mask of PAYLOAD field. */
+#define RADIO_INTENCLR_PAYLOAD_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENCLR_PAYLOAD_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENCLR_PAYLOAD_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on ADDRESS event. */
+#define RADIO_INTENCLR_ADDRESS_Pos (1UL) /*!< Position of ADDRESS field. */
+#define RADIO_INTENCLR_ADDRESS_Msk (0x1UL << RADIO_INTENCLR_ADDRESS_Pos) /*!< Bit mask of ADDRESS field. */
+#define RADIO_INTENCLR_ADDRESS_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENCLR_ADDRESS_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENCLR_ADDRESS_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 0 : Disable interrupt on READY event. */
+#define RADIO_INTENCLR_READY_Pos (0UL) /*!< Position of READY field. */
+#define RADIO_INTENCLR_READY_Msk (0x1UL << RADIO_INTENCLR_READY_Pos) /*!< Bit mask of READY field. */
+#define RADIO_INTENCLR_READY_Disabled (0UL) /*!< Interrupt disabled. */
+#define RADIO_INTENCLR_READY_Enabled (1UL) /*!< Interrupt enabled. */
+#define RADIO_INTENCLR_READY_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: RADIO_CRCSTATUS */
+/* Description: CRC status of received packet. */
+
+/* Bit 0 : CRC status of received packet. */
+#define RADIO_CRCSTATUS_CRCSTATUS_Pos (0UL) /*!< Position of CRCSTATUS field. */
+#define RADIO_CRCSTATUS_CRCSTATUS_Msk (0x1UL << RADIO_CRCSTATUS_CRCSTATUS_Pos) /*!< Bit mask of CRCSTATUS field. */
+#define RADIO_CRCSTATUS_CRCSTATUS_CRCError (0UL) /*!< Packet received with CRC error. */
+#define RADIO_CRCSTATUS_CRCSTATUS_CRCOk (1UL) /*!< Packet received with CRC ok. */
+
+/* Register: RADIO_RXMATCH */
+/* Description: Received address. */
+
+/* Bits 2..0 : Logical address in which previous packet was received. */
+#define RADIO_RXMATCH_RXMATCH_Pos (0UL) /*!< Position of RXMATCH field. */
+#define RADIO_RXMATCH_RXMATCH_Msk (0x7UL << RADIO_RXMATCH_RXMATCH_Pos) /*!< Bit mask of RXMATCH field. */
+
+/* Register: RADIO_RXCRC */
+/* Description: Received CRC. */
+
+/* Bits 23..0 : CRC field of previously received packet. */
+#define RADIO_RXCRC_RXCRC_Pos (0UL) /*!< Position of RXCRC field. */
+#define RADIO_RXCRC_RXCRC_Msk (0xFFFFFFUL << RADIO_RXCRC_RXCRC_Pos) /*!< Bit mask of RXCRC field. */
+
+/* Register: RADIO_DAI */
+/* Description: Device address match index. */
+
+/* Bits 2..0 : Index (n) of device address (see DAB[n] and DAP[n]) that obtained an address match. */
+#define RADIO_DAI_DAI_Pos (0UL) /*!< Position of DAI field. */
+#define RADIO_DAI_DAI_Msk (0x7UL << RADIO_DAI_DAI_Pos) /*!< Bit mask of DAI field. */
+
+/* Register: RADIO_FREQUENCY */
+/* Description: Frequency. */
+
+/* Bits 6..0 : Radio channel frequency offset in MHz: RF Frequency = 2400 + FREQUENCY (MHz). Decision point: TXEN or RXEN task.  */
+#define RADIO_FREQUENCY_FREQUENCY_Pos (0UL) /*!< Position of FREQUENCY field. */
+#define RADIO_FREQUENCY_FREQUENCY_Msk (0x7FUL << RADIO_FREQUENCY_FREQUENCY_Pos) /*!< Bit mask of FREQUENCY field. */
+
+/* Register: RADIO_TXPOWER */
+/* Description: Output power. */
+
+/* Bits 7..0 : Radio output power. Decision point: TXEN task. */
+#define RADIO_TXPOWER_TXPOWER_Pos (0UL) /*!< Position of TXPOWER field. */
+#define RADIO_TXPOWER_TXPOWER_Msk (0xFFUL << RADIO_TXPOWER_TXPOWER_Pos) /*!< Bit mask of TXPOWER field. */
+#define RADIO_TXPOWER_TXPOWER_0dBm (0x00UL) /*!< 0dBm. */
+#define RADIO_TXPOWER_TXPOWER_Pos4dBm (0x04UL) /*!< +4dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg30dBm (0xD8UL) /*!< -30dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg20dBm (0xECUL) /*!< -20dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg16dBm (0xF0UL) /*!< -16dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg12dBm (0xF4UL) /*!< -12dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg8dBm (0xF8UL) /*!< -8dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg4dBm (0xFCUL) /*!< -4dBm. */
+
+/* Register: RADIO_MODE */
+/* Description: Data rate and modulation. */
+
+/* Bits 1..0 : Radio data rate and modulation setting. Decision point: TXEN or RXEN task. */
+#define RADIO_MODE_MODE_Pos (0UL) /*!< Position of MODE field. */
+#define RADIO_MODE_MODE_Msk (0x3UL << RADIO_MODE_MODE_Pos) /*!< Bit mask of MODE field. */
+#define RADIO_MODE_MODE_Nrf_1Mbit (0x00UL) /*!< 1Mbit/s Nordic propietary radio mode. */
+#define RADIO_MODE_MODE_Nrf_2Mbit (0x01UL) /*!< 2Mbit/s Nordic propietary radio mode. */
+#define RADIO_MODE_MODE_Nrf_250Kbit (0x02UL) /*!< 250kbit/s Nordic propietary radio mode. */
+#define RADIO_MODE_MODE_Ble_1Mbit (0x03UL) /*!< 1Mbit/s Bluetooth Low Energy */
+
+/* Register: RADIO_PCNF0 */
+/* Description: Packet configuration 0. */
+
+/* Bits 19..16 : Length of S1 field in number of bits. Decision point: START task. */
+#define RADIO_PCNF0_S1LEN_Pos (16UL) /*!< Position of S1LEN field. */
+#define RADIO_PCNF0_S1LEN_Msk (0xFUL << RADIO_PCNF0_S1LEN_Pos) /*!< Bit mask of S1LEN field. */
+
+/* Bit 8 : Length of S0 field in number of bytes. Decision point: START task. */
+#define RADIO_PCNF0_S0LEN_Pos (8UL) /*!< Position of S0LEN field. */
+#define RADIO_PCNF0_S0LEN_Msk (0x1UL << RADIO_PCNF0_S0LEN_Pos) /*!< Bit mask of S0LEN field. */
+
+/* Bits 3..0 : Length of length field in number of bits. Decision point: START task. */
+#define RADIO_PCNF0_LFLEN_Pos (0UL) /*!< Position of LFLEN field. */
+#define RADIO_PCNF0_LFLEN_Msk (0xFUL << RADIO_PCNF0_LFLEN_Pos) /*!< Bit mask of LFLEN field. */
+
+/* Register: RADIO_PCNF1 */
+/* Description: Packet configuration 1. */
+
+/* Bit 25 : Packet whitening enable. */
+#define RADIO_PCNF1_WHITEEN_Pos (25UL) /*!< Position of WHITEEN field. */
+#define RADIO_PCNF1_WHITEEN_Msk (0x1UL << RADIO_PCNF1_WHITEEN_Pos) /*!< Bit mask of WHITEEN field. */
+#define RADIO_PCNF1_WHITEEN_Disabled (0UL) /*!< Whitening disabled. */
+#define RADIO_PCNF1_WHITEEN_Enabled (1UL) /*!< Whitening enabled. */
+
+/* Bit 24 : On air endianness of packet length field. Decision point: START task. */
+#define RADIO_PCNF1_ENDIAN_Pos (24UL) /*!< Position of ENDIAN field. */
+#define RADIO_PCNF1_ENDIAN_Msk (0x1UL << RADIO_PCNF1_ENDIAN_Pos) /*!< Bit mask of ENDIAN field. */
+#define RADIO_PCNF1_ENDIAN_Little (0UL) /*!< Least significant bit on air first */
+#define RADIO_PCNF1_ENDIAN_Big (1UL) /*!< Most significant bit on air first */
+
+/* Bits 18..16 : Base address length in number of bytes. Decision point: START task. */
+#define RADIO_PCNF1_BALEN_Pos (16UL) /*!< Position of BALEN field. */
+#define RADIO_PCNF1_BALEN_Msk (0x7UL << RADIO_PCNF1_BALEN_Pos) /*!< Bit mask of BALEN field. */
+
+/* Bits 15..8 : Static length in number of bytes. Decision point: START task. */
+#define RADIO_PCNF1_STATLEN_Pos (8UL) /*!< Position of STATLEN field. */
+#define RADIO_PCNF1_STATLEN_Msk (0xFFUL << RADIO_PCNF1_STATLEN_Pos) /*!< Bit mask of STATLEN field. */
+
+/* Bits 7..0 : Maximum length of packet payload in number of bytes. */
+#define RADIO_PCNF1_MAXLEN_Pos (0UL) /*!< Position of MAXLEN field. */
+#define RADIO_PCNF1_MAXLEN_Msk (0xFFUL << RADIO_PCNF1_MAXLEN_Pos) /*!< Bit mask of MAXLEN field. */
+
+/* Register: RADIO_PREFIX0 */
+/* Description: Prefixes bytes for logical addresses 0 to 3. */
+
+/* Bits 31..24 : Address prefix 3. Decision point: START task. */
+#define RADIO_PREFIX0_AP3_Pos (24UL) /*!< Position of AP3 field. */
+#define RADIO_PREFIX0_AP3_Msk (0xFFUL << RADIO_PREFIX0_AP3_Pos) /*!< Bit mask of AP3 field. */
+
+/* Bits 23..16 : Address prefix 2. Decision point: START task. */
+#define RADIO_PREFIX0_AP2_Pos (16UL) /*!< Position of AP2 field. */
+#define RADIO_PREFIX0_AP2_Msk (0xFFUL << RADIO_PREFIX0_AP2_Pos) /*!< Bit mask of AP2 field. */
+
+/* Bits 15..8 : Address prefix 1. Decision point: START task. */
+#define RADIO_PREFIX0_AP1_Pos (8UL) /*!< Position of AP1 field. */
+#define RADIO_PREFIX0_AP1_Msk (0xFFUL << RADIO_PREFIX0_AP1_Pos) /*!< Bit mask of AP1 field. */
+
+/* Bits 7..0 : Address prefix 0. Decision point: START task. */
+#define RADIO_PREFIX0_AP0_Pos (0UL) /*!< Position of AP0 field. */
+#define RADIO_PREFIX0_AP0_Msk (0xFFUL << RADIO_PREFIX0_AP0_Pos) /*!< Bit mask of AP0 field. */
+
+/* Register: RADIO_PREFIX1 */
+/* Description: Prefixes bytes for logical addresses 4 to 7. */
+
+/* Bits 31..24 : Address prefix 7. Decision point: START task. */
+#define RADIO_PREFIX1_AP7_Pos (24UL) /*!< Position of AP7 field. */
+#define RADIO_PREFIX1_AP7_Msk (0xFFUL << RADIO_PREFIX1_AP7_Pos) /*!< Bit mask of AP7 field. */
+
+/* Bits 23..16 : Address prefix 6. Decision point: START task. */
+#define RADIO_PREFIX1_AP6_Pos (16UL) /*!< Position of AP6 field. */
+#define RADIO_PREFIX1_AP6_Msk (0xFFUL << RADIO_PREFIX1_AP6_Pos) /*!< Bit mask of AP6 field. */
+
+/* Bits 15..8 : Address prefix 5. Decision point: START task. */
+#define RADIO_PREFIX1_AP5_Pos (8UL) /*!< Position of AP5 field. */
+#define RADIO_PREFIX1_AP5_Msk (0xFFUL << RADIO_PREFIX1_AP5_Pos) /*!< Bit mask of AP5 field. */
+
+/* Bits 7..0 : Address prefix 4. Decision point: START task. */
+#define RADIO_PREFIX1_AP4_Pos (0UL) /*!< Position of AP4 field. */
+#define RADIO_PREFIX1_AP4_Msk (0xFFUL << RADIO_PREFIX1_AP4_Pos) /*!< Bit mask of AP4 field. */
+
+/* Register: RADIO_TXADDRESS */
+/* Description: Transmit address select. */
+
+/* Bits 2..0 : Logical address to be used when transmitting a packet. Decision point: START task. */
+#define RADIO_TXADDRESS_TXADDRESS_Pos (0UL) /*!< Position of TXADDRESS field. */
+#define RADIO_TXADDRESS_TXADDRESS_Msk (0x7UL << RADIO_TXADDRESS_TXADDRESS_Pos) /*!< Bit mask of TXADDRESS field. */
+
+/* Register: RADIO_RXADDRESSES */
+/* Description: Receive address select. */
+
+/* Bit 7 : Enable reception on logical address 7. Decision point: START task. */
+#define RADIO_RXADDRESSES_ADDR7_Pos (7UL) /*!< Position of ADDR7 field. */
+#define RADIO_RXADDRESSES_ADDR7_Msk (0x1UL << RADIO_RXADDRESSES_ADDR7_Pos) /*!< Bit mask of ADDR7 field. */
+#define RADIO_RXADDRESSES_ADDR7_Disabled (0UL) /*!< Reception disabled. */
+#define RADIO_RXADDRESSES_ADDR7_Enabled (1UL) /*!< Reception enabled. */
+
+/* Bit 6 : Enable reception on logical address 6. Decision point: START task. */
+#define RADIO_RXADDRESSES_ADDR6_Pos (6UL) /*!< Position of ADDR6 field. */
+#define RADIO_RXADDRESSES_ADDR6_Msk (0x1UL << RADIO_RXADDRESSES_ADDR6_Pos) /*!< Bit mask of ADDR6 field. */
+#define RADIO_RXADDRESSES_ADDR6_Disabled (0UL) /*!< Reception disabled. */
+#define RADIO_RXADDRESSES_ADDR6_Enabled (1UL) /*!< Reception enabled. */
+
+/* Bit 5 : Enable reception on logical address 5. Decision point: START task. */
+#define RADIO_RXADDRESSES_ADDR5_Pos (5UL) /*!< Position of ADDR5 field. */
+#define RADIO_RXADDRESSES_ADDR5_Msk (0x1UL << RADIO_RXADDRESSES_ADDR5_Pos) /*!< Bit mask of ADDR5 field. */
+#define RADIO_RXADDRESSES_ADDR5_Disabled (0UL) /*!< Reception disabled. */
+#define RADIO_RXADDRESSES_ADDR5_Enabled (1UL) /*!< Reception enabled. */
+
+/* Bit 4 : Enable reception on logical address 4. Decision point: START task. */
+#define RADIO_RXADDRESSES_ADDR4_Pos (4UL) /*!< Position of ADDR4 field. */
+#define RADIO_RXADDRESSES_ADDR4_Msk (0x1UL << RADIO_RXADDRESSES_ADDR4_Pos) /*!< Bit mask of ADDR4 field. */
+#define RADIO_RXADDRESSES_ADDR4_Disabled (0UL) /*!< Reception disabled. */
+#define RADIO_RXADDRESSES_ADDR4_Enabled (1UL) /*!< Reception enabled. */
+
+/* Bit 3 : Enable reception on logical address 3. Decision point: START task. */
+#define RADIO_RXADDRESSES_ADDR3_Pos (3UL) /*!< Position of ADDR3 field. */
+#define RADIO_RXADDRESSES_ADDR3_Msk (0x1UL << RADIO_RXADDRESSES_ADDR3_Pos) /*!< Bit mask of ADDR3 field. */
+#define RADIO_RXADDRESSES_ADDR3_Disabled (0UL) /*!< Reception disabled. */
+#define RADIO_RXADDRESSES_ADDR3_Enabled (1UL) /*!< Reception enabled. */
+
+/* Bit 2 : Enable reception on logical address 2. Decision point: START task. */
+#define RADIO_RXADDRESSES_ADDR2_Pos (2UL) /*!< Position of ADDR2 field. */
+#define RADIO_RXADDRESSES_ADDR2_Msk (0x1UL << RADIO_RXADDRESSES_ADDR2_Pos) /*!< Bit mask of ADDR2 field. */
+#define RADIO_RXADDRESSES_ADDR2_Disabled (0UL) /*!< Reception disabled. */
+#define RADIO_RXADDRESSES_ADDR2_Enabled (1UL) /*!< Reception enabled. */
+
+/* Bit 1 : Enable reception on logical address 1. Decision point: START task. */
+#define RADIO_RXADDRESSES_ADDR1_Pos (1UL) /*!< Position of ADDR1 field. */
+#define RADIO_RXADDRESSES_ADDR1_Msk (0x1UL << RADIO_RXADDRESSES_ADDR1_Pos) /*!< Bit mask of ADDR1 field. */
+#define RADIO_RXADDRESSES_ADDR1_Disabled (0UL) /*!< Reception disabled. */
+#define RADIO_RXADDRESSES_ADDR1_Enabled (1UL) /*!< Reception enabled. */
+
+/* Bit 0 : Enable reception on logical address 0. Decision point: START task. */
+#define RADIO_RXADDRESSES_ADDR0_Pos (0UL) /*!< Position of ADDR0 field. */
+#define RADIO_RXADDRESSES_ADDR0_Msk (0x1UL << RADIO_RXADDRESSES_ADDR0_Pos) /*!< Bit mask of ADDR0 field. */
+#define RADIO_RXADDRESSES_ADDR0_Disabled (0UL) /*!< Reception disabled. */
+#define RADIO_RXADDRESSES_ADDR0_Enabled (1UL) /*!< Reception enabled. */
+
+/* Register: RADIO_CRCCNF */
+/* Description: CRC configuration. */
+
+/* Bit 8 : Leave packet address field out of the CRC calculation. Decision point: START task. */
+#define RADIO_CRCCNF_SKIPADDR_Pos (8UL) /*!< Position of SKIPADDR field. */
+#define RADIO_CRCCNF_SKIPADDR_Msk (0x1UL << RADIO_CRCCNF_SKIPADDR_Pos) /*!< Bit mask of SKIPADDR field. */
+#define RADIO_CRCCNF_SKIPADDR_Include (0UL) /*!< Include packet address in CRC calculation. */
+#define RADIO_CRCCNF_SKIPADDR_Skip (1UL) /*!< Packet address is skipped in CRC calculation. The CRC calculation will start at the first byte after the address. */
+
+/* Bits 1..0 : CRC length. Decision point: START task. */
+#define RADIO_CRCCNF_LEN_Pos (0UL) /*!< Position of LEN field. */
+#define RADIO_CRCCNF_LEN_Msk (0x3UL << RADIO_CRCCNF_LEN_Pos) /*!< Bit mask of LEN field. */
+#define RADIO_CRCCNF_LEN_Disabled (0UL) /*!< CRC calculation disabled. */
+#define RADIO_CRCCNF_LEN_One (1UL) /*!< One byte long CRC. */
+#define RADIO_CRCCNF_LEN_Two (2UL) /*!< Two bytes long CRC. */
+#define RADIO_CRCCNF_LEN_Three (3UL) /*!< Three bytes long CRC. */
+
+/* Register: RADIO_CRCPOLY */
+/* Description: CRC polynomial. */
+
+/* Bits 23..0 : CRC polynomial. Decision point: START task. */
+#define RADIO_CRCPOLY_CRCPOLY_Pos (0UL) /*!< Position of CRCPOLY field. */
+#define RADIO_CRCPOLY_CRCPOLY_Msk (0xFFFFFFUL << RADIO_CRCPOLY_CRCPOLY_Pos) /*!< Bit mask of CRCPOLY field. */
+
+/* Register: RADIO_CRCINIT */
+/* Description: CRC initial value. */
+
+/* Bits 23..0 : Initial value for CRC calculation. Decision point: START task. */
+#define RADIO_CRCINIT_CRCINIT_Pos (0UL) /*!< Position of CRCINIT field. */
+#define RADIO_CRCINIT_CRCINIT_Msk (0xFFFFFFUL << RADIO_CRCINIT_CRCINIT_Pos) /*!< Bit mask of CRCINIT field. */
+
+/* Register: RADIO_TEST */
+/* Description: Test features enable register. */
+
+/* Bit 1 : PLL lock. Decision point: TXEN or RXEN task. */
+#define RADIO_TEST_PLLLOCK_Pos (1UL) /*!< Position of PLLLOCK field. */
+#define RADIO_TEST_PLLLOCK_Msk (0x1UL << RADIO_TEST_PLLLOCK_Pos) /*!< Bit mask of PLLLOCK field. */
+#define RADIO_TEST_PLLLOCK_Disabled (0UL) /*!< PLL lock disabled. */
+#define RADIO_TEST_PLLLOCK_Enabled (1UL) /*!< PLL lock enabled. */
+
+/* Bit 0 : Constant carrier. Decision point: TXEN task. */
+#define RADIO_TEST_CONSTCARRIER_Pos (0UL) /*!< Position of CONSTCARRIER field. */
+#define RADIO_TEST_CONSTCARRIER_Msk (0x1UL << RADIO_TEST_CONSTCARRIER_Pos) /*!< Bit mask of CONSTCARRIER field. */
+#define RADIO_TEST_CONSTCARRIER_Disabled (0UL) /*!< Constant carrier disabled. */
+#define RADIO_TEST_CONSTCARRIER_Enabled (1UL) /*!< Constant carrier enabled. */
+
+/* Register: RADIO_TIFS */
+/* Description: Inter Frame Spacing in microseconds. */
+
+/* Bits 7..0 : Inter frame spacing in microseconds. Decision point: START rask */
+#define RADIO_TIFS_TIFS_Pos (0UL) /*!< Position of TIFS field. */
+#define RADIO_TIFS_TIFS_Msk (0xFFUL << RADIO_TIFS_TIFS_Pos) /*!< Bit mask of TIFS field. */
+
+/* Register: RADIO_RSSISAMPLE */
+/* Description: RSSI sample. */
+
+/* Bits 6..0 : RSSI sample result. The result is read as a positive value so that ReceivedSignalStrength = -RSSISAMPLE dBm */
+#define RADIO_RSSISAMPLE_RSSISAMPLE_Pos (0UL) /*!< Position of RSSISAMPLE field. */
+#define RADIO_RSSISAMPLE_RSSISAMPLE_Msk (0x7FUL << RADIO_RSSISAMPLE_RSSISAMPLE_Pos) /*!< Bit mask of RSSISAMPLE field. */
+
+/* Register: RADIO_STATE */
+/* Description: Current radio state. */
+
+/* Bits 3..0 : Current radio state. */
+#define RADIO_STATE_STATE_Pos (0UL) /*!< Position of STATE field. */
+#define RADIO_STATE_STATE_Msk (0xFUL << RADIO_STATE_STATE_Pos) /*!< Bit mask of STATE field. */
+#define RADIO_STATE_STATE_Disabled (0x00UL) /*!< Radio is in the Disabled state. */
+#define RADIO_STATE_STATE_RxRu (0x01UL) /*!< Radio is in the Rx Ramp Up state. */
+#define RADIO_STATE_STATE_RxIdle (0x02UL) /*!< Radio is in the Rx Idle state. */
+#define RADIO_STATE_STATE_Rx (0x03UL) /*!< Radio is in the Rx state. */
+#define RADIO_STATE_STATE_RxDisable (0x04UL) /*!< Radio is in the Rx Disable state. */
+#define RADIO_STATE_STATE_TxRu (0x09UL) /*!< Radio is in the Tx Ramp Up state. */
+#define RADIO_STATE_STATE_TxIdle (0x0AUL) /*!< Radio is in the Tx Idle state. */
+#define RADIO_STATE_STATE_Tx (0x0BUL) /*!< Radio is in the Tx state. */
+#define RADIO_STATE_STATE_TxDisable (0x0CUL) /*!< Radio is in the Tx Disable state. */
+
+/* Register: RADIO_DATAWHITEIV */
+/* Description: Data whitening initial value. */
+
+/* Bits 6..0 : Data whitening initial value. Bit 0 corresponds to Position 0 of the LSFR, Bit 1 to position 5... Decision point: TXEN or RXEN task. */
+#define RADIO_DATAWHITEIV_DATAWHITEIV_Pos (0UL) /*!< Position of DATAWHITEIV field. */
+#define RADIO_DATAWHITEIV_DATAWHITEIV_Msk (0x7FUL << RADIO_DATAWHITEIV_DATAWHITEIV_Pos) /*!< Bit mask of DATAWHITEIV field. */
+
+/* Register: RADIO_DAP */
+/* Description: Device address prefix. */
+
+/* Bits 15..0 : Device address prefix. */
+#define RADIO_DAP_DAP_Pos (0UL) /*!< Position of DAP field. */
+#define RADIO_DAP_DAP_Msk (0xFFFFUL << RADIO_DAP_DAP_Pos) /*!< Bit mask of DAP field. */
+
+/* Register: RADIO_DACNF */
+/* Description: Device address match configuration. */
+
+/* Bit 15 : TxAdd for device address 7. */
+#define RADIO_DACNF_TXADD7_Pos (15UL) /*!< Position of TXADD7 field. */
+#define RADIO_DACNF_TXADD7_Msk (0x1UL << RADIO_DACNF_TXADD7_Pos) /*!< Bit mask of TXADD7 field. */
+
+/* Bit 14 : TxAdd for device address 6. */
+#define RADIO_DACNF_TXADD6_Pos (14UL) /*!< Position of TXADD6 field. */
+#define RADIO_DACNF_TXADD6_Msk (0x1UL << RADIO_DACNF_TXADD6_Pos) /*!< Bit mask of TXADD6 field. */
+
+/* Bit 13 : TxAdd for device address 5. */
+#define RADIO_DACNF_TXADD5_Pos (13UL) /*!< Position of TXADD5 field. */
+#define RADIO_DACNF_TXADD5_Msk (0x1UL << RADIO_DACNF_TXADD5_Pos) /*!< Bit mask of TXADD5 field. */
+
+/* Bit 12 : TxAdd for device address 4. */
+#define RADIO_DACNF_TXADD4_Pos (12UL) /*!< Position of TXADD4 field. */
+#define RADIO_DACNF_TXADD4_Msk (0x1UL << RADIO_DACNF_TXADD4_Pos) /*!< Bit mask of TXADD4 field. */
+
+/* Bit 11 : TxAdd for device address 3. */
+#define RADIO_DACNF_TXADD3_Pos (11UL) /*!< Position of TXADD3 field. */
+#define RADIO_DACNF_TXADD3_Msk (0x1UL << RADIO_DACNF_TXADD3_Pos) /*!< Bit mask of TXADD3 field. */
+
+/* Bit 10 : TxAdd for device address 2. */
+#define RADIO_DACNF_TXADD2_Pos (10UL) /*!< Position of TXADD2 field. */
+#define RADIO_DACNF_TXADD2_Msk (0x1UL << RADIO_DACNF_TXADD2_Pos) /*!< Bit mask of TXADD2 field. */
+
+/* Bit 9 : TxAdd for device address 1. */
+#define RADIO_DACNF_TXADD1_Pos (9UL) /*!< Position of TXADD1 field. */
+#define RADIO_DACNF_TXADD1_Msk (0x1UL << RADIO_DACNF_TXADD1_Pos) /*!< Bit mask of TXADD1 field. */
+
+/* Bit 8 : TxAdd for device address 0. */
+#define RADIO_DACNF_TXADD0_Pos (8UL) /*!< Position of TXADD0 field. */
+#define RADIO_DACNF_TXADD0_Msk (0x1UL << RADIO_DACNF_TXADD0_Pos) /*!< Bit mask of TXADD0 field. */
+
+/* Bit 7 : Enable or disable device address matching using device address 7. */
+#define RADIO_DACNF_ENA7_Pos (7UL) /*!< Position of ENA7 field. */
+#define RADIO_DACNF_ENA7_Msk (0x1UL << RADIO_DACNF_ENA7_Pos) /*!< Bit mask of ENA7 field. */
+#define RADIO_DACNF_ENA7_Disabled (0UL) /*!< Disabled. */
+#define RADIO_DACNF_ENA7_Enabled (1UL) /*!< Enabled. */
+
+/* Bit 6 : Enable or disable device address matching using device address 6. */
+#define RADIO_DACNF_ENA6_Pos (6UL) /*!< Position of ENA6 field. */
+#define RADIO_DACNF_ENA6_Msk (0x1UL << RADIO_DACNF_ENA6_Pos) /*!< Bit mask of ENA6 field. */
+#define RADIO_DACNF_ENA6_Disabled (0UL) /*!< Disabled. */
+#define RADIO_DACNF_ENA6_Enabled (1UL) /*!< Enabled. */
+
+/* Bit 5 : Enable or disable device address matching using device address 5. */
+#define RADIO_DACNF_ENA5_Pos (5UL) /*!< Position of ENA5 field. */
+#define RADIO_DACNF_ENA5_Msk (0x1UL << RADIO_DACNF_ENA5_Pos) /*!< Bit mask of ENA5 field. */
+#define RADIO_DACNF_ENA5_Disabled (0UL) /*!< Disabled. */
+#define RADIO_DACNF_ENA5_Enabled (1UL) /*!< Enabled. */
+
+/* Bit 4 : Enable or disable device address matching using device address 4. */
+#define RADIO_DACNF_ENA4_Pos (4UL) /*!< Position of ENA4 field. */
+#define RADIO_DACNF_ENA4_Msk (0x1UL << RADIO_DACNF_ENA4_Pos) /*!< Bit mask of ENA4 field. */
+#define RADIO_DACNF_ENA4_Disabled (0UL) /*!< Disabled. */
+#define RADIO_DACNF_ENA4_Enabled (1UL) /*!< Enabled. */
+
+/* Bit 3 : Enable or disable device address matching using device address 3. */
+#define RADIO_DACNF_ENA3_Pos (3UL) /*!< Position of ENA3 field. */
+#define RADIO_DACNF_ENA3_Msk (0x1UL << RADIO_DACNF_ENA3_Pos) /*!< Bit mask of ENA3 field. */
+#define RADIO_DACNF_ENA3_Disabled (0UL) /*!< Disabled. */
+#define RADIO_DACNF_ENA3_Enabled (1UL) /*!< Enabled. */
+
+/* Bit 2 : Enable or disable device address matching using device address 2. */
+#define RADIO_DACNF_ENA2_Pos (2UL) /*!< Position of ENA2 field. */
+#define RADIO_DACNF_ENA2_Msk (0x1UL << RADIO_DACNF_ENA2_Pos) /*!< Bit mask of ENA2 field. */
+#define RADIO_DACNF_ENA2_Disabled (0UL) /*!< Disabled. */
+#define RADIO_DACNF_ENA2_Enabled (1UL) /*!< Enabled. */
+
+/* Bit 1 : Enable or disable device address matching using device address 1. */
+#define RADIO_DACNF_ENA1_Pos (1UL) /*!< Position of ENA1 field. */
+#define RADIO_DACNF_ENA1_Msk (0x1UL << RADIO_DACNF_ENA1_Pos) /*!< Bit mask of ENA1 field. */
+#define RADIO_DACNF_ENA1_Disabled (0UL) /*!< Disabled. */
+#define RADIO_DACNF_ENA1_Enabled (1UL) /*!< Enabled. */
+
+/* Bit 0 : Enable or disable device address matching using device address 0. */
+#define RADIO_DACNF_ENA0_Pos (0UL) /*!< Position of ENA0 field. */
+#define RADIO_DACNF_ENA0_Msk (0x1UL << RADIO_DACNF_ENA0_Pos) /*!< Bit mask of ENA0 field. */
+#define RADIO_DACNF_ENA0_Disabled (0UL) /*!< Disabled. */
+#define RADIO_DACNF_ENA0_Enabled (1UL) /*!< Enabled. */
+
+/* Register: RADIO_OVERRIDE0 */
+/* Description: Trim value override register 0. */
+
+/* Bits 31..0 : Trim value override 0. */
+#define RADIO_OVERRIDE0_OVERRIDE0_Pos (0UL) /*!< Position of OVERRIDE0 field. */
+#define RADIO_OVERRIDE0_OVERRIDE0_Msk (0xFFFFFFFFUL << RADIO_OVERRIDE0_OVERRIDE0_Pos) /*!< Bit mask of OVERRIDE0 field. */
+
+/* Register: RADIO_OVERRIDE1 */
+/* Description: Trim value override register 1. */
+
+/* Bits 31..0 : Trim value override 1. */
+#define RADIO_OVERRIDE1_OVERRIDE1_Pos (0UL) /*!< Position of OVERRIDE1 field. */
+#define RADIO_OVERRIDE1_OVERRIDE1_Msk (0xFFFFFFFFUL << RADIO_OVERRIDE1_OVERRIDE1_Pos) /*!< Bit mask of OVERRIDE1 field. */
+
+/* Register: RADIO_OVERRIDE2 */
+/* Description: Trim value override register 2. */
+
+/* Bits 31..0 : Trim value override 2. */
+#define RADIO_OVERRIDE2_OVERRIDE2_Pos (0UL) /*!< Position of OVERRIDE2 field. */
+#define RADIO_OVERRIDE2_OVERRIDE2_Msk (0xFFFFFFFFUL << RADIO_OVERRIDE2_OVERRIDE2_Pos) /*!< Bit mask of OVERRIDE2 field. */
+
+/* Register: RADIO_OVERRIDE3 */
+/* Description: Trim value override register 3. */
+
+/* Bits 31..0 : Trim value override 3. */
+#define RADIO_OVERRIDE3_OVERRIDE3_Pos (0UL) /*!< Position of OVERRIDE3 field. */
+#define RADIO_OVERRIDE3_OVERRIDE3_Msk (0xFFFFFFFFUL << RADIO_OVERRIDE3_OVERRIDE3_Pos) /*!< Bit mask of OVERRIDE3 field. */
+
+/* Register: RADIO_OVERRIDE4 */
+/* Description: Trim value override register 4. */
+
+/* Bit 31 : Enable or disable override of default trim values. */
+#define RADIO_OVERRIDE4_ENABLE_Pos (31UL) /*!< Position of ENABLE field. */
+#define RADIO_OVERRIDE4_ENABLE_Msk (0x1UL << RADIO_OVERRIDE4_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define RADIO_OVERRIDE4_ENABLE_Disabled (0UL) /*!< Override trim values disabled. */
+#define RADIO_OVERRIDE4_ENABLE_Enabled (1UL) /*!< Override trim values enabled. */
+
+/* Bits 27..0 : Trim value override 4. */
+#define RADIO_OVERRIDE4_OVERRIDE4_Pos (0UL) /*!< Position of OVERRIDE4 field. */
+#define RADIO_OVERRIDE4_OVERRIDE4_Msk (0xFFFFFFFUL << RADIO_OVERRIDE4_OVERRIDE4_Pos) /*!< Bit mask of OVERRIDE4 field. */
+
+/* Register: RADIO_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define RADIO_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define RADIO_POWER_POWER_Msk (0x1UL << RADIO_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define RADIO_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define RADIO_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: RNG */
+/* Description: Random Number Generator. */
+
+/* Register: RNG_SHORTS */
+/* Description: Shortcuts for the RNG. */
+
+/* Bit 0 : Shortcut between VALRDY event and STOP task. */
+#define RNG_SHORTS_VALRDY_STOP_Pos (0UL) /*!< Position of VALRDY_STOP field. */
+#define RNG_SHORTS_VALRDY_STOP_Msk (0x1UL << RNG_SHORTS_VALRDY_STOP_Pos) /*!< Bit mask of VALRDY_STOP field. */
+#define RNG_SHORTS_VALRDY_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define RNG_SHORTS_VALRDY_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Register: RNG_INTENSET */
+/* Description: Interrupt enable set register */
+
+/* Bit 0 : Enable interrupt on VALRDY event. */
+#define RNG_INTENSET_VALRDY_Pos (0UL) /*!< Position of VALRDY field. */
+#define RNG_INTENSET_VALRDY_Msk (0x1UL << RNG_INTENSET_VALRDY_Pos) /*!< Bit mask of VALRDY field. */
+#define RNG_INTENSET_VALRDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define RNG_INTENSET_VALRDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define RNG_INTENSET_VALRDY_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: RNG_INTENCLR */
+/* Description: Interrupt enable clear register */
+
+/* Bit 0 : Disable interrupt on VALRDY event. */
+#define RNG_INTENCLR_VALRDY_Pos (0UL) /*!< Position of VALRDY field. */
+#define RNG_INTENCLR_VALRDY_Msk (0x1UL << RNG_INTENCLR_VALRDY_Pos) /*!< Bit mask of VALRDY field. */
+#define RNG_INTENCLR_VALRDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define RNG_INTENCLR_VALRDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define RNG_INTENCLR_VALRDY_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: RNG_CONFIG */
+/* Description: Configuration register. */
+
+/* Bit 0 : Digital error correction enable. */
+#define RNG_CONFIG_DERCEN_Pos (0UL) /*!< Position of DERCEN field. */
+#define RNG_CONFIG_DERCEN_Msk (0x1UL << RNG_CONFIG_DERCEN_Pos) /*!< Bit mask of DERCEN field. */
+#define RNG_CONFIG_DERCEN_Disabled (0UL) /*!< Digital error correction disabled. */
+#define RNG_CONFIG_DERCEN_Enabled (1UL) /*!< Digital error correction enabled. */
+
+/* Register: RNG_VALUE */
+/* Description: RNG random number. */
+
+/* Bits 7..0 : Generated random number. */
+#define RNG_VALUE_VALUE_Pos (0UL) /*!< Position of VALUE field. */
+#define RNG_VALUE_VALUE_Msk (0xFFUL << RNG_VALUE_VALUE_Pos) /*!< Bit mask of VALUE field. */
+
+/* Register: RNG_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define RNG_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define RNG_POWER_POWER_Msk (0x1UL << RNG_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define RNG_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define RNG_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: RTC */
+/* Description: Real time counter 0. */
+
+/* Register: RTC_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 19 : Enable interrupt on COMPARE[3] event. */
+#define RTC_INTENSET_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define RTC_INTENSET_COMPARE3_Msk (0x1UL << RTC_INTENSET_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define RTC_INTENSET_COMPARE3_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENSET_COMPARE3_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENSET_COMPARE3_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 18 : Enable interrupt on COMPARE[2] event. */
+#define RTC_INTENSET_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define RTC_INTENSET_COMPARE2_Msk (0x1UL << RTC_INTENSET_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define RTC_INTENSET_COMPARE2_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENSET_COMPARE2_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENSET_COMPARE2_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 17 : Enable interrupt on COMPARE[1] event. */
+#define RTC_INTENSET_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define RTC_INTENSET_COMPARE1_Msk (0x1UL << RTC_INTENSET_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define RTC_INTENSET_COMPARE1_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENSET_COMPARE1_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENSET_COMPARE1_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 16 : Enable interrupt on COMPARE[0] event. */
+#define RTC_INTENSET_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define RTC_INTENSET_COMPARE0_Msk (0x1UL << RTC_INTENSET_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define RTC_INTENSET_COMPARE0_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENSET_COMPARE0_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENSET_COMPARE0_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on OVRFLW event. */
+#define RTC_INTENSET_OVRFLW_Pos (1UL) /*!< Position of OVRFLW field. */
+#define RTC_INTENSET_OVRFLW_Msk (0x1UL << RTC_INTENSET_OVRFLW_Pos) /*!< Bit mask of OVRFLW field. */
+#define RTC_INTENSET_OVRFLW_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENSET_OVRFLW_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENSET_OVRFLW_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 0 : Enable interrupt on TICK event. */
+#define RTC_INTENSET_TICK_Pos (0UL) /*!< Position of TICK field. */
+#define RTC_INTENSET_TICK_Msk (0x1UL << RTC_INTENSET_TICK_Pos) /*!< Bit mask of TICK field. */
+#define RTC_INTENSET_TICK_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENSET_TICK_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENSET_TICK_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: RTC_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 19 : Disable interrupt on COMPARE[3] event. */
+#define RTC_INTENCLR_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define RTC_INTENCLR_COMPARE3_Msk (0x1UL << RTC_INTENCLR_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define RTC_INTENCLR_COMPARE3_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENCLR_COMPARE3_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENCLR_COMPARE3_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 18 : Disable interrupt on COMPARE[2] event. */
+#define RTC_INTENCLR_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define RTC_INTENCLR_COMPARE2_Msk (0x1UL << RTC_INTENCLR_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define RTC_INTENCLR_COMPARE2_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENCLR_COMPARE2_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENCLR_COMPARE2_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 17 : Disable interrupt on COMPARE[1] event. */
+#define RTC_INTENCLR_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define RTC_INTENCLR_COMPARE1_Msk (0x1UL << RTC_INTENCLR_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define RTC_INTENCLR_COMPARE1_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENCLR_COMPARE1_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENCLR_COMPARE1_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 16 : Disable interrupt on COMPARE[0] event. */
+#define RTC_INTENCLR_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define RTC_INTENCLR_COMPARE0_Msk (0x1UL << RTC_INTENCLR_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define RTC_INTENCLR_COMPARE0_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENCLR_COMPARE0_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENCLR_COMPARE0_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on OVRFLW event. */
+#define RTC_INTENCLR_OVRFLW_Pos (1UL) /*!< Position of OVRFLW field. */
+#define RTC_INTENCLR_OVRFLW_Msk (0x1UL << RTC_INTENCLR_OVRFLW_Pos) /*!< Bit mask of OVRFLW field. */
+#define RTC_INTENCLR_OVRFLW_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENCLR_OVRFLW_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENCLR_OVRFLW_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 0 : Disable interrupt on TICK event. */
+#define RTC_INTENCLR_TICK_Pos (0UL) /*!< Position of TICK field. */
+#define RTC_INTENCLR_TICK_Msk (0x1UL << RTC_INTENCLR_TICK_Pos) /*!< Bit mask of TICK field. */
+#define RTC_INTENCLR_TICK_Disabled (0UL) /*!< Interrupt disabled. */
+#define RTC_INTENCLR_TICK_Enabled (1UL) /*!< Interrupt enabled. */
+#define RTC_INTENCLR_TICK_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: RTC_EVTEN */
+/* Description: Configures event enable routing to PPI for each RTC event. */
+
+/* Bit 19 : COMPARE[3] event enable. */
+#define RTC_EVTEN_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define RTC_EVTEN_COMPARE3_Msk (0x1UL << RTC_EVTEN_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define RTC_EVTEN_COMPARE3_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTEN_COMPARE3_Enabled (1UL) /*!< Event enabled. */
+
+/* Bit 18 : COMPARE[2] event enable. */
+#define RTC_EVTEN_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define RTC_EVTEN_COMPARE2_Msk (0x1UL << RTC_EVTEN_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define RTC_EVTEN_COMPARE2_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTEN_COMPARE2_Enabled (1UL) /*!< Event enabled. */
+
+/* Bit 17 : COMPARE[1] event enable. */
+#define RTC_EVTEN_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define RTC_EVTEN_COMPARE1_Msk (0x1UL << RTC_EVTEN_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define RTC_EVTEN_COMPARE1_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTEN_COMPARE1_Enabled (1UL) /*!< Event enabled. */
+
+/* Bit 16 : COMPARE[0] event enable. */
+#define RTC_EVTEN_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define RTC_EVTEN_COMPARE0_Msk (0x1UL << RTC_EVTEN_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define RTC_EVTEN_COMPARE0_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTEN_COMPARE0_Enabled (1UL) /*!< Event enabled. */
+
+/* Bit 1 : OVRFLW event enable. */
+#define RTC_EVTEN_OVRFLW_Pos (1UL) /*!< Position of OVRFLW field. */
+#define RTC_EVTEN_OVRFLW_Msk (0x1UL << RTC_EVTEN_OVRFLW_Pos) /*!< Bit mask of OVRFLW field. */
+#define RTC_EVTEN_OVRFLW_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTEN_OVRFLW_Enabled (1UL) /*!< Event enabled. */
+
+/* Bit 0 : TICK event enable. */
+#define RTC_EVTEN_TICK_Pos (0UL) /*!< Position of TICK field. */
+#define RTC_EVTEN_TICK_Msk (0x1UL << RTC_EVTEN_TICK_Pos) /*!< Bit mask of TICK field. */
+#define RTC_EVTEN_TICK_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTEN_TICK_Enabled (1UL) /*!< Event enabled. */
+
+/* Register: RTC_EVTENSET */
+/* Description: Enable events routing to PPI. The reading of this register gives the value of EVTEN. */
+
+/* Bit 19 : Enable routing to PPI of COMPARE[3] event. */
+#define RTC_EVTENSET_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define RTC_EVTENSET_COMPARE3_Msk (0x1UL << RTC_EVTENSET_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define RTC_EVTENSET_COMPARE3_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENSET_COMPARE3_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENSET_COMPARE3_Set (1UL) /*!< Enable event on write. */
+
+/* Bit 18 : Enable routing to PPI of COMPARE[2] event. */
+#define RTC_EVTENSET_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define RTC_EVTENSET_COMPARE2_Msk (0x1UL << RTC_EVTENSET_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define RTC_EVTENSET_COMPARE2_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENSET_COMPARE2_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENSET_COMPARE2_Set (1UL) /*!< Enable event on write. */
+
+/* Bit 17 : Enable routing to PPI of COMPARE[1] event. */
+#define RTC_EVTENSET_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define RTC_EVTENSET_COMPARE1_Msk (0x1UL << RTC_EVTENSET_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define RTC_EVTENSET_COMPARE1_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENSET_COMPARE1_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENSET_COMPARE1_Set (1UL) /*!< Enable event on write. */
+
+/* Bit 16 : Enable routing to PPI of COMPARE[0] event. */
+#define RTC_EVTENSET_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define RTC_EVTENSET_COMPARE0_Msk (0x1UL << RTC_EVTENSET_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define RTC_EVTENSET_COMPARE0_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENSET_COMPARE0_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENSET_COMPARE0_Set (1UL) /*!< Enable event on write. */
+
+/* Bit 1 : Enable routing to PPI of OVRFLW event. */
+#define RTC_EVTENSET_OVRFLW_Pos (1UL) /*!< Position of OVRFLW field. */
+#define RTC_EVTENSET_OVRFLW_Msk (0x1UL << RTC_EVTENSET_OVRFLW_Pos) /*!< Bit mask of OVRFLW field. */
+#define RTC_EVTENSET_OVRFLW_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENSET_OVRFLW_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENSET_OVRFLW_Set (1UL) /*!< Enable event on write. */
+
+/* Bit 0 : Enable routing to PPI of TICK event. */
+#define RTC_EVTENSET_TICK_Pos (0UL) /*!< Position of TICK field. */
+#define RTC_EVTENSET_TICK_Msk (0x1UL << RTC_EVTENSET_TICK_Pos) /*!< Bit mask of TICK field. */
+#define RTC_EVTENSET_TICK_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENSET_TICK_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENSET_TICK_Set (1UL) /*!< Enable event on write. */
+
+/* Register: RTC_EVTENCLR */
+/* Description: Disable events routing to PPI. The reading of this register gives the value of EVTEN. */
+
+/* Bit 19 : Disable routing to PPI of COMPARE[3] event. */
+#define RTC_EVTENCLR_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define RTC_EVTENCLR_COMPARE3_Msk (0x1UL << RTC_EVTENCLR_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define RTC_EVTENCLR_COMPARE3_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENCLR_COMPARE3_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENCLR_COMPARE3_Clear (1UL) /*!< Disable event on write. */
+
+/* Bit 18 : Disable routing to PPI of COMPARE[2] event. */
+#define RTC_EVTENCLR_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define RTC_EVTENCLR_COMPARE2_Msk (0x1UL << RTC_EVTENCLR_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define RTC_EVTENCLR_COMPARE2_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENCLR_COMPARE2_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENCLR_COMPARE2_Clear (1UL) /*!< Disable event on write. */
+
+/* Bit 17 : Disable routing to PPI of COMPARE[1] event. */
+#define RTC_EVTENCLR_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define RTC_EVTENCLR_COMPARE1_Msk (0x1UL << RTC_EVTENCLR_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define RTC_EVTENCLR_COMPARE1_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENCLR_COMPARE1_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENCLR_COMPARE1_Clear (1UL) /*!< Disable event on write. */
+
+/* Bit 16 : Disable routing to PPI of COMPARE[0] event. */
+#define RTC_EVTENCLR_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define RTC_EVTENCLR_COMPARE0_Msk (0x1UL << RTC_EVTENCLR_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define RTC_EVTENCLR_COMPARE0_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENCLR_COMPARE0_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENCLR_COMPARE0_Clear (1UL) /*!< Disable event on write. */
+
+/* Bit 1 : Disable routing to PPI of OVRFLW event. */
+#define RTC_EVTENCLR_OVRFLW_Pos (1UL) /*!< Position of OVRFLW field. */
+#define RTC_EVTENCLR_OVRFLW_Msk (0x1UL << RTC_EVTENCLR_OVRFLW_Pos) /*!< Bit mask of OVRFLW field. */
+#define RTC_EVTENCLR_OVRFLW_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENCLR_OVRFLW_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENCLR_OVRFLW_Clear (1UL) /*!< Disable event on write. */
+
+/* Bit 0 : Disable routing to PPI of TICK event. */
+#define RTC_EVTENCLR_TICK_Pos (0UL) /*!< Position of TICK field. */
+#define RTC_EVTENCLR_TICK_Msk (0x1UL << RTC_EVTENCLR_TICK_Pos) /*!< Bit mask of TICK field. */
+#define RTC_EVTENCLR_TICK_Disabled (0UL) /*!< Event disabled. */
+#define RTC_EVTENCLR_TICK_Enabled (1UL) /*!< Event enabled. */
+#define RTC_EVTENCLR_TICK_Clear (1UL) /*!< Disable event on write. */
+
+/* Register: RTC_COUNTER */
+/* Description: Current COUNTER value. */
+
+/* Bits 23..0 : Counter value. */
+#define RTC_COUNTER_COUNTER_Pos (0UL) /*!< Position of COUNTER field. */
+#define RTC_COUNTER_COUNTER_Msk (0xFFFFFFUL << RTC_COUNTER_COUNTER_Pos) /*!< Bit mask of COUNTER field. */
+
+/* Register: RTC_PRESCALER */
+/* Description: 12-bit prescaler for COUNTER frequency (32768/(PRESCALER+1)). Must be written when RTC is STOPed. */
+
+/* Bits 11..0 : RTC PRESCALER value. */
+#define RTC_PRESCALER_PRESCALER_Pos (0UL) /*!< Position of PRESCALER field. */
+#define RTC_PRESCALER_PRESCALER_Msk (0xFFFUL << RTC_PRESCALER_PRESCALER_Pos) /*!< Bit mask of PRESCALER field. */
+
+/* Register: RTC_CC */
+/* Description: Capture/compare registers. */
+
+/* Bits 23..0 : Compare value. */
+#define RTC_CC_COMPARE_Pos (0UL) /*!< Position of COMPARE field. */
+#define RTC_CC_COMPARE_Msk (0xFFFFFFUL << RTC_CC_COMPARE_Pos) /*!< Bit mask of COMPARE field. */
+
+/* Register: RTC_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define RTC_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define RTC_POWER_POWER_Msk (0x1UL << RTC_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define RTC_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define RTC_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: SPI */
+/* Description: SPI master 0. */
+
+/* Register: SPI_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 2 : Enable interrupt on READY event. */
+#define SPI_INTENSET_READY_Pos (2UL) /*!< Position of READY field. */
+#define SPI_INTENSET_READY_Msk (0x1UL << SPI_INTENSET_READY_Pos) /*!< Bit mask of READY field. */
+#define SPI_INTENSET_READY_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPI_INTENSET_READY_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPI_INTENSET_READY_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: SPI_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 2 : Disable interrupt on READY event. */
+#define SPI_INTENCLR_READY_Pos (2UL) /*!< Position of READY field. */
+#define SPI_INTENCLR_READY_Msk (0x1UL << SPI_INTENCLR_READY_Pos) /*!< Bit mask of READY field. */
+#define SPI_INTENCLR_READY_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPI_INTENCLR_READY_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPI_INTENCLR_READY_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: SPI_ENABLE */
+/* Description: Enable SPI. */
+
+/* Bits 2..0 : Enable or disable SPI. */
+#define SPI_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define SPI_ENABLE_ENABLE_Msk (0x7UL << SPI_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define SPI_ENABLE_ENABLE_Disabled (0x00UL) /*!< Disabled SPI. */
+#define SPI_ENABLE_ENABLE_Enabled (0x01UL) /*!< Enable SPI. */
+
+/* Register: SPI_RXD */
+/* Description: RX data. */
+
+/* Bits 7..0 : RX data from last transfer. */
+#define SPI_RXD_RXD_Pos (0UL) /*!< Position of RXD field. */
+#define SPI_RXD_RXD_Msk (0xFFUL << SPI_RXD_RXD_Pos) /*!< Bit mask of RXD field. */
+
+/* Register: SPI_TXD */
+/* Description: TX data. */
+
+/* Bits 7..0 : TX data for next transfer. */
+#define SPI_TXD_TXD_Pos (0UL) /*!< Position of TXD field. */
+#define SPI_TXD_TXD_Msk (0xFFUL << SPI_TXD_TXD_Pos) /*!< Bit mask of TXD field. */
+
+/* Register: SPI_FREQUENCY */
+/* Description: SPI frequency */
+
+/* Bits 31..0 : SPI data rate. */
+#define SPI_FREQUENCY_FREQUENCY_Pos (0UL) /*!< Position of FREQUENCY field. */
+#define SPI_FREQUENCY_FREQUENCY_Msk (0xFFFFFFFFUL << SPI_FREQUENCY_FREQUENCY_Pos) /*!< Bit mask of FREQUENCY field. */
+#define SPI_FREQUENCY_FREQUENCY_K125 (0x02000000UL) /*!< 125kbps. */
+#define SPI_FREQUENCY_FREQUENCY_K250 (0x04000000UL) /*!< 250kbps. */
+#define SPI_FREQUENCY_FREQUENCY_K500 (0x08000000UL) /*!< 500kbps. */
+#define SPI_FREQUENCY_FREQUENCY_M1 (0x10000000UL) /*!< 1Mbps. */
+#define SPI_FREQUENCY_FREQUENCY_M2 (0x20000000UL) /*!< 2Mbps. */
+#define SPI_FREQUENCY_FREQUENCY_M4 (0x40000000UL) /*!< 4Mbps. */
+#define SPI_FREQUENCY_FREQUENCY_M8 (0x80000000UL) /*!< 8Mbps. */
+
+/* Register: SPI_CONFIG */
+/* Description: Configuration register. */
+
+/* Bit 2 : Serial clock (SCK) polarity. */
+#define SPI_CONFIG_CPOL_Pos (2UL) /*!< Position of CPOL field. */
+#define SPI_CONFIG_CPOL_Msk (0x1UL << SPI_CONFIG_CPOL_Pos) /*!< Bit mask of CPOL field. */
+#define SPI_CONFIG_CPOL_ActiveHigh (0UL) /*!< Active high. */
+#define SPI_CONFIG_CPOL_ActiveLow (1UL) /*!< Active low. */
+
+/* Bit 1 : Serial clock (SCK) phase. */
+#define SPI_CONFIG_CPHA_Pos (1UL) /*!< Position of CPHA field. */
+#define SPI_CONFIG_CPHA_Msk (0x1UL << SPI_CONFIG_CPHA_Pos) /*!< Bit mask of CPHA field. */
+#define SPI_CONFIG_CPHA_Leading (0UL) /*!< Sample on leading edge of the clock. Shift serial data on trailing edge. */
+#define SPI_CONFIG_CPHA_Trailing (1UL) /*!< Sample on trailing edge of the clock. Shift serial data on leading edge. */
+
+/* Bit 0 : Bit order. */
+#define SPI_CONFIG_ORDER_Pos (0UL) /*!< Position of ORDER field. */
+#define SPI_CONFIG_ORDER_Msk (0x1UL << SPI_CONFIG_ORDER_Pos) /*!< Bit mask of ORDER field. */
+#define SPI_CONFIG_ORDER_MsbFirst (0UL) /*!< Most significant bit transmitted out first. */
+#define SPI_CONFIG_ORDER_LsbFirst (1UL) /*!< Least significant bit transmitted out first. */
+
+/* Register: SPI_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define SPI_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define SPI_POWER_POWER_Msk (0x1UL << SPI_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define SPI_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define SPI_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: SPIM */
+/* Description: SPI master with easyDMA 1. */
+
+/* Register: SPIM_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 19 : Enable interrupt on STARTED event. */
+#define SPIM_INTENSET_STARTED_Pos (19UL) /*!< Position of STARTED field. */
+#define SPIM_INTENSET_STARTED_Msk (0x1UL << SPIM_INTENSET_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define SPIM_INTENSET_STARTED_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIM_INTENSET_STARTED_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIM_INTENSET_STARTED_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 8 : Enable interrupt on ENDTX event. */
+#define SPIM_INTENSET_ENDTX_Pos (8UL) /*!< Position of ENDTX field. */
+#define SPIM_INTENSET_ENDTX_Msk (0x1UL << SPIM_INTENSET_ENDTX_Pos) /*!< Bit mask of ENDTX field. */
+#define SPIM_INTENSET_ENDTX_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIM_INTENSET_ENDTX_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIM_INTENSET_ENDTX_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 4 : Enable interrupt on ENDRX event. */
+#define SPIM_INTENSET_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define SPIM_INTENSET_ENDRX_Msk (0x1UL << SPIM_INTENSET_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define SPIM_INTENSET_ENDRX_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIM_INTENSET_ENDRX_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIM_INTENSET_ENDRX_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on STOPPED event. */
+#define SPIM_INTENSET_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define SPIM_INTENSET_STOPPED_Msk (0x1UL << SPIM_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define SPIM_INTENSET_STOPPED_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIM_INTENSET_STOPPED_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIM_INTENSET_STOPPED_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: SPIM_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 19 : Disable interrupt on STARTED event. */
+#define SPIM_INTENCLR_STARTED_Pos (19UL) /*!< Position of STARTED field. */
+#define SPIM_INTENCLR_STARTED_Msk (0x1UL << SPIM_INTENCLR_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define SPIM_INTENCLR_STARTED_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIM_INTENCLR_STARTED_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIM_INTENCLR_STARTED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 8 : Disable interrupt on ENDTX event. */
+#define SPIM_INTENCLR_ENDTX_Pos (8UL) /*!< Position of ENDTX field. */
+#define SPIM_INTENCLR_ENDTX_Msk (0x1UL << SPIM_INTENCLR_ENDTX_Pos) /*!< Bit mask of ENDTX field. */
+#define SPIM_INTENCLR_ENDTX_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIM_INTENCLR_ENDTX_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIM_INTENCLR_ENDTX_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 4 : Disable interrupt on ENDRX event. */
+#define SPIM_INTENCLR_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define SPIM_INTENCLR_ENDRX_Msk (0x1UL << SPIM_INTENCLR_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define SPIM_INTENCLR_ENDRX_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIM_INTENCLR_ENDRX_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIM_INTENCLR_ENDRX_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on STOPPED event. */
+#define SPIM_INTENCLR_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define SPIM_INTENCLR_STOPPED_Msk (0x1UL << SPIM_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define SPIM_INTENCLR_STOPPED_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIM_INTENCLR_STOPPED_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIM_INTENCLR_STOPPED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: SPIM_ENABLE */
+/* Description: Enable SPIM. */
+
+/* Bits 3..0 : Enable or disable SPIM. */
+#define SPIM_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define SPIM_ENABLE_ENABLE_Msk (0xFUL << SPIM_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define SPIM_ENABLE_ENABLE_Disabled (0x00UL) /*!< Disabled SPIM. */
+#define SPIM_ENABLE_ENABLE_Enabled (0x07UL) /*!< Enable SPIM. */
+
+/* Register: SPIM_FREQUENCY */
+/* Description: SPI frequency. */
+
+/* Bits 31..0 : SPI master data rate. */
+#define SPIM_FREQUENCY_FREQUENCY_Pos (0UL) /*!< Position of FREQUENCY field. */
+#define SPIM_FREQUENCY_FREQUENCY_Msk (0xFFFFFFFFUL << SPIM_FREQUENCY_FREQUENCY_Pos) /*!< Bit mask of FREQUENCY field. */
+#define SPIM_FREQUENCY_FREQUENCY_K125 (0x02000000UL) /*!< 125 kbps. */
+#define SPIM_FREQUENCY_FREQUENCY_K250 (0x04000000UL) /*!< 250 kbps. */
+#define SPIM_FREQUENCY_FREQUENCY_K500 (0x08000000UL) /*!< 500 kbps. */
+#define SPIM_FREQUENCY_FREQUENCY_M1 (0x10000000UL) /*!< 1 Mbps. */
+#define SPIM_FREQUENCY_FREQUENCY_M2 (0x20000000UL) /*!< 2 Mbps. */
+#define SPIM_FREQUENCY_FREQUENCY_M4 (0x40000000UL) /*!< 4 Mbps. */
+#define SPIM_FREQUENCY_FREQUENCY_M8 (0x80000000UL) /*!< 8 Mbps. */
+
+/* Register: SPIM_RXD_PTR */
+/* Description: Data pointer. */
+
+/* Bits 31..0 : Data pointer. */
+#define SPIM_RXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define SPIM_RXD_PTR_PTR_Msk (0xFFFFFFFFUL << SPIM_RXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: SPIM_RXD_MAXCNT */
+/* Description: Maximum number of buffer bytes to receive. */
+
+/* Bits 7..0 : Maximum number of buffer bytes to receive. */
+#define SPIM_RXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define SPIM_RXD_MAXCNT_MAXCNT_Msk (0xFFUL << SPIM_RXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: SPIM_RXD_AMOUNT */
+/* Description: Number of bytes received in the last transaction. */
+
+/* Bits 7..0 : Number of bytes received in the last transaction. */
+#define SPIM_RXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define SPIM_RXD_AMOUNT_AMOUNT_Msk (0xFFUL << SPIM_RXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: SPIM_TXD_PTR */
+/* Description: Data pointer. */
+
+/* Bits 31..0 : Data pointer. */
+#define SPIM_TXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define SPIM_TXD_PTR_PTR_Msk (0xFFFFFFFFUL << SPIM_TXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: SPIM_TXD_MAXCNT */
+/* Description: Maximum number of buffer bytes to send. */
+
+/* Bits 7..0 : Maximum number of buffer bytes to send. */
+#define SPIM_TXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define SPIM_TXD_MAXCNT_MAXCNT_Msk (0xFFUL << SPIM_TXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: SPIM_TXD_AMOUNT */
+/* Description: Number of bytes sent in the last transaction. */
+
+/* Bits 7..0 : Number of bytes sent in the last transaction. */
+#define SPIM_TXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define SPIM_TXD_AMOUNT_AMOUNT_Msk (0xFFUL << SPIM_TXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: SPIM_CONFIG */
+/* Description: Configuration register. */
+
+/* Bit 2 : Serial clock (SCK) polarity. */
+#define SPIM_CONFIG_CPOL_Pos (2UL) /*!< Position of CPOL field. */
+#define SPIM_CONFIG_CPOL_Msk (0x1UL << SPIM_CONFIG_CPOL_Pos) /*!< Bit mask of CPOL field. */
+#define SPIM_CONFIG_CPOL_ActiveHigh (0UL) /*!< Active high. */
+#define SPIM_CONFIG_CPOL_ActiveLow (1UL) /*!< Active low. */
+
+/* Bit 1 : Serial clock (SCK) phase. */
+#define SPIM_CONFIG_CPHA_Pos (1UL) /*!< Position of CPHA field. */
+#define SPIM_CONFIG_CPHA_Msk (0x1UL << SPIM_CONFIG_CPHA_Pos) /*!< Bit mask of CPHA field. */
+#define SPIM_CONFIG_CPHA_Leading (0UL) /*!< Sample on leading edge of the clock. Shift serial data on trailing edge. */
+#define SPIM_CONFIG_CPHA_Trailing (1UL) /*!< Sample on trailing edge of the clock. Shift serial data on leading edge. */
+
+/* Bit 0 : Bit order. */
+#define SPIM_CONFIG_ORDER_Pos (0UL) /*!< Position of ORDER field. */
+#define SPIM_CONFIG_ORDER_Msk (0x1UL << SPIM_CONFIG_ORDER_Pos) /*!< Bit mask of ORDER field. */
+#define SPIM_CONFIG_ORDER_MsbFirst (0UL) /*!< Most significant bit transmitted out first. */
+#define SPIM_CONFIG_ORDER_LsbFirst (1UL) /*!< Least significant bit transmitted out first. */
+
+/* Register: SPIM_ORC */
+/* Description: Over-read character. */
+
+/* Bits 7..0 : Over-read character. */
+#define SPIM_ORC_ORC_Pos (0UL) /*!< Position of ORC field. */
+#define SPIM_ORC_ORC_Msk (0xFFUL << SPIM_ORC_ORC_Pos) /*!< Bit mask of ORC field. */
+
+/* Register: SPIM_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define SPIM_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define SPIM_POWER_POWER_Msk (0x1UL << SPIM_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define SPIM_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define SPIM_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: SPIS */
+/* Description: SPI slave 1. */
+
+/* Register: SPIS_SHORTS */
+/* Description: Shortcuts for SPIS. */
+
+/* Bit 2 : Shortcut between END event and the ACQUIRE task. */
+#define SPIS_SHORTS_END_ACQUIRE_Pos (2UL) /*!< Position of END_ACQUIRE field. */
+#define SPIS_SHORTS_END_ACQUIRE_Msk (0x1UL << SPIS_SHORTS_END_ACQUIRE_Pos) /*!< Bit mask of END_ACQUIRE field. */
+#define SPIS_SHORTS_END_ACQUIRE_Disabled (0UL) /*!< Shortcut disabled. */
+#define SPIS_SHORTS_END_ACQUIRE_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Register: SPIS_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 10 : Enable interrupt on ACQUIRED event. */
+#define SPIS_INTENSET_ACQUIRED_Pos (10UL) /*!< Position of ACQUIRED field. */
+#define SPIS_INTENSET_ACQUIRED_Msk (0x1UL << SPIS_INTENSET_ACQUIRED_Pos) /*!< Bit mask of ACQUIRED field. */
+#define SPIS_INTENSET_ACQUIRED_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIS_INTENSET_ACQUIRED_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIS_INTENSET_ACQUIRED_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 4 : enable interrupt on ENDRX event. */
+#define SPIS_INTENSET_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define SPIS_INTENSET_ENDRX_Msk (0x1UL << SPIS_INTENSET_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define SPIS_INTENSET_ENDRX_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIS_INTENSET_ENDRX_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIS_INTENSET_ENDRX_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on END event. */
+#define SPIS_INTENSET_END_Pos (1UL) /*!< Position of END field. */
+#define SPIS_INTENSET_END_Msk (0x1UL << SPIS_INTENSET_END_Pos) /*!< Bit mask of END field. */
+#define SPIS_INTENSET_END_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIS_INTENSET_END_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIS_INTENSET_END_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: SPIS_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 10 : Disable interrupt on ACQUIRED event. */
+#define SPIS_INTENCLR_ACQUIRED_Pos (10UL) /*!< Position of ACQUIRED field. */
+#define SPIS_INTENCLR_ACQUIRED_Msk (0x1UL << SPIS_INTENCLR_ACQUIRED_Pos) /*!< Bit mask of ACQUIRED field. */
+#define SPIS_INTENCLR_ACQUIRED_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIS_INTENCLR_ACQUIRED_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIS_INTENCLR_ACQUIRED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 4 : Disable interrupt on ENDRX event. */
+#define SPIS_INTENCLR_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define SPIS_INTENCLR_ENDRX_Msk (0x1UL << SPIS_INTENCLR_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define SPIS_INTENCLR_ENDRX_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIS_INTENCLR_ENDRX_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIS_INTENCLR_ENDRX_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on END event. */
+#define SPIS_INTENCLR_END_Pos (1UL) /*!< Position of END field. */
+#define SPIS_INTENCLR_END_Msk (0x1UL << SPIS_INTENCLR_END_Pos) /*!< Bit mask of END field. */
+#define SPIS_INTENCLR_END_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIS_INTENCLR_END_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIS_INTENCLR_END_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: SPIS_SEMSTAT */
+/* Description: Semaphore status. */
+
+/* Bits 1..0 : Semaphore status. */
+#define SPIS_SEMSTAT_SEMSTAT_Pos (0UL) /*!< Position of SEMSTAT field. */
+#define SPIS_SEMSTAT_SEMSTAT_Msk (0x3UL << SPIS_SEMSTAT_SEMSTAT_Pos) /*!< Bit mask of SEMSTAT field. */
+#define SPIS_SEMSTAT_SEMSTAT_Free (0x00UL) /*!< Semaphore is free. */
+#define SPIS_SEMSTAT_SEMSTAT_CPU (0x01UL) /*!< Semaphore is assigned to the CPU. */
+#define SPIS_SEMSTAT_SEMSTAT_SPIS (0x02UL) /*!< Semaphore is assigned to the SPIS. */
+#define SPIS_SEMSTAT_SEMSTAT_CPUPending (0x03UL) /*!< Semaphore is assigned to the SPIS, but a handover to the CPU is pending. */
+
+/* Register: SPIS_STATUS */
+/* Description: Status from last transaction. */
+
+/* Bit 1 : RX buffer overflow detected, and prevented. */
+#define SPIS_STATUS_OVERFLOW_Pos (1UL) /*!< Position of OVERFLOW field. */
+#define SPIS_STATUS_OVERFLOW_Msk (0x1UL << SPIS_STATUS_OVERFLOW_Pos) /*!< Bit mask of OVERFLOW field. */
+#define SPIS_STATUS_OVERFLOW_NotPresent (0UL) /*!< Error not present. */
+#define SPIS_STATUS_OVERFLOW_Present (1UL) /*!< Error present. */
+#define SPIS_STATUS_OVERFLOW_Clear (1UL) /*!< Clear on write. */
+
+/* Bit 0 : TX buffer overread detected, and prevented. */
+#define SPIS_STATUS_OVERREAD_Pos (0UL) /*!< Position of OVERREAD field. */
+#define SPIS_STATUS_OVERREAD_Msk (0x1UL << SPIS_STATUS_OVERREAD_Pos) /*!< Bit mask of OVERREAD field. */
+#define SPIS_STATUS_OVERREAD_NotPresent (0UL) /*!< Error not present. */
+#define SPIS_STATUS_OVERREAD_Present (1UL) /*!< Error present. */
+#define SPIS_STATUS_OVERREAD_Clear (1UL) /*!< Clear on write. */
+
+/* Register: SPIS_ENABLE */
+/* Description: Enable SPIS. */
+
+/* Bits 2..0 : Enable or disable SPIS. */
+#define SPIS_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define SPIS_ENABLE_ENABLE_Msk (0x7UL << SPIS_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define SPIS_ENABLE_ENABLE_Disabled (0x00UL) /*!< Disabled SPIS. */
+#define SPIS_ENABLE_ENABLE_Enabled (0x02UL) /*!< Enable SPIS. */
+
+/* Register: SPIS_MAXRX */
+/* Description: Maximum number of bytes in the receive buffer. */
+
+/* Bits 7..0 : Maximum number of bytes in the receive buffer. */
+#define SPIS_MAXRX_MAXRX_Pos (0UL) /*!< Position of MAXRX field. */
+#define SPIS_MAXRX_MAXRX_Msk (0xFFUL << SPIS_MAXRX_MAXRX_Pos) /*!< Bit mask of MAXRX field. */
+
+/* Register: SPIS_AMOUNTRX */
+/* Description: Number of bytes received in last granted transaction. */
+
+/* Bits 7..0 : Number of bytes received in last granted transaction. */
+#define SPIS_AMOUNTRX_AMOUNTRX_Pos (0UL) /*!< Position of AMOUNTRX field. */
+#define SPIS_AMOUNTRX_AMOUNTRX_Msk (0xFFUL << SPIS_AMOUNTRX_AMOUNTRX_Pos) /*!< Bit mask of AMOUNTRX field. */
+
+/* Register: SPIS_MAXTX */
+/* Description: Maximum number of bytes in the transmit buffer. */
+
+/* Bits 7..0 : Maximum number of bytes in the transmit buffer. */
+#define SPIS_MAXTX_MAXTX_Pos (0UL) /*!< Position of MAXTX field. */
+#define SPIS_MAXTX_MAXTX_Msk (0xFFUL << SPIS_MAXTX_MAXTX_Pos) /*!< Bit mask of MAXTX field. */
+
+/* Register: SPIS_AMOUNTTX */
+/* Description: Number of bytes transmitted in last granted transaction. */
+
+/* Bits 7..0 : Number of bytes transmitted in last granted transaction. */
+#define SPIS_AMOUNTTX_AMOUNTTX_Pos (0UL) /*!< Position of AMOUNTTX field. */
+#define SPIS_AMOUNTTX_AMOUNTTX_Msk (0xFFUL << SPIS_AMOUNTTX_AMOUNTTX_Pos) /*!< Bit mask of AMOUNTTX field. */
+
+/* Register: SPIS_CONFIG */
+/* Description: Configuration register. */
+
+/* Bit 2 : Serial clock (SCK) polarity. */
+#define SPIS_CONFIG_CPOL_Pos (2UL) /*!< Position of CPOL field. */
+#define SPIS_CONFIG_CPOL_Msk (0x1UL << SPIS_CONFIG_CPOL_Pos) /*!< Bit mask of CPOL field. */
+#define SPIS_CONFIG_CPOL_ActiveHigh (0UL) /*!< Active high. */
+#define SPIS_CONFIG_CPOL_ActiveLow (1UL) /*!< Active low. */
+
+/* Bit 1 : Serial clock (SCK) phase. */
+#define SPIS_CONFIG_CPHA_Pos (1UL) /*!< Position of CPHA field. */
+#define SPIS_CONFIG_CPHA_Msk (0x1UL << SPIS_CONFIG_CPHA_Pos) /*!< Bit mask of CPHA field. */
+#define SPIS_CONFIG_CPHA_Leading (0UL) /*!< Sample on leading edge of the clock. Shift serial data on trailing edge. */
+#define SPIS_CONFIG_CPHA_Trailing (1UL) /*!< Sample on trailing edge of the clock. Shift serial data on leading edge. */
+
+/* Bit 0 : Bit order. */
+#define SPIS_CONFIG_ORDER_Pos (0UL) /*!< Position of ORDER field. */
+#define SPIS_CONFIG_ORDER_Msk (0x1UL << SPIS_CONFIG_ORDER_Pos) /*!< Bit mask of ORDER field. */
+#define SPIS_CONFIG_ORDER_MsbFirst (0UL) /*!< Most significant bit transmitted out first. */
+#define SPIS_CONFIG_ORDER_LsbFirst (1UL) /*!< Least significant bit transmitted out first. */
+
+/* Register: SPIS_DEF */
+/* Description: Default character. */
+
+/* Bits 7..0 : Default character. */
+#define SPIS_DEF_DEF_Pos (0UL) /*!< Position of DEF field. */
+#define SPIS_DEF_DEF_Msk (0xFFUL << SPIS_DEF_DEF_Pos) /*!< Bit mask of DEF field. */
+
+/* Register: SPIS_ORC */
+/* Description: Over-read character. */
+
+/* Bits 7..0 : Over-read character. */
+#define SPIS_ORC_ORC_Pos (0UL) /*!< Position of ORC field. */
+#define SPIS_ORC_ORC_Msk (0xFFUL << SPIS_ORC_ORC_Pos) /*!< Bit mask of ORC field. */
+
+/* Register: SPIS_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define SPIS_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define SPIS_POWER_POWER_Msk (0x1UL << SPIS_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define SPIS_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define SPIS_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: TEMP */
+/* Description: Temperature Sensor. */
+
+/* Register: TEMP_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 0 : Enable interrupt on DATARDY event. */
+#define TEMP_INTENSET_DATARDY_Pos (0UL) /*!< Position of DATARDY field. */
+#define TEMP_INTENSET_DATARDY_Msk (0x1UL << TEMP_INTENSET_DATARDY_Pos) /*!< Bit mask of DATARDY field. */
+#define TEMP_INTENSET_DATARDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define TEMP_INTENSET_DATARDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define TEMP_INTENSET_DATARDY_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: TEMP_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 0 : Disable interrupt on DATARDY event. */
+#define TEMP_INTENCLR_DATARDY_Pos (0UL) /*!< Position of DATARDY field. */
+#define TEMP_INTENCLR_DATARDY_Msk (0x1UL << TEMP_INTENCLR_DATARDY_Pos) /*!< Bit mask of DATARDY field. */
+#define TEMP_INTENCLR_DATARDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define TEMP_INTENCLR_DATARDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define TEMP_INTENCLR_DATARDY_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: TEMP_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define TEMP_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define TEMP_POWER_POWER_Msk (0x1UL << TEMP_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define TEMP_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define TEMP_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: TIMER */
+/* Description: Timer 0. */
+
+/* Register: TIMER_SHORTS */
+/* Description: Shortcuts for Timer. */
+
+/* Bit 11 : Shortcut between CC[3] event and the STOP task. */
+#define TIMER_SHORTS_COMPARE3_STOP_Pos (11UL) /*!< Position of COMPARE3_STOP field. */
+#define TIMER_SHORTS_COMPARE3_STOP_Msk (0x1UL << TIMER_SHORTS_COMPARE3_STOP_Pos) /*!< Bit mask of COMPARE3_STOP field. */
+#define TIMER_SHORTS_COMPARE3_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define TIMER_SHORTS_COMPARE3_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 10 : Shortcut between CC[2] event and the STOP task. */
+#define TIMER_SHORTS_COMPARE2_STOP_Pos (10UL) /*!< Position of COMPARE2_STOP field. */
+#define TIMER_SHORTS_COMPARE2_STOP_Msk (0x1UL << TIMER_SHORTS_COMPARE2_STOP_Pos) /*!< Bit mask of COMPARE2_STOP field. */
+#define TIMER_SHORTS_COMPARE2_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define TIMER_SHORTS_COMPARE2_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 9 : Shortcut between CC[1] event and the STOP task. */
+#define TIMER_SHORTS_COMPARE1_STOP_Pos (9UL) /*!< Position of COMPARE1_STOP field. */
+#define TIMER_SHORTS_COMPARE1_STOP_Msk (0x1UL << TIMER_SHORTS_COMPARE1_STOP_Pos) /*!< Bit mask of COMPARE1_STOP field. */
+#define TIMER_SHORTS_COMPARE1_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define TIMER_SHORTS_COMPARE1_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 8 : Shortcut between CC[0] event and the STOP task. */
+#define TIMER_SHORTS_COMPARE0_STOP_Pos (8UL) /*!< Position of COMPARE0_STOP field. */
+#define TIMER_SHORTS_COMPARE0_STOP_Msk (0x1UL << TIMER_SHORTS_COMPARE0_STOP_Pos) /*!< Bit mask of COMPARE0_STOP field. */
+#define TIMER_SHORTS_COMPARE0_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define TIMER_SHORTS_COMPARE0_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 3 : Shortcut between CC[3] event and the CLEAR task. */
+#define TIMER_SHORTS_COMPARE3_CLEAR_Pos (3UL) /*!< Position of COMPARE3_CLEAR field. */
+#define TIMER_SHORTS_COMPARE3_CLEAR_Msk (0x1UL << TIMER_SHORTS_COMPARE3_CLEAR_Pos) /*!< Bit mask of COMPARE3_CLEAR field. */
+#define TIMER_SHORTS_COMPARE3_CLEAR_Disabled (0UL) /*!< Shortcut disabled. */
+#define TIMER_SHORTS_COMPARE3_CLEAR_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 2 : Shortcut between CC[2] event and the CLEAR task. */
+#define TIMER_SHORTS_COMPARE2_CLEAR_Pos (2UL) /*!< Position of COMPARE2_CLEAR field. */
+#define TIMER_SHORTS_COMPARE2_CLEAR_Msk (0x1UL << TIMER_SHORTS_COMPARE2_CLEAR_Pos) /*!< Bit mask of COMPARE2_CLEAR field. */
+#define TIMER_SHORTS_COMPARE2_CLEAR_Disabled (0UL) /*!< Shortcut disabled. */
+#define TIMER_SHORTS_COMPARE2_CLEAR_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 1 : Shortcut between CC[1] event and the CLEAR task. */
+#define TIMER_SHORTS_COMPARE1_CLEAR_Pos (1UL) /*!< Position of COMPARE1_CLEAR field. */
+#define TIMER_SHORTS_COMPARE1_CLEAR_Msk (0x1UL << TIMER_SHORTS_COMPARE1_CLEAR_Pos) /*!< Bit mask of COMPARE1_CLEAR field. */
+#define TIMER_SHORTS_COMPARE1_CLEAR_Disabled (0UL) /*!< Shortcut disabled. */
+#define TIMER_SHORTS_COMPARE1_CLEAR_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 0 : Shortcut between CC[0] event and the CLEAR task. */
+#define TIMER_SHORTS_COMPARE0_CLEAR_Pos (0UL) /*!< Position of COMPARE0_CLEAR field. */
+#define TIMER_SHORTS_COMPARE0_CLEAR_Msk (0x1UL << TIMER_SHORTS_COMPARE0_CLEAR_Pos) /*!< Bit mask of COMPARE0_CLEAR field. */
+#define TIMER_SHORTS_COMPARE0_CLEAR_Disabled (0UL) /*!< Shortcut disabled. */
+#define TIMER_SHORTS_COMPARE0_CLEAR_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Register: TIMER_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 19 : Enable interrupt on COMPARE[3] */
+#define TIMER_INTENSET_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define TIMER_INTENSET_COMPARE3_Msk (0x1UL << TIMER_INTENSET_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define TIMER_INTENSET_COMPARE3_Disabled (0UL) /*!< Interrupt disabled. */
+#define TIMER_INTENSET_COMPARE3_Enabled (1UL) /*!< Interrupt enabled. */
+#define TIMER_INTENSET_COMPARE3_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 18 : Enable interrupt on COMPARE[2] */
+#define TIMER_INTENSET_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define TIMER_INTENSET_COMPARE2_Msk (0x1UL << TIMER_INTENSET_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define TIMER_INTENSET_COMPARE2_Disabled (0UL) /*!< Interrupt disabled. */
+#define TIMER_INTENSET_COMPARE2_Enabled (1UL) /*!< Interrupt enabled. */
+#define TIMER_INTENSET_COMPARE2_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 17 : Enable interrupt on COMPARE[1] */
+#define TIMER_INTENSET_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define TIMER_INTENSET_COMPARE1_Msk (0x1UL << TIMER_INTENSET_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define TIMER_INTENSET_COMPARE1_Disabled (0UL) /*!< Interrupt disabled. */
+#define TIMER_INTENSET_COMPARE1_Enabled (1UL) /*!< Interrupt enabled. */
+#define TIMER_INTENSET_COMPARE1_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 16 : Enable interrupt on COMPARE[0] */
+#define TIMER_INTENSET_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define TIMER_INTENSET_COMPARE0_Msk (0x1UL << TIMER_INTENSET_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define TIMER_INTENSET_COMPARE0_Disabled (0UL) /*!< Interrupt disabled. */
+#define TIMER_INTENSET_COMPARE0_Enabled (1UL) /*!< Interrupt enabled. */
+#define TIMER_INTENSET_COMPARE0_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: TIMER_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 19 : Disable interrupt on COMPARE[3] */
+#define TIMER_INTENCLR_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define TIMER_INTENCLR_COMPARE3_Msk (0x1UL << TIMER_INTENCLR_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define TIMER_INTENCLR_COMPARE3_Disabled (0UL) /*!< Interrupt disabled. */
+#define TIMER_INTENCLR_COMPARE3_Enabled (1UL) /*!< Interrupt enabled. */
+#define TIMER_INTENCLR_COMPARE3_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 18 : Disable interrupt on COMPARE[2] */
+#define TIMER_INTENCLR_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define TIMER_INTENCLR_COMPARE2_Msk (0x1UL << TIMER_INTENCLR_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define TIMER_INTENCLR_COMPARE2_Disabled (0UL) /*!< Interrupt disabled. */
+#define TIMER_INTENCLR_COMPARE2_Enabled (1UL) /*!< Interrupt enabled. */
+#define TIMER_INTENCLR_COMPARE2_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 17 : Disable interrupt on COMPARE[1] */
+#define TIMER_INTENCLR_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define TIMER_INTENCLR_COMPARE1_Msk (0x1UL << TIMER_INTENCLR_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define TIMER_INTENCLR_COMPARE1_Disabled (0UL) /*!< Interrupt disabled. */
+#define TIMER_INTENCLR_COMPARE1_Enabled (1UL) /*!< Interrupt enabled. */
+#define TIMER_INTENCLR_COMPARE1_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 16 : Disable interrupt on COMPARE[0] */
+#define TIMER_INTENCLR_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define TIMER_INTENCLR_COMPARE0_Msk (0x1UL << TIMER_INTENCLR_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define TIMER_INTENCLR_COMPARE0_Disabled (0UL) /*!< Interrupt disabled. */
+#define TIMER_INTENCLR_COMPARE0_Enabled (1UL) /*!< Interrupt enabled. */
+#define TIMER_INTENCLR_COMPARE0_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: TIMER_MODE */
+/* Description: Timer Mode selection. */
+
+/* Bit 0 : Select Normal or Counter mode. */
+#define TIMER_MODE_MODE_Pos (0UL) /*!< Position of MODE field. */
+#define TIMER_MODE_MODE_Msk (0x1UL << TIMER_MODE_MODE_Pos) /*!< Bit mask of MODE field. */
+#define TIMER_MODE_MODE_Timer (0UL) /*!< Timer in Normal mode. */
+#define TIMER_MODE_MODE_Counter (1UL) /*!< Timer in Counter mode. */
+
+/* Register: TIMER_BITMODE */
+/* Description: Sets timer behaviour. */
+
+/* Bits 1..0 : Sets timer behaviour ro be like the implementation of a timer with width as indicated. */
+#define TIMER_BITMODE_BITMODE_Pos (0UL) /*!< Position of BITMODE field. */
+#define TIMER_BITMODE_BITMODE_Msk (0x3UL << TIMER_BITMODE_BITMODE_Pos) /*!< Bit mask of BITMODE field. */
+#define TIMER_BITMODE_BITMODE_16Bit (0x00UL) /*!< 16-bit timer behaviour. */
+#define TIMER_BITMODE_BITMODE_08Bit (0x01UL) /*!< 8-bit timer behaviour. */
+#define TIMER_BITMODE_BITMODE_24Bit (0x02UL) /*!< 24-bit timer behaviour. */
+#define TIMER_BITMODE_BITMODE_32Bit (0x03UL) /*!< 32-bit timer behaviour. */
+
+/* Register: TIMER_PRESCALER */
+/* Description: 4-bit prescaler to source clock frequency (max value 9). Source clock frequency is divided by 2^SCALE. */
+
+/* Bits 3..0 : Timer PRESCALER value. Max value is 9. */
+#define TIMER_PRESCALER_PRESCALER_Pos (0UL) /*!< Position of PRESCALER field. */
+#define TIMER_PRESCALER_PRESCALER_Msk (0xFUL << TIMER_PRESCALER_PRESCALER_Pos) /*!< Bit mask of PRESCALER field. */
+
+/* Register: TIMER_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define TIMER_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define TIMER_POWER_POWER_Msk (0x1UL << TIMER_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define TIMER_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define TIMER_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: TWI */
+/* Description: Two-wire interface master 0. */
+
+/* Register: TWI_SHORTS */
+/* Description: Shortcuts for TWI. */
+
+/* Bit 1 : Shortcut between BB event and the STOP task. */
+#define TWI_SHORTS_BB_STOP_Pos (1UL) /*!< Position of BB_STOP field. */
+#define TWI_SHORTS_BB_STOP_Msk (0x1UL << TWI_SHORTS_BB_STOP_Pos) /*!< Bit mask of BB_STOP field. */
+#define TWI_SHORTS_BB_STOP_Disabled (0UL) /*!< Shortcut disabled. */
+#define TWI_SHORTS_BB_STOP_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 0 : Shortcut between BB event and the SUSPEND task. */
+#define TWI_SHORTS_BB_SUSPEND_Pos (0UL) /*!< Position of BB_SUSPEND field. */
+#define TWI_SHORTS_BB_SUSPEND_Msk (0x1UL << TWI_SHORTS_BB_SUSPEND_Pos) /*!< Bit mask of BB_SUSPEND field. */
+#define TWI_SHORTS_BB_SUSPEND_Disabled (0UL) /*!< Shortcut disabled. */
+#define TWI_SHORTS_BB_SUSPEND_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Register: TWI_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 18 : Enable interrupt on SUSPENDED event. */
+#define TWI_INTENSET_SUSPENDED_Pos (18UL) /*!< Position of SUSPENDED field. */
+#define TWI_INTENSET_SUSPENDED_Msk (0x1UL << TWI_INTENSET_SUSPENDED_Pos) /*!< Bit mask of SUSPENDED field. */
+#define TWI_INTENSET_SUSPENDED_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENSET_SUSPENDED_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENSET_SUSPENDED_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 14 : Enable interrupt on BB event. */
+#define TWI_INTENSET_BB_Pos (14UL) /*!< Position of BB field. */
+#define TWI_INTENSET_BB_Msk (0x1UL << TWI_INTENSET_BB_Pos) /*!< Bit mask of BB field. */
+#define TWI_INTENSET_BB_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENSET_BB_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENSET_BB_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 9 : Enable interrupt on ERROR event. */
+#define TWI_INTENSET_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define TWI_INTENSET_ERROR_Msk (0x1UL << TWI_INTENSET_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define TWI_INTENSET_ERROR_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENSET_ERROR_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENSET_ERROR_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 7 : Enable interrupt on TXDSENT event. */
+#define TWI_INTENSET_TXDSENT_Pos (7UL) /*!< Position of TXDSENT field. */
+#define TWI_INTENSET_TXDSENT_Msk (0x1UL << TWI_INTENSET_TXDSENT_Pos) /*!< Bit mask of TXDSENT field. */
+#define TWI_INTENSET_TXDSENT_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENSET_TXDSENT_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENSET_TXDSENT_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 2 : Enable interrupt on READY event. */
+#define TWI_INTENSET_RXDREADY_Pos (2UL) /*!< Position of RXDREADY field. */
+#define TWI_INTENSET_RXDREADY_Msk (0x1UL << TWI_INTENSET_RXDREADY_Pos) /*!< Bit mask of RXDREADY field. */
+#define TWI_INTENSET_RXDREADY_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENSET_RXDREADY_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENSET_RXDREADY_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on STOPPED event. */
+#define TWI_INTENSET_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define TWI_INTENSET_STOPPED_Msk (0x1UL << TWI_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define TWI_INTENSET_STOPPED_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENSET_STOPPED_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENSET_STOPPED_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: TWI_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 18 : Disable interrupt on SUSPENDED event. */
+#define TWI_INTENCLR_SUSPENDED_Pos (18UL) /*!< Position of SUSPENDED field. */
+#define TWI_INTENCLR_SUSPENDED_Msk (0x1UL << TWI_INTENCLR_SUSPENDED_Pos) /*!< Bit mask of SUSPENDED field. */
+#define TWI_INTENCLR_SUSPENDED_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENCLR_SUSPENDED_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENCLR_SUSPENDED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 14 : Disable interrupt on BB event. */
+#define TWI_INTENCLR_BB_Pos (14UL) /*!< Position of BB field. */
+#define TWI_INTENCLR_BB_Msk (0x1UL << TWI_INTENCLR_BB_Pos) /*!< Bit mask of BB field. */
+#define TWI_INTENCLR_BB_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENCLR_BB_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENCLR_BB_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 9 : Disable interrupt on ERROR event. */
+#define TWI_INTENCLR_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define TWI_INTENCLR_ERROR_Msk (0x1UL << TWI_INTENCLR_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define TWI_INTENCLR_ERROR_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENCLR_ERROR_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENCLR_ERROR_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 7 : Disable interrupt on TXDSENT event. */
+#define TWI_INTENCLR_TXDSENT_Pos (7UL) /*!< Position of TXDSENT field. */
+#define TWI_INTENCLR_TXDSENT_Msk (0x1UL << TWI_INTENCLR_TXDSENT_Pos) /*!< Bit mask of TXDSENT field. */
+#define TWI_INTENCLR_TXDSENT_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENCLR_TXDSENT_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENCLR_TXDSENT_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 2 : Disable interrupt on RXDREADY event. */
+#define TWI_INTENCLR_RXDREADY_Pos (2UL) /*!< Position of RXDREADY field. */
+#define TWI_INTENCLR_RXDREADY_Msk (0x1UL << TWI_INTENCLR_RXDREADY_Pos) /*!< Bit mask of RXDREADY field. */
+#define TWI_INTENCLR_RXDREADY_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENCLR_RXDREADY_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENCLR_RXDREADY_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on STOPPED event. */
+#define TWI_INTENCLR_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define TWI_INTENCLR_STOPPED_Msk (0x1UL << TWI_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define TWI_INTENCLR_STOPPED_Disabled (0UL) /*!< Interrupt disabled. */
+#define TWI_INTENCLR_STOPPED_Enabled (1UL) /*!< Interrupt enabled. */
+#define TWI_INTENCLR_STOPPED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: TWI_ERRORSRC */
+/* Description: Two-wire error source. Write error field to 1 to clear error. */
+
+/* Bit 2 : NACK received after sending a data byte. */
+#define TWI_ERRORSRC_DNACK_Pos (2UL) /*!< Position of DNACK field. */
+#define TWI_ERRORSRC_DNACK_Msk (0x1UL << TWI_ERRORSRC_DNACK_Pos) /*!< Bit mask of DNACK field. */
+#define TWI_ERRORSRC_DNACK_NotPresent (0UL) /*!< Error not present. */
+#define TWI_ERRORSRC_DNACK_Present (1UL) /*!< Error present. */
+#define TWI_ERRORSRC_DNACK_Clear (1UL) /*!< Clear error on write. */
+
+/* Bit 1 : NACK received after sending the address. */
+#define TWI_ERRORSRC_ANACK_Pos (1UL) /*!< Position of ANACK field. */
+#define TWI_ERRORSRC_ANACK_Msk (0x1UL << TWI_ERRORSRC_ANACK_Pos) /*!< Bit mask of ANACK field. */
+#define TWI_ERRORSRC_ANACK_NotPresent (0UL) /*!< Error not present. */
+#define TWI_ERRORSRC_ANACK_Present (1UL) /*!< Error present. */
+#define TWI_ERRORSRC_ANACK_Clear (1UL) /*!< Clear error on write. */
+
+/* Bit 0 : Byte received in RXD register before read of the last received byte (data loss). */
+#define TWI_ERRORSRC_OVERRUN_Pos (0UL) /*!< Position of OVERRUN field. */
+#define TWI_ERRORSRC_OVERRUN_Msk (0x1UL << TWI_ERRORSRC_OVERRUN_Pos) /*!< Bit mask of OVERRUN field. */
+#define TWI_ERRORSRC_OVERRUN_NotPresent (0UL) /*!< Error not present. */
+#define TWI_ERRORSRC_OVERRUN_Present (1UL) /*!< Error present. */
+#define TWI_ERRORSRC_OVERRUN_Clear (1UL) /*!< Clear error on write. */
+
+/* Register: TWI_ENABLE */
+/* Description: Enable two-wire master. */
+
+/* Bits 2..0 : Enable or disable W2M */
+#define TWI_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define TWI_ENABLE_ENABLE_Msk (0x7UL << TWI_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define TWI_ENABLE_ENABLE_Disabled (0x00UL) /*!< Disabled. */
+#define TWI_ENABLE_ENABLE_Enabled (0x05UL) /*!< Enabled. */
+
+/* Register: TWI_RXD */
+/* Description: RX data register. */
+
+/* Bits 7..0 : RX data from last transfer. */
+#define TWI_RXD_RXD_Pos (0UL) /*!< Position of RXD field. */
+#define TWI_RXD_RXD_Msk (0xFFUL << TWI_RXD_RXD_Pos) /*!< Bit mask of RXD field. */
+
+/* Register: TWI_TXD */
+/* Description: TX data register. */
+
+/* Bits 7..0 : TX data for next transfer. */
+#define TWI_TXD_TXD_Pos (0UL) /*!< Position of TXD field. */
+#define TWI_TXD_TXD_Msk (0xFFUL << TWI_TXD_TXD_Pos) /*!< Bit mask of TXD field. */
+
+/* Register: TWI_FREQUENCY */
+/* Description: Two-wire frequency. */
+
+/* Bits 31..0 : Two-wire master clock frequency. */
+#define TWI_FREQUENCY_FREQUENCY_Pos (0UL) /*!< Position of FREQUENCY field. */
+#define TWI_FREQUENCY_FREQUENCY_Msk (0xFFFFFFFFUL << TWI_FREQUENCY_FREQUENCY_Pos) /*!< Bit mask of FREQUENCY field. */
+#define TWI_FREQUENCY_FREQUENCY_K100 (0x01980000UL) /*!< 100 kbps. */
+#define TWI_FREQUENCY_FREQUENCY_K250 (0x04000000UL) /*!< 250 kbps. */
+#define TWI_FREQUENCY_FREQUENCY_K400 (0x06680000UL) /*!< 400 kbps. */
+
+/* Register: TWI_ADDRESS */
+/* Description: Address used in the two-wire transfer. */
+
+/* Bits 6..0 : Two-wire address. */
+#define TWI_ADDRESS_ADDRESS_Pos (0UL) /*!< Position of ADDRESS field. */
+#define TWI_ADDRESS_ADDRESS_Msk (0x7FUL << TWI_ADDRESS_ADDRESS_Pos) /*!< Bit mask of ADDRESS field. */
+
+/* Register: TWI_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define TWI_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define TWI_POWER_POWER_Msk (0x1UL << TWI_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define TWI_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define TWI_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: UART */
+/* Description: Universal Asynchronous Receiver/Transmitter. */
+
+/* Register: UART_SHORTS */
+/* Description: Shortcuts for UART. */
+
+/* Bit 4 : Shortcut between NCTS event and STOPRX task. */
+#define UART_SHORTS_NCTS_STOPRX_Pos (4UL) /*!< Position of NCTS_STOPRX field. */
+#define UART_SHORTS_NCTS_STOPRX_Msk (0x1UL << UART_SHORTS_NCTS_STOPRX_Pos) /*!< Bit mask of NCTS_STOPRX field. */
+#define UART_SHORTS_NCTS_STOPRX_Disabled (0UL) /*!< Shortcut disabled. */
+#define UART_SHORTS_NCTS_STOPRX_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Bit 3 : Shortcut between CTS event and STARTRX task. */
+#define UART_SHORTS_CTS_STARTRX_Pos (3UL) /*!< Position of CTS_STARTRX field. */
+#define UART_SHORTS_CTS_STARTRX_Msk (0x1UL << UART_SHORTS_CTS_STARTRX_Pos) /*!< Bit mask of CTS_STARTRX field. */
+#define UART_SHORTS_CTS_STARTRX_Disabled (0UL) /*!< Shortcut disabled. */
+#define UART_SHORTS_CTS_STARTRX_Enabled (1UL) /*!< Shortcut enabled. */
+
+/* Register: UART_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 17 : Enable interrupt on RXTO event. */
+#define UART_INTENSET_RXTO_Pos (17UL) /*!< Position of RXTO field. */
+#define UART_INTENSET_RXTO_Msk (0x1UL << UART_INTENSET_RXTO_Pos) /*!< Bit mask of RXTO field. */
+#define UART_INTENSET_RXTO_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENSET_RXTO_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENSET_RXTO_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 9 : Enable interrupt on ERROR event. */
+#define UART_INTENSET_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define UART_INTENSET_ERROR_Msk (0x1UL << UART_INTENSET_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define UART_INTENSET_ERROR_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENSET_ERROR_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENSET_ERROR_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 7 : Enable interrupt on TXRDY event. */
+#define UART_INTENSET_TXDRDY_Pos (7UL) /*!< Position of TXDRDY field. */
+#define UART_INTENSET_TXDRDY_Msk (0x1UL << UART_INTENSET_TXDRDY_Pos) /*!< Bit mask of TXDRDY field. */
+#define UART_INTENSET_TXDRDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENSET_TXDRDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENSET_TXDRDY_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 2 : Enable interrupt on RXRDY event. */
+#define UART_INTENSET_RXDRDY_Pos (2UL) /*!< Position of RXDRDY field. */
+#define UART_INTENSET_RXDRDY_Msk (0x1UL << UART_INTENSET_RXDRDY_Pos) /*!< Bit mask of RXDRDY field. */
+#define UART_INTENSET_RXDRDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENSET_RXDRDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENSET_RXDRDY_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 1 : Enable interrupt on NCTS event. */
+#define UART_INTENSET_NCTS_Pos (1UL) /*!< Position of NCTS field. */
+#define UART_INTENSET_NCTS_Msk (0x1UL << UART_INTENSET_NCTS_Pos) /*!< Bit mask of NCTS field. */
+#define UART_INTENSET_NCTS_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENSET_NCTS_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENSET_NCTS_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Bit 0 : Enable interrupt on CTS event. */
+#define UART_INTENSET_CTS_Pos (0UL) /*!< Position of CTS field. */
+#define UART_INTENSET_CTS_Msk (0x1UL << UART_INTENSET_CTS_Pos) /*!< Bit mask of CTS field. */
+#define UART_INTENSET_CTS_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENSET_CTS_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENSET_CTS_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: UART_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 17 : Disable interrupt on RXTO event. */
+#define UART_INTENCLR_RXTO_Pos (17UL) /*!< Position of RXTO field. */
+#define UART_INTENCLR_RXTO_Msk (0x1UL << UART_INTENCLR_RXTO_Pos) /*!< Bit mask of RXTO field. */
+#define UART_INTENCLR_RXTO_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENCLR_RXTO_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENCLR_RXTO_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 9 : Disable interrupt on ERROR event. */
+#define UART_INTENCLR_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define UART_INTENCLR_ERROR_Msk (0x1UL << UART_INTENCLR_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define UART_INTENCLR_ERROR_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENCLR_ERROR_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENCLR_ERROR_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 7 : Disable interrupt on TXRDY event. */
+#define UART_INTENCLR_TXDRDY_Pos (7UL) /*!< Position of TXDRDY field. */
+#define UART_INTENCLR_TXDRDY_Msk (0x1UL << UART_INTENCLR_TXDRDY_Pos) /*!< Bit mask of TXDRDY field. */
+#define UART_INTENCLR_TXDRDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENCLR_TXDRDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENCLR_TXDRDY_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 2 : Disable interrupt on RXRDY event. */
+#define UART_INTENCLR_RXDRDY_Pos (2UL) /*!< Position of RXDRDY field. */
+#define UART_INTENCLR_RXDRDY_Msk (0x1UL << UART_INTENCLR_RXDRDY_Pos) /*!< Bit mask of RXDRDY field. */
+#define UART_INTENCLR_RXDRDY_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENCLR_RXDRDY_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENCLR_RXDRDY_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 1 : Disable interrupt on NCTS event. */
+#define UART_INTENCLR_NCTS_Pos (1UL) /*!< Position of NCTS field. */
+#define UART_INTENCLR_NCTS_Msk (0x1UL << UART_INTENCLR_NCTS_Pos) /*!< Bit mask of NCTS field. */
+#define UART_INTENCLR_NCTS_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENCLR_NCTS_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENCLR_NCTS_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 0 : Disable interrupt on CTS event. */
+#define UART_INTENCLR_CTS_Pos (0UL) /*!< Position of CTS field. */
+#define UART_INTENCLR_CTS_Msk (0x1UL << UART_INTENCLR_CTS_Pos) /*!< Bit mask of CTS field. */
+#define UART_INTENCLR_CTS_Disabled (0UL) /*!< Interrupt disabled. */
+#define UART_INTENCLR_CTS_Enabled (1UL) /*!< Interrupt enabled. */
+#define UART_INTENCLR_CTS_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: UART_ERRORSRC */
+/* Description: Error source. Write error field to 1 to clear error. */
+
+/* Bit 3 : The serial data input is '0' for longer than the length of a data frame. */
+#define UART_ERRORSRC_BREAK_Pos (3UL) /*!< Position of BREAK field. */
+#define UART_ERRORSRC_BREAK_Msk (0x1UL << UART_ERRORSRC_BREAK_Pos) /*!< Bit mask of BREAK field. */
+#define UART_ERRORSRC_BREAK_NotPresent (0UL) /*!< Error not present. */
+#define UART_ERRORSRC_BREAK_Present (1UL) /*!< Error present. */
+#define UART_ERRORSRC_BREAK_Clear (1UL) /*!< Clear error on write. */
+
+/* Bit 2 : A valid stop bit is not detected on the serial data input after all bits in a character have been received. */
+#define UART_ERRORSRC_FRAMING_Pos (2UL) /*!< Position of FRAMING field. */
+#define UART_ERRORSRC_FRAMING_Msk (0x1UL << UART_ERRORSRC_FRAMING_Pos) /*!< Bit mask of FRAMING field. */
+#define UART_ERRORSRC_FRAMING_NotPresent (0UL) /*!< Error not present. */
+#define UART_ERRORSRC_FRAMING_Present (1UL) /*!< Error present. */
+#define UART_ERRORSRC_FRAMING_Clear (1UL) /*!< Clear error on write. */
+
+/* Bit 1 : A character with bad parity is received. Only checked if HW parity control is enabled. */
+#define UART_ERRORSRC_PARITY_Pos (1UL) /*!< Position of PARITY field. */
+#define UART_ERRORSRC_PARITY_Msk (0x1UL << UART_ERRORSRC_PARITY_Pos) /*!< Bit mask of PARITY field. */
+#define UART_ERRORSRC_PARITY_NotPresent (0UL) /*!< Error not present. */
+#define UART_ERRORSRC_PARITY_Present (1UL) /*!< Error present. */
+#define UART_ERRORSRC_PARITY_Clear (1UL) /*!< Clear error on write. */
+
+/* Bit 0 : A start bit is received while the previous data still lies in RXD. (Data loss). */
+#define UART_ERRORSRC_OVERRUN_Pos (0UL) /*!< Position of OVERRUN field. */
+#define UART_ERRORSRC_OVERRUN_Msk (0x1UL << UART_ERRORSRC_OVERRUN_Pos) /*!< Bit mask of OVERRUN field. */
+#define UART_ERRORSRC_OVERRUN_NotPresent (0UL) /*!< Error not present. */
+#define UART_ERRORSRC_OVERRUN_Present (1UL) /*!< Error present. */
+#define UART_ERRORSRC_OVERRUN_Clear (1UL) /*!< Clear error on write. */
+
+/* Register: UART_ENABLE */
+/* Description: Enable UART and acquire IOs. */
+
+/* Bits 2..0 : Enable or disable UART and acquire IOs. */
+#define UART_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define UART_ENABLE_ENABLE_Msk (0x7UL << UART_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define UART_ENABLE_ENABLE_Disabled (0x00UL) /*!< UART disabled. */
+#define UART_ENABLE_ENABLE_Enabled (0x04UL) /*!< UART enabled. */
+
+/* Register: UART_RXD */
+/* Description: RXD register. On read action the buffer pointer is displaced. Once read the character is consumed. If read when no character available, the UART will stop working. */
+
+/* Bits 7..0 : RX data from previous transfer. Double buffered. */
+#define UART_RXD_RXD_Pos (0UL) /*!< Position of RXD field. */
+#define UART_RXD_RXD_Msk (0xFFUL << UART_RXD_RXD_Pos) /*!< Bit mask of RXD field. */
+
+/* Register: UART_TXD */
+/* Description: TXD register. */
+
+/* Bits 7..0 : TX data for transfer. */
+#define UART_TXD_TXD_Pos (0UL) /*!< Position of TXD field. */
+#define UART_TXD_TXD_Msk (0xFFUL << UART_TXD_TXD_Pos) /*!< Bit mask of TXD field. */
+
+/* Register: UART_BAUDRATE */
+/* Description: UART Baudrate. */
+
+/* Bits 31..0 : UART baudrate. */
+#define UART_BAUDRATE_BAUDRATE_Pos (0UL) /*!< Position of BAUDRATE field. */
+#define UART_BAUDRATE_BAUDRATE_Msk (0xFFFFFFFFUL << UART_BAUDRATE_BAUDRATE_Pos) /*!< Bit mask of BAUDRATE field. */
+#define UART_BAUDRATE_BAUDRATE_Baud1200 (0x0004F000UL) /*!< 1200 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud2400 (0x0009D000UL) /*!< 2400 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud4800 (0x0013B000UL) /*!< 4800 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud9600 (0x00275000UL) /*!< 9600 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud14400 (0x003B0000UL) /*!< 14400 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud19200 (0x004EA000UL) /*!< 19200 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud28800 (0x0075F000UL) /*!< 28800 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud38400 (0x009D5000UL) /*!< 38400 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud57600 (0x00EBF000UL) /*!< 57600 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud76800 (0x013A9000UL) /*!< 76800 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud115200 (0x01D7E000UL) /*!< 115200 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud230400 (0x03AFB000UL) /*!< 230400 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud250000 (0x04000000UL) /*!< 250000 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud460800 (0x075F7000UL) /*!< 460800 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud921600 (0x0EBED000UL) /*!< 921600 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud1M (0x10000000UL) /*!< 1M baud. */
+
+/* Register: UART_CONFIG */
+/* Description: Configuration of parity and hardware flow control register. */
+
+/* Bits 3..1 : Include parity bit. */
+#define UART_CONFIG_PARITY_Pos (1UL) /*!< Position of PARITY field. */
+#define UART_CONFIG_PARITY_Msk (0x7UL << UART_CONFIG_PARITY_Pos) /*!< Bit mask of PARITY field. */
+#define UART_CONFIG_PARITY_Excluded (0UL) /*!< Parity bit excluded. */
+#define UART_CONFIG_PARITY_Included (7UL) /*!< Parity bit included. */
+
+/* Bit 0 : Hardware flow control. */
+#define UART_CONFIG_HWFC_Pos (0UL) /*!< Position of HWFC field. */
+#define UART_CONFIG_HWFC_Msk (0x1UL << UART_CONFIG_HWFC_Pos) /*!< Bit mask of HWFC field. */
+#define UART_CONFIG_HWFC_Disabled (0UL) /*!< Hardware flow control disabled. */
+#define UART_CONFIG_HWFC_Enabled (1UL) /*!< Hardware flow control enabled. */
+
+/* Register: UART_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define UART_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define UART_POWER_POWER_Msk (0x1UL << UART_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define UART_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define UART_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/* Peripheral: UICR */
+/* Description: User Information Configuration. */
+
+/* Register: UICR_RBPCONF */
+/* Description: Readback protection configuration. */
+
+/* Bits 15..8 : Readback protect all code in the device. */
+#define UICR_RBPCONF_PALL_Pos (8UL) /*!< Position of PALL field. */
+#define UICR_RBPCONF_PALL_Msk (0xFFUL << UICR_RBPCONF_PALL_Pos) /*!< Bit mask of PALL field. */
+#define UICR_RBPCONF_PALL_Enabled (0x00UL) /*!< Enabled. */
+#define UICR_RBPCONF_PALL_Disabled (0xFFUL) /*!< Disabled. */
+
+/* Bits 7..0 : Readback protect region 0. Will be ignored if pre-programmed factory code is present on the chip. */
+#define UICR_RBPCONF_PR0_Pos (0UL) /*!< Position of PR0 field. */
+#define UICR_RBPCONF_PR0_Msk (0xFFUL << UICR_RBPCONF_PR0_Pos) /*!< Bit mask of PR0 field. */
+#define UICR_RBPCONF_PR0_Enabled (0x00UL) /*!< Enabled. */
+#define UICR_RBPCONF_PR0_Disabled (0xFFUL) /*!< Disabled. */
+
+/* Register: UICR_XTALFREQ */
+/* Description: Reset value for CLOCK XTALFREQ register. */
+
+/* Bits 7..0 : Reset value for CLOCK XTALFREQ register. */
+#define UICR_XTALFREQ_XTALFREQ_Pos (0UL) /*!< Position of XTALFREQ field. */
+#define UICR_XTALFREQ_XTALFREQ_Msk (0xFFUL << UICR_XTALFREQ_XTALFREQ_Pos) /*!< Bit mask of XTALFREQ field. */
+#define UICR_XTALFREQ_XTALFREQ_32MHz (0x00UL) /*!< 32MHz Xtal is used. */
+#define UICR_XTALFREQ_XTALFREQ_16MHz (0xFFUL) /*!< 16MHz Xtal is used. */
+
+/* Register: UICR_FWID */
+/* Description: Firmware ID. */
+
+/* Bits 15..0 : Identification number for the firmware loaded into the chip. */
+#define UICR_FWID_FWID_Pos (0UL) /*!< Position of FWID field. */
+#define UICR_FWID_FWID_Msk (0xFFFFUL << UICR_FWID_FWID_Pos) /*!< Bit mask of FWID field. */
+
+
+/* Peripheral: WDT */
+/* Description: Watchdog Timer. */
+
+/* Register: WDT_INTENSET */
+/* Description: Interrupt enable set register. */
+
+/* Bit 0 : Enable interrupt on TIMEOUT event. */
+#define WDT_INTENSET_TIMEOUT_Pos (0UL) /*!< Position of TIMEOUT field. */
+#define WDT_INTENSET_TIMEOUT_Msk (0x1UL << WDT_INTENSET_TIMEOUT_Pos) /*!< Bit mask of TIMEOUT field. */
+#define WDT_INTENSET_TIMEOUT_Disabled (0UL) /*!< Interrupt disabled. */
+#define WDT_INTENSET_TIMEOUT_Enabled (1UL) /*!< Interrupt enabled. */
+#define WDT_INTENSET_TIMEOUT_Set (1UL) /*!< Enable interrupt on write. */
+
+/* Register: WDT_INTENCLR */
+/* Description: Interrupt enable clear register. */
+
+/* Bit 0 : Disable interrupt on TIMEOUT event. */
+#define WDT_INTENCLR_TIMEOUT_Pos (0UL) /*!< Position of TIMEOUT field. */
+#define WDT_INTENCLR_TIMEOUT_Msk (0x1UL << WDT_INTENCLR_TIMEOUT_Pos) /*!< Bit mask of TIMEOUT field. */
+#define WDT_INTENCLR_TIMEOUT_Disabled (0UL) /*!< Interrupt disabled. */
+#define WDT_INTENCLR_TIMEOUT_Enabled (1UL) /*!< Interrupt enabled. */
+#define WDT_INTENCLR_TIMEOUT_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Register: WDT_RUNSTATUS */
+/* Description: Watchdog running status. */
+
+/* Bit 0 : Watchdog running status. */
+#define WDT_RUNSTATUS_RUNSTATUS_Pos (0UL) /*!< Position of RUNSTATUS field. */
+#define WDT_RUNSTATUS_RUNSTATUS_Msk (0x1UL << WDT_RUNSTATUS_RUNSTATUS_Pos) /*!< Bit mask of RUNSTATUS field. */
+#define WDT_RUNSTATUS_RUNSTATUS_NotRunning (0UL) /*!< Watchdog timer is not running. */
+#define WDT_RUNSTATUS_RUNSTATUS_Running (1UL) /*!< Watchdog timer is running. */
+
+/* Register: WDT_REQSTATUS */
+/* Description: Request status. */
+
+/* Bit 7 : Request status for RR[7]. */
+#define WDT_REQSTATUS_RR7_Pos (7UL) /*!< Position of RR7 field. */
+#define WDT_REQSTATUS_RR7_Msk (0x1UL << WDT_REQSTATUS_RR7_Pos) /*!< Bit mask of RR7 field. */
+#define WDT_REQSTATUS_RR7_DisabledOrRequested (0UL) /*!< RR[7] register is not enabled or has already requested reload. */
+#define WDT_REQSTATUS_RR7_EnabledAndUnrequested (1UL) /*!< RR[7] register is enabled and has not jet requested. */
+
+/* Bit 6 : Request status for RR[6]. */
+#define WDT_REQSTATUS_RR6_Pos (6UL) /*!< Position of RR6 field. */
+#define WDT_REQSTATUS_RR6_Msk (0x1UL << WDT_REQSTATUS_RR6_Pos) /*!< Bit mask of RR6 field. */
+#define WDT_REQSTATUS_RR6_DisabledOrRequested (0UL) /*!< RR[6] register is not enabled or has already requested reload. */
+#define WDT_REQSTATUS_RR6_EnabledAndUnrequested (1UL) /*!< RR[6] register is enabled and has not jet requested. */
+
+/* Bit 5 : Request status for RR[5]. */
+#define WDT_REQSTATUS_RR5_Pos (5UL) /*!< Position of RR5 field. */
+#define WDT_REQSTATUS_RR5_Msk (0x1UL << WDT_REQSTATUS_RR5_Pos) /*!< Bit mask of RR5 field. */
+#define WDT_REQSTATUS_RR5_DisabledOrRequested (0UL) /*!< RR[5] register is not enabled or has already requested reload. */
+#define WDT_REQSTATUS_RR5_EnabledAndUnrequested (1UL) /*!< RR[5] register is enabled and has not jet requested. */
+
+/* Bit 4 : Request status for RR[4]. */
+#define WDT_REQSTATUS_RR4_Pos (4UL) /*!< Position of RR4 field. */
+#define WDT_REQSTATUS_RR4_Msk (0x1UL << WDT_REQSTATUS_RR4_Pos) /*!< Bit mask of RR4 field. */
+#define WDT_REQSTATUS_RR4_DisabledOrRequested (0UL) /*!< RR[4] register is not enabled or has already requested reload. */
+#define WDT_REQSTATUS_RR4_EnabledAndUnrequested (1UL) /*!< RR[4] register is enabled and has not jet requested. */
+
+/* Bit 3 : Request status for RR[3]. */
+#define WDT_REQSTATUS_RR3_Pos (3UL) /*!< Position of RR3 field. */
+#define WDT_REQSTATUS_RR3_Msk (0x1UL << WDT_REQSTATUS_RR3_Pos) /*!< Bit mask of RR3 field. */
+#define WDT_REQSTATUS_RR3_DisabledOrRequested (0UL) /*!< RR[3] register is not enabled or has already requested reload. */
+#define WDT_REQSTATUS_RR3_EnabledAndUnrequested (1UL) /*!< RR[3] register is enabled and has not jet requested. */
+
+/* Bit 2 : Request status for RR[2]. */
+#define WDT_REQSTATUS_RR2_Pos (2UL) /*!< Position of RR2 field. */
+#define WDT_REQSTATUS_RR2_Msk (0x1UL << WDT_REQSTATUS_RR2_Pos) /*!< Bit mask of RR2 field. */
+#define WDT_REQSTATUS_RR2_DisabledOrRequested (0UL) /*!< RR[2] register is not enabled or has already requested reload. */
+#define WDT_REQSTATUS_RR2_EnabledAndUnrequested (1UL) /*!< RR[2] register is enabled and has not jet requested. */
+
+/* Bit 1 : Request status for RR[1]. */
+#define WDT_REQSTATUS_RR1_Pos (1UL) /*!< Position of RR1 field. */
+#define WDT_REQSTATUS_RR1_Msk (0x1UL << WDT_REQSTATUS_RR1_Pos) /*!< Bit mask of RR1 field. */
+#define WDT_REQSTATUS_RR1_DisabledOrRequested (0UL) /*!< RR[1] register is not enabled or has already requested reload. */
+#define WDT_REQSTATUS_RR1_EnabledAndUnrequested (1UL) /*!< RR[1] register is enabled and has not jet requested. */
+
+/* Bit 0 : Request status for RR[0]. */
+#define WDT_REQSTATUS_RR0_Pos (0UL) /*!< Position of RR0 field. */
+#define WDT_REQSTATUS_RR0_Msk (0x1UL << WDT_REQSTATUS_RR0_Pos) /*!< Bit mask of RR0 field. */
+#define WDT_REQSTATUS_RR0_DisabledOrRequested (0UL) /*!< RR[0] register is not enabled or has already requested reload. */
+#define WDT_REQSTATUS_RR0_EnabledAndUnrequested (1UL) /*!< RR[0] register is enabled and has not jet requested. */
+
+/* Register: WDT_RREN */
+/* Description: Reload request enable. */
+
+/* Bit 7 : Enable or disable RR[7] register. */
+#define WDT_RREN_RR7_Pos (7UL) /*!< Position of RR7 field. */
+#define WDT_RREN_RR7_Msk (0x1UL << WDT_RREN_RR7_Pos) /*!< Bit mask of RR7 field. */
+#define WDT_RREN_RR7_Disabled (0UL) /*!< RR[7] register is disabled. */
+#define WDT_RREN_RR7_Enabled (1UL) /*!< RR[7] register is enabled. */
+
+/* Bit 6 : Enable or disable RR[6] register. */
+#define WDT_RREN_RR6_Pos (6UL) /*!< Position of RR6 field. */
+#define WDT_RREN_RR6_Msk (0x1UL << WDT_RREN_RR6_Pos) /*!< Bit mask of RR6 field. */
+#define WDT_RREN_RR6_Disabled (0UL) /*!< RR[6] register is disabled. */
+#define WDT_RREN_RR6_Enabled (1UL) /*!< RR[6] register is enabled. */
+
+/* Bit 5 : Enable or disable RR[5] register. */
+#define WDT_RREN_RR5_Pos (5UL) /*!< Position of RR5 field. */
+#define WDT_RREN_RR5_Msk (0x1UL << WDT_RREN_RR5_Pos) /*!< Bit mask of RR5 field. */
+#define WDT_RREN_RR5_Disabled (0UL) /*!< RR[5] register is disabled. */
+#define WDT_RREN_RR5_Enabled (1UL) /*!< RR[5] register is enabled. */
+
+/* Bit 4 : Enable or disable RR[4] register. */
+#define WDT_RREN_RR4_Pos (4UL) /*!< Position of RR4 field. */
+#define WDT_RREN_RR4_Msk (0x1UL << WDT_RREN_RR4_Pos) /*!< Bit mask of RR4 field. */
+#define WDT_RREN_RR4_Disabled (0UL) /*!< RR[4] register is disabled. */
+#define WDT_RREN_RR4_Enabled (1UL) /*!< RR[4] register is enabled. */
+
+/* Bit 3 : Enable or disable RR[3] register. */
+#define WDT_RREN_RR3_Pos (3UL) /*!< Position of RR3 field. */
+#define WDT_RREN_RR3_Msk (0x1UL << WDT_RREN_RR3_Pos) /*!< Bit mask of RR3 field. */
+#define WDT_RREN_RR3_Disabled (0UL) /*!< RR[3] register is disabled. */
+#define WDT_RREN_RR3_Enabled (1UL) /*!< RR[3] register is enabled. */
+
+/* Bit 2 : Enable or disable RR[2] register. */
+#define WDT_RREN_RR2_Pos (2UL) /*!< Position of RR2 field. */
+#define WDT_RREN_RR2_Msk (0x1UL << WDT_RREN_RR2_Pos) /*!< Bit mask of RR2 field. */
+#define WDT_RREN_RR2_Disabled (0UL) /*!< RR[2] register is disabled. */
+#define WDT_RREN_RR2_Enabled (1UL) /*!< RR[2] register is enabled. */
+
+/* Bit 1 : Enable or disable RR[1] register. */
+#define WDT_RREN_RR1_Pos (1UL) /*!< Position of RR1 field. */
+#define WDT_RREN_RR1_Msk (0x1UL << WDT_RREN_RR1_Pos) /*!< Bit mask of RR1 field. */
+#define WDT_RREN_RR1_Disabled (0UL) /*!< RR[1] register is disabled. */
+#define WDT_RREN_RR1_Enabled (1UL) /*!< RR[1] register is enabled. */
+
+/* Bit 0 : Enable or disable RR[0] register. */
+#define WDT_RREN_RR0_Pos (0UL) /*!< Position of RR0 field. */
+#define WDT_RREN_RR0_Msk (0x1UL << WDT_RREN_RR0_Pos) /*!< Bit mask of RR0 field. */
+#define WDT_RREN_RR0_Disabled (0UL) /*!< RR[0] register is disabled. */
+#define WDT_RREN_RR0_Enabled (1UL) /*!< RR[0] register is enabled. */
+
+/* Register: WDT_CONFIG */
+/* Description: Configuration register. */
+
+/* Bit 3 : Configure the watchdog to pause or not while the CPU is halted by the debugger. */
+#define WDT_CONFIG_HALT_Pos (3UL) /*!< Position of HALT field. */
+#define WDT_CONFIG_HALT_Msk (0x1UL << WDT_CONFIG_HALT_Pos) /*!< Bit mask of HALT field. */
+#define WDT_CONFIG_HALT_Pause (0UL) /*!< Pause watchdog while the CPU is halted by the debugger. */
+#define WDT_CONFIG_HALT_Run (1UL) /*!< Do not pause watchdog while the CPU is halted by the debugger. */
+
+/* Bit 0 : Configure the watchdog to pause or not while the CPU is sleeping. */
+#define WDT_CONFIG_SLEEP_Pos (0UL) /*!< Position of SLEEP field. */
+#define WDT_CONFIG_SLEEP_Msk (0x1UL << WDT_CONFIG_SLEEP_Pos) /*!< Bit mask of SLEEP field. */
+#define WDT_CONFIG_SLEEP_Pause (0UL) /*!< Pause watchdog while the CPU is asleep. */
+#define WDT_CONFIG_SLEEP_Run (1UL) /*!< Do not pause watchdog while the CPU is asleep. */
+
+/* Register: WDT_RR */
+/* Description: Reload requests registers. */
+
+/* Bits 31..0 : Reload register. */
+#define WDT_RR_RR_Pos (0UL) /*!< Position of RR field. */
+#define WDT_RR_RR_Msk (0xFFFFFFFFUL << WDT_RR_RR_Pos) /*!< Bit mask of RR field. */
+#define WDT_RR_RR_Reload (0x6E524635UL) /*!< Value to request a reload of the watchdog timer. */
+
+/* Register: WDT_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define WDT_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define WDT_POWER_POWER_Msk (0x1UL << WDT_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define WDT_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define WDT_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
+
+/*lint --flb "Leave library region" */
+#endif

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf51_common.ld
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf51_common.ld
@@ -1,0 +1,164 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ * 
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.Vectors))
+		*(.text*)
+
+		KEEP(*(.init))
+		KEEP(*(.fini))
+
+		/* .ctors */
+		*crtbegin.o(.ctors)
+		*crtbegin?.o(.ctors)
+		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+		*(SORT(.ctors.*))
+		*(.ctors)
+
+		/* .dtors */
+ 		*crtbegin.o(.dtors)
+ 		*crtbegin?.o(.dtors)
+ 		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+ 		*(SORT(.dtors.*))
+ 		*(.dtors)
+
+		*(.rodata*)
+
+		*(.eh_frame*)
+		. = ALIGN(4);
+	} > FLASH
+    
+
+	.ARM.extab : 
+	{
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		. = ALIGN(4);
+	} > FLASH
+
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+		. = ALIGN(4);
+	} > FLASH
+	__exidx_end = .;
+
+	__etext = .;
+		
+	.data : AT (__etext)
+	{
+		__data_start__ = .;
+		*(vtable)
+		*(.data*)
+
+		. = ALIGN(4);
+		/* preinit data */
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		*(.preinit_array)
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+
+		. = ALIGN(4);
+		/* init data */
+		PROVIDE_HIDDEN (__init_array_start = .);
+		*(SORT(.init_array.*))
+		*(.init_array)
+		PROVIDE_HIDDEN (__init_array_end = .);
+
+
+		. = ALIGN(4);
+		/* finit data */
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		*(SORT(.fini_array.*))
+		*(.fini_array)
+		PROVIDE_HIDDEN (__fini_array_end = .);
+
+		*(.jcr)
+		. = ALIGN(4);
+		/* All data end */
+		__data_end__ = .;
+
+	} > RAM
+
+	.bss :
+	{
+		. = ALIGN(4);
+		__bss_start__ = .;
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);
+		__bss_end__ = .;
+	} > RAM
+	
+	.heap (COPY):
+	{
+		__end__ = .;
+		end = __end__;
+		*(.heap*)
+		__HeapLimit = .;
+	} > RAM
+
+	/* .stack_dummy section doesn't contains any symbols. It is only
+	 * used for linker to calculate size of stack sections, and assign
+	 * values to stack symbols later */
+	.stack_dummy (COPY):
+	{
+		*(.stack*)
+	} > RAM
+
+	/* Set stack top to end of RAM, and stack limit move down by
+	 * size of stack_dummy section */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
+	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
+	PROVIDE(__stack = __StackTop);
+	
+	/* Check if data + heap + stack exceeds RAM limit */
+	ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}
+

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf51_deprecated.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf51_deprecated.h
@@ -1,0 +1,438 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef NRF51_DEPRECATED_H
+#define NRF51_DEPRECATED_H
+
+/*lint ++flb "Enter library region */
+
+/* This file is given to prevent your SW from not compiling with the updates made to nrf51.h and 
+ * nrf51_bitfields.h. The macros defined in this file were available previously. Do not use these
+ * macros on purpose. Use the ones defined in nrf51.h and nrf51_bitfields.h instead.
+ */
+
+/* NVMC */
+/* The register ERASEPROTECTEDPAGE is called ERASEPCR0 in the documentation. */
+#define ERASEPROTECTEDPAGE   ERASEPCR0
+
+ 
+/* LPCOMP */
+/* The interrupt ISR was renamed. Adding old name to the macros. */
+#define LPCOMP_COMP_IRQHandler      LPCOMP_IRQHandler
+#define LPCOMP_COMP_IRQn            LPCOMP_IRQn
+ 
+ 
+/* MPU */
+/* The field MPU.PERR0.LPCOMP_COMP was renamed. Added into deprecated in case somebody was using the macros defined for it. */
+#define MPU_PERR0_LPCOMP_COMP_Pos           MPU_PERR0_LPCOMP_Pos
+#define MPU_PERR0_LPCOMP_COMP_Msk           MPU_PERR0_LPCOMP_Msk
+#define MPU_PERR0_LPCOMP_COMP_InRegion1     MPU_PERR0_LPCOMP_InRegion1
+#define MPU_PERR0_LPCOMP_COMP_InRegion0     MPU_PERR0_LPCOMP_InRegion0
+ 
+ 
+/* POWER */
+/* The field POWER.RAMON.OFFRAM3 was eliminated. Added into deprecated in case somebody was using the macros defined for it. */
+#define POWER_RAMON_OFFRAM3_Pos         (19UL)                                  
+#define POWER_RAMON_OFFRAM3_Msk         (0x1UL << POWER_RAMON_OFFRAM3_Pos)      
+#define POWER_RAMON_OFFRAM3_RAM3Off     (0UL)                                   
+#define POWER_RAMON_OFFRAM3_RAM3On      (1UL)                                   
+/* The field POWER.RAMON.OFFRAM2 was eliminated. Added into deprecated in case somebody was using the macros defined for it. */
+#define POWER_RAMON_OFFRAM2_Pos         (18UL)                                  
+#define POWER_RAMON_OFFRAM2_Msk         (0x1UL << POWER_RAMON_OFFRAM2_Pos)      
+#define POWER_RAMON_OFFRAM2_RAM2Off     (0UL)                                   
+#define POWER_RAMON_OFFRAM2_RAM2On      (1UL)                                  
+/* The field POWER.RAMON.ONRAM3 was eliminated. Added into deprecated in case somebody was using the macros defined for it. */
+#define POWER_RAMON_ONRAM3_Pos          (3UL)                                  
+#define POWER_RAMON_ONRAM3_Msk          (0x1UL << POWER_RAMON_ONRAM3_Pos)      
+#define POWER_RAMON_ONRAM3_RAM3Off      (0UL)                                  
+#define POWER_RAMON_ONRAM3_RAM3On       (1UL)                                  
+/* The field POWER.RAMON.ONRAM2 was eliminated. Added into deprecated in case somebody was using the macros defined for it. */
+#define POWER_RAMON_ONRAM2_Pos          (2UL)                                  
+#define POWER_RAMON_ONRAM2_Msk          (0x1UL << POWER_RAMON_ONRAM2_Pos)       
+#define POWER_RAMON_ONRAM2_RAM2Off      (0UL)                                  
+#define POWER_RAMON_ONRAM2_RAM2On       (1UL)                                 
+
+ 
+/* RADIO */
+/* The enumerated value RADIO.TXPOWER.TXPOWER.Neg40dBm was renamed. Added into deprecated with the new macro name. */
+#define RADIO_TXPOWER_TXPOWER_Neg40dBm  RADIO_TXPOWER_TXPOWER_Neg30dBm      
+/* The name of the field SKIPADDR was corrected. Old macros added for compatibility. */
+#define RADIO_CRCCNF_SKIP_ADDR_Pos      RADIO_CRCCNF_SKIPADDR_Pos 
+#define RADIO_CRCCNF_SKIP_ADDR_Msk      RADIO_CRCCNF_SKIPADDR_Msk 
+#define RADIO_CRCCNF_SKIP_ADDR_Include  RADIO_CRCCNF_SKIPADDR_Include 
+#define RADIO_CRCCNF_SKIP_ADDR_Skip     RADIO_CRCCNF_SKIPADDR_Skip 
+/* The name of the field PLLLOCK was corrected. Old macros added for compatibility. */
+#define RADIO_TEST_PLL_LOCK_Pos         RADIO_TEST_PLLLOCK_Pos 
+#define RADIO_TEST_PLL_LOCK_Msk         RADIO_TEST_PLLLOCK_Msk 
+#define RADIO_TEST_PLL_LOCK_Disabled    RADIO_TEST_PLLLOCK_Disabled 
+#define RADIO_TEST_PLL_LOCK_Enabled     RADIO_TEST_PLLLOCK_Enabled 
+/* The name of the field CONSTCARRIER was corrected. Old macros added for compatibility. */
+#define RADIO_TEST_CONST_CARRIER_Pos        RADIO_TEST_CONSTCARRIER_Pos 
+#define RADIO_TEST_CONST_CARRIER_Msk        RADIO_TEST_CONSTCARRIER_Msk 
+#define RADIO_TEST_CONST_CARRIER_Disabled   RADIO_TEST_CONSTCARRIER_Disabled 
+#define RADIO_TEST_CONST_CARRIER_Enabled    RADIO_TEST_CONSTCARRIER_Enabled 
+
+
+/* FICR */
+/* The registers FICR.SIZERAMBLOCK0, FICR.SIZERAMBLOCK1, FICR.SIZERAMBLOCK2 and FICR.SIZERAMBLOCK3 were renamed into an array. */
+#define SIZERAMBLOCK0   SIZERAMBLOCKS                   
+#define SIZERAMBLOCK1   SIZERAMBLOCKS                   
+#define SIZERAMBLOCK2   SIZERAMBLOCK[2]                 /*!< Note that this macro will disapear when SIZERAMBLOCK array is eliminated. SIZERAMBLOCK is a deprecated array. */
+#define SIZERAMBLOCK3   SIZERAMBLOCK[3]                 /*!< Note that this macro will disapear when SIZERAMBLOCK array is eliminated. SIZERAMBLOCK is a deprecated array. */
+/* The registers FICR.DEVICEID0 and FICR.DEVICEID1 were renamed into an array. */
+#define DEVICEID0       DEVICEID[0]                     
+#define DEVICEID1       DEVICEID[1]                     
+/* The registers FICR.ER0, FICR.ER1, FICR.ER2 and FICR.ER3 were renamed into an array. */
+#define ER0             ER[0]                           
+#define ER1             ER[1]                          
+#define ER2             ER[2]                       
+#define ER3             ER[3]                      
+/* The registers FICR.IR0, FICR.IR1, FICR.IR2 and FICR.IR3 were renamed into an array. */
+#define IR0             IR[0]                         
+#define IR1             IR[1]                         
+#define IR2             IR[2]                         
+#define IR3             IR[3]                          
+/* The registers FICR.DEVICEADDR0 and FICR.DEVICEADDR1 were renamed into an array. */
+#define DEVICEADDR0     DEVICEADDR[0]                  
+#define DEVICEADDR1     DEVICEADDR[1]                  
+
+
+/* PPI */
+/* The tasks PPI.TASKS_CHGxEN and PPI.TASKS_CHGxDIS were renamed into an array of structs. */
+#define TASKS_CHG0EN     TASKS_CHG[0].EN                    
+#define TASKS_CHG0DIS    TASKS_CHG[0].DIS                  
+#define TASKS_CHG1EN     TASKS_CHG[1].EN                    
+#define TASKS_CHG1DIS    TASKS_CHG[1].DIS                  
+#define TASKS_CHG2EN     TASKS_CHG[2].EN                   
+#define TASKS_CHG2DIS    TASKS_CHG[2].DIS                  
+#define TASKS_CHG3EN     TASKS_CHG[3].EN                    
+#define TASKS_CHG3DIS    TASKS_CHG[3].DIS                  
+/* The registers PPI.CHx_EEP and PPI.CHx_TEP were renamed into an array of structs. */
+#define CH0_EEP          CH[0].EEP                          
+#define CH0_TEP          CH[0].TEP                          
+#define CH1_EEP          CH[1].EEP                         
+#define CH1_TEP          CH[1].TEP                         
+#define CH2_EEP          CH[2].EEP                          
+#define CH2_TEP          CH[2].TEP                         
+#define CH3_EEP          CH[3].EEP                          
+#define CH3_TEP          CH[3].TEP                         
+#define CH4_EEP          CH[4].EEP                         
+#define CH4_TEP          CH[4].TEP                         
+#define CH5_EEP          CH[5].EEP                          
+#define CH5_TEP          CH[5].TEP                          
+#define CH6_EEP          CH[6].EEP                          
+#define CH6_TEP          CH[6].TEP                         
+#define CH7_EEP          CH[7].EEP                          
+#define CH7_TEP          CH[7].TEP                          
+#define CH8_EEP          CH[8].EEP                         
+#define CH8_TEP          CH[8].TEP                          
+#define CH9_EEP          CH[9].EEP                          
+#define CH9_TEP          CH[9].TEP                          
+#define CH10_EEP         CH[10].EEP                         
+#define CH10_TEP         CH[10].TEP                         
+#define CH11_EEP         CH[11].EEP                         
+#define CH11_TEP         CH[11].TEP                         
+#define CH12_EEP         CH[12].EEP                         
+#define CH12_TEP         CH[12].TEP                         
+#define CH13_EEP         CH[13].EEP                         
+#define CH13_TEP         CH[13].TEP                         
+#define CH14_EEP         CH[14].EEP                         
+#define CH14_TEP         CH[14].TEP                         
+#define CH15_EEP         CH[15].EEP                         
+#define CH15_TEP         CH[15].TEP                        
+/* The registers PPI.CHG0, PPI.CHG1, PPI.CHG2 and PPI.CHG3 were renamed into an array. */
+#define CHG0             CHG[0]                            
+#define CHG1             CHG[1]                            
+#define CHG2             CHG[2]                             
+#define CHG3             CHG[3]                           
+/* All bitfield macros for the CHGx registers therefore changed name. */
+#define PPI_CHG0_CH15_Pos       PPI_CHG_CH15_Pos            
+#define PPI_CHG0_CH15_Msk       PPI_CHG_CH15_Msk            
+#define PPI_CHG0_CH15_Excluded  PPI_CHG_CH15_Excluded       
+#define PPI_CHG0_CH15_Included  PPI_CHG_CH15_Included       
+#define PPI_CHG0_CH14_Pos       PPI_CHG_CH14_Pos            
+#define PPI_CHG0_CH14_Msk       PPI_CHG_CH14_Msk           
+#define PPI_CHG0_CH14_Excluded  PPI_CHG_CH14_Excluded       
+#define PPI_CHG0_CH14_Included  PPI_CHG_CH14_Included       
+#define PPI_CHG0_CH13_Pos       PPI_CHG_CH13_Pos            
+#define PPI_CHG0_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG0_CH13_Excluded  PPI_CHG_CH13_Excluded      
+#define PPI_CHG0_CH13_Included  PPI_CHG_CH13_Included       
+#define PPI_CHG0_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG0_CH12_Msk       PPI_CHG_CH12_Msk            
+#define PPI_CHG0_CH12_Excluded  PPI_CHG_CH12_Excluded       
+#define PPI_CHG0_CH12_Included  PPI_CHG_CH12_Included       
+#define PPI_CHG0_CH11_Pos       PPI_CHG_CH11_Pos            
+#define PPI_CHG0_CH11_Msk       PPI_CHG_CH11_Msk            
+#define PPI_CHG0_CH11_Excluded  PPI_CHG_CH11_Excluded       
+#define PPI_CHG0_CH11_Included  PPI_CHG_CH11_Included       
+#define PPI_CHG0_CH10_Pos       PPI_CHG_CH10_Pos            
+#define PPI_CHG0_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG0_CH10_Excluded  PPI_CHG_CH10_Excluded       
+#define PPI_CHG0_CH10_Included  PPI_CHG_CH10_Included       
+#define PPI_CHG0_CH9_Pos        PPI_CHG_CH9_Pos             
+#define PPI_CHG0_CH9_Msk        PPI_CHG_CH9_Msk             
+#define PPI_CHG0_CH9_Excluded   PPI_CHG_CH9_Excluded        
+#define PPI_CHG0_CH9_Included   PPI_CHG_CH9_Included        
+#define PPI_CHG0_CH8_Pos        PPI_CHG_CH8_Pos             
+#define PPI_CHG0_CH8_Msk        PPI_CHG_CH8_Msk             
+#define PPI_CHG0_CH8_Excluded   PPI_CHG_CH8_Excluded        
+#define PPI_CHG0_CH8_Included   PPI_CHG_CH8_Included        
+#define PPI_CHG0_CH7_Pos        PPI_CHG_CH7_Pos             
+#define PPI_CHG0_CH7_Msk        PPI_CHG_CH7_Msk             
+#define PPI_CHG0_CH7_Excluded   PPI_CHG_CH7_Excluded        
+#define PPI_CHG0_CH7_Included   PPI_CHG_CH7_Included        
+#define PPI_CHG0_CH6_Pos        PPI_CHG_CH6_Pos             
+#define PPI_CHG0_CH6_Msk        PPI_CHG_CH6_Msk             
+#define PPI_CHG0_CH6_Excluded   PPI_CHG_CH6_Excluded        
+#define PPI_CHG0_CH6_Included   PPI_CHG_CH6_Included        
+#define PPI_CHG0_CH5_Pos        PPI_CHG_CH5_Pos             
+#define PPI_CHG0_CH5_Msk        PPI_CHG_CH5_Msk             
+#define PPI_CHG0_CH5_Excluded   PPI_CHG_CH5_Excluded       
+#define PPI_CHG0_CH5_Included   PPI_CHG_CH5_Included        
+#define PPI_CHG0_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG0_CH4_Msk        PPI_CHG_CH4_Msk             
+#define PPI_CHG0_CH4_Excluded   PPI_CHG_CH4_Excluded       
+#define PPI_CHG0_CH4_Included   PPI_CHG_CH4_Included       
+#define PPI_CHG0_CH3_Pos        PPI_CHG_CH3_Pos             
+#define PPI_CHG0_CH3_Msk        PPI_CHG_CH3_Msk            
+#define PPI_CHG0_CH3_Excluded   PPI_CHG_CH3_Excluded        
+#define PPI_CHG0_CH3_Included   PPI_CHG_CH3_Included       
+#define PPI_CHG0_CH2_Pos        PPI_CHG_CH2_Pos            
+#define PPI_CHG0_CH2_Msk        PPI_CHG_CH2_Msk             
+#define PPI_CHG0_CH2_Excluded   PPI_CHG_CH2_Excluded       
+#define PPI_CHG0_CH2_Included   PPI_CHG_CH2_Included       
+#define PPI_CHG0_CH1_Pos        PPI_CHG_CH1_Pos            
+#define PPI_CHG0_CH1_Msk        PPI_CHG_CH1_Msk            
+#define PPI_CHG0_CH1_Excluded   PPI_CHG_CH1_Excluded        
+#define PPI_CHG0_CH1_Included   PPI_CHG_CH1_Included       
+#define PPI_CHG0_CH0_Pos        PPI_CHG_CH0_Pos            
+#define PPI_CHG0_CH0_Msk        PPI_CHG_CH0_Msk            
+#define PPI_CHG0_CH0_Excluded   PPI_CHG_CH0_Excluded        
+#define PPI_CHG0_CH0_Included   PPI_CHG_CH0_Included       
+#define PPI_CHG1_CH15_Pos       PPI_CHG_CH15_Pos           
+#define PPI_CHG1_CH15_Msk       PPI_CHG_CH15_Msk           
+#define PPI_CHG1_CH15_Excluded  PPI_CHG_CH15_Excluded       
+#define PPI_CHG1_CH15_Included  PPI_CHG_CH15_Included      
+#define PPI_CHG1_CH14_Pos       PPI_CHG_CH14_Pos           
+#define PPI_CHG1_CH14_Msk       PPI_CHG_CH14_Msk            
+#define PPI_CHG1_CH14_Excluded  PPI_CHG_CH14_Excluded      
+#define PPI_CHG1_CH14_Included  PPI_CHG_CH14_Included       
+#define PPI_CHG1_CH13_Pos       PPI_CHG_CH13_Pos           
+#define PPI_CHG1_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG1_CH13_Excluded  PPI_CHG_CH13_Excluded      
+#define PPI_CHG1_CH13_Included  PPI_CHG_CH13_Included      
+#define PPI_CHG1_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG1_CH12_Msk       PPI_CHG_CH12_Msk           
+#define PPI_CHG1_CH12_Excluded  PPI_CHG_CH12_Excluded      
+#define PPI_CHG1_CH12_Included  PPI_CHG_CH12_Included      
+#define PPI_CHG1_CH11_Pos       PPI_CHG_CH11_Pos            
+#define PPI_CHG1_CH11_Msk       PPI_CHG_CH11_Msk           
+#define PPI_CHG1_CH11_Excluded  PPI_CHG_CH11_Excluded      
+#define PPI_CHG1_CH11_Included  PPI_CHG_CH11_Included      
+#define PPI_CHG1_CH10_Pos       PPI_CHG_CH10_Pos           
+#define PPI_CHG1_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG1_CH10_Excluded  PPI_CHG_CH10_Excluded      
+#define PPI_CHG1_CH10_Included  PPI_CHG_CH10_Included      
+#define PPI_CHG1_CH9_Pos        PPI_CHG_CH9_Pos            
+#define PPI_CHG1_CH9_Msk        PPI_CHG_CH9_Msk            
+#define PPI_CHG1_CH9_Excluded   PPI_CHG_CH9_Excluded       
+#define PPI_CHG1_CH9_Included   PPI_CHG_CH9_Included       
+#define PPI_CHG1_CH8_Pos        PPI_CHG_CH8_Pos            
+#define PPI_CHG1_CH8_Msk        PPI_CHG_CH8_Msk            
+#define PPI_CHG1_CH8_Excluded   PPI_CHG_CH8_Excluded       
+#define PPI_CHG1_CH8_Included   PPI_CHG_CH8_Included       
+#define PPI_CHG1_CH7_Pos        PPI_CHG_CH7_Pos             
+#define PPI_CHG1_CH7_Msk        PPI_CHG_CH7_Msk            
+#define PPI_CHG1_CH7_Excluded   PPI_CHG_CH7_Excluded        
+#define PPI_CHG1_CH7_Included   PPI_CHG_CH7_Included       
+#define PPI_CHG1_CH6_Pos        PPI_CHG_CH6_Pos             
+#define PPI_CHG1_CH6_Msk        PPI_CHG_CH6_Msk            
+#define PPI_CHG1_CH6_Excluded   PPI_CHG_CH6_Excluded       
+#define PPI_CHG1_CH6_Included   PPI_CHG_CH6_Included       
+#define PPI_CHG1_CH5_Pos        PPI_CHG_CH5_Pos             
+#define PPI_CHG1_CH5_Msk        PPI_CHG_CH5_Msk             
+#define PPI_CHG1_CH5_Excluded   PPI_CHG_CH5_Excluded       
+#define PPI_CHG1_CH5_Included   PPI_CHG_CH5_Included        
+#define PPI_CHG1_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG1_CH4_Msk        PPI_CHG_CH4_Msk             
+#define PPI_CHG1_CH4_Excluded   PPI_CHG_CH4_Excluded        
+#define PPI_CHG1_CH4_Included   PPI_CHG_CH4_Included        
+#define PPI_CHG1_CH3_Pos        PPI_CHG_CH3_Pos            
+#define PPI_CHG1_CH3_Msk        PPI_CHG_CH3_Msk             
+#define PPI_CHG1_CH3_Excluded   PPI_CHG_CH3_Excluded        
+#define PPI_CHG1_CH3_Included   PPI_CHG_CH3_Included       
+#define PPI_CHG1_CH2_Pos        PPI_CHG_CH2_Pos            
+#define PPI_CHG1_CH2_Msk        PPI_CHG_CH2_Msk             
+#define PPI_CHG1_CH2_Excluded   PPI_CHG_CH2_Excluded        
+#define PPI_CHG1_CH2_Included   PPI_CHG_CH2_Included        
+#define PPI_CHG1_CH1_Pos        PPI_CHG_CH1_Pos             
+#define PPI_CHG1_CH1_Msk        PPI_CHG_CH1_Msk            
+#define PPI_CHG1_CH1_Excluded   PPI_CHG_CH1_Excluded        
+#define PPI_CHG1_CH1_Included   PPI_CHG_CH1_Included       
+#define PPI_CHG1_CH0_Pos        PPI_CHG_CH0_Pos             
+#define PPI_CHG1_CH0_Msk        PPI_CHG_CH0_Msk            
+#define PPI_CHG1_CH0_Excluded   PPI_CHG_CH0_Excluded       
+#define PPI_CHG1_CH0_Included   PPI_CHG_CH0_Included       
+#define PPI_CHG2_CH15_Pos       PPI_CHG_CH15_Pos           
+#define PPI_CHG2_CH15_Msk       PPI_CHG_CH15_Msk            
+#define PPI_CHG2_CH15_Excluded  PPI_CHG_CH15_Excluded      
+#define PPI_CHG2_CH15_Included  PPI_CHG_CH15_Included      
+#define PPI_CHG2_CH14_Pos       PPI_CHG_CH14_Pos           
+#define PPI_CHG2_CH14_Msk       PPI_CHG_CH14_Msk           
+#define PPI_CHG2_CH14_Excluded  PPI_CHG_CH14_Excluded       
+#define PPI_CHG2_CH14_Included  PPI_CHG_CH14_Included      
+#define PPI_CHG2_CH13_Pos       PPI_CHG_CH13_Pos           
+#define PPI_CHG2_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG2_CH13_Excluded  PPI_CHG_CH13_Excluded       
+#define PPI_CHG2_CH13_Included  PPI_CHG_CH13_Included      
+#define PPI_CHG2_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG2_CH12_Msk       PPI_CHG_CH12_Msk            
+#define PPI_CHG2_CH12_Excluded  PPI_CHG_CH12_Excluded      
+#define PPI_CHG2_CH12_Included  PPI_CHG_CH12_Included       
+#define PPI_CHG2_CH11_Pos       PPI_CHG_CH11_Pos           
+#define PPI_CHG2_CH11_Msk       PPI_CHG_CH11_Msk           
+#define PPI_CHG2_CH11_Excluded  PPI_CHG_CH11_Excluded       
+#define PPI_CHG2_CH11_Included  PPI_CHG_CH11_Included       
+#define PPI_CHG2_CH10_Pos       PPI_CHG_CH10_Pos            
+#define PPI_CHG2_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG2_CH10_Excluded  PPI_CHG_CH10_Excluded      
+#define PPI_CHG2_CH10_Included  PPI_CHG_CH10_Included      
+#define PPI_CHG2_CH9_Pos        PPI_CHG_CH9_Pos            
+#define PPI_CHG2_CH9_Msk        PPI_CHG_CH9_Msk            
+#define PPI_CHG2_CH9_Excluded   PPI_CHG_CH9_Excluded        
+#define PPI_CHG2_CH9_Included   PPI_CHG_CH9_Included       
+#define PPI_CHG2_CH8_Pos        PPI_CHG_CH8_Pos            
+#define PPI_CHG2_CH8_Msk        PPI_CHG_CH8_Msk            
+#define PPI_CHG2_CH8_Excluded   PPI_CHG_CH8_Excluded       
+#define PPI_CHG2_CH8_Included   PPI_CHG_CH8_Included        
+#define PPI_CHG2_CH7_Pos        PPI_CHG_CH7_Pos            
+#define PPI_CHG2_CH7_Msk        PPI_CHG_CH7_Msk            
+#define PPI_CHG2_CH7_Excluded   PPI_CHG_CH7_Excluded       
+#define PPI_CHG2_CH7_Included   PPI_CHG_CH7_Included       
+#define PPI_CHG2_CH6_Pos        PPI_CHG_CH6_Pos            
+#define PPI_CHG2_CH6_Msk        PPI_CHG_CH6_Msk            
+#define PPI_CHG2_CH6_Excluded   PPI_CHG_CH6_Excluded       
+#define PPI_CHG2_CH6_Included   PPI_CHG_CH6_Included       
+#define PPI_CHG2_CH5_Pos        PPI_CHG_CH5_Pos            
+#define PPI_CHG2_CH5_Msk        PPI_CHG_CH5_Msk            
+#define PPI_CHG2_CH5_Excluded   PPI_CHG_CH5_Excluded       
+#define PPI_CHG2_CH5_Included   PPI_CHG_CH5_Included        
+#define PPI_CHG2_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG2_CH4_Msk        PPI_CHG_CH4_Msk             
+#define PPI_CHG2_CH4_Excluded   PPI_CHG_CH4_Excluded        
+#define PPI_CHG2_CH4_Included   PPI_CHG_CH4_Included       
+#define PPI_CHG2_CH3_Pos        PPI_CHG_CH3_Pos            
+#define PPI_CHG2_CH3_Msk        PPI_CHG_CH3_Msk            
+#define PPI_CHG2_CH3_Excluded   PPI_CHG_CH3_Excluded       
+#define PPI_CHG2_CH3_Included   PPI_CHG_CH3_Included       
+#define PPI_CHG2_CH2_Pos        PPI_CHG_CH2_Pos            
+#define PPI_CHG2_CH2_Msk        PPI_CHG_CH2_Msk           
+#define PPI_CHG2_CH2_Excluded   PPI_CHG_CH2_Excluded       
+#define PPI_CHG2_CH2_Included   PPI_CHG_CH2_Included       
+#define PPI_CHG2_CH1_Pos        PPI_CHG_CH1_Pos             
+#define PPI_CHG2_CH1_Msk        PPI_CHG_CH1_Msk             
+#define PPI_CHG2_CH1_Excluded   PPI_CHG_CH1_Excluded       
+#define PPI_CHG2_CH1_Included   PPI_CHG_CH1_Included       
+#define PPI_CHG2_CH0_Pos        PPI_CHG_CH0_Pos            
+#define PPI_CHG2_CH0_Msk        PPI_CHG_CH0_Msk            
+#define PPI_CHG2_CH0_Excluded   PPI_CHG_CH0_Excluded       
+#define PPI_CHG2_CH0_Included   PPI_CHG_CH0_Included        
+#define PPI_CHG3_CH15_Pos       PPI_CHG_CH15_Pos           
+#define PPI_CHG3_CH15_Msk       PPI_CHG_CH15_Msk           
+#define PPI_CHG3_CH15_Excluded  PPI_CHG_CH15_Excluded     
+#define PPI_CHG3_CH15_Included  PPI_CHG_CH15_Included      
+#define PPI_CHG3_CH14_Pos       PPI_CHG_CH14_Pos          
+#define PPI_CHG3_CH14_Msk       PPI_CHG_CH14_Msk           
+#define PPI_CHG3_CH14_Excluded  PPI_CHG_CH14_Excluded      
+#define PPI_CHG3_CH14_Included  PPI_CHG_CH14_Included       
+#define PPI_CHG3_CH13_Pos       PPI_CHG_CH13_Pos           
+#define PPI_CHG3_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG3_CH13_Excluded  PPI_CHG_CH13_Excluded      
+#define PPI_CHG3_CH13_Included  PPI_CHG_CH13_Included      
+#define PPI_CHG3_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG3_CH12_Msk       PPI_CHG_CH12_Msk            
+#define PPI_CHG3_CH12_Excluded  PPI_CHG_CH12_Excluded       
+#define PPI_CHG3_CH12_Included  PPI_CHG_CH12_Included       
+#define PPI_CHG3_CH11_Pos       PPI_CHG_CH11_Pos            
+#define PPI_CHG3_CH11_Msk       PPI_CHG_CH11_Msk            
+#define PPI_CHG3_CH11_Excluded  PPI_CHG_CH11_Excluded      
+#define PPI_CHG3_CH11_Included  PPI_CHG_CH11_Included       
+#define PPI_CHG3_CH10_Pos       PPI_CHG_CH10_Pos            
+#define PPI_CHG3_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG3_CH10_Excluded  PPI_CHG_CH10_Excluded      
+#define PPI_CHG3_CH10_Included  PPI_CHG_CH10_Included      
+#define PPI_CHG3_CH9_Pos        PPI_CHG_CH9_Pos            
+#define PPI_CHG3_CH9_Msk        PPI_CHG_CH9_Msk            
+#define PPI_CHG3_CH9_Excluded   PPI_CHG_CH9_Excluded       
+#define PPI_CHG3_CH9_Included   PPI_CHG_CH9_Included       
+#define PPI_CHG3_CH8_Pos        PPI_CHG_CH8_Pos            
+#define PPI_CHG3_CH8_Msk        PPI_CHG_CH8_Msk             
+#define PPI_CHG3_CH8_Excluded   PPI_CHG_CH8_Excluded       
+#define PPI_CHG3_CH8_Included   PPI_CHG_CH8_Included       
+#define PPI_CHG3_CH7_Pos        PPI_CHG_CH7_Pos             
+#define PPI_CHG3_CH7_Msk        PPI_CHG_CH7_Msk            
+#define PPI_CHG3_CH7_Excluded   PPI_CHG_CH7_Excluded        
+#define PPI_CHG3_CH7_Included   PPI_CHG_CH7_Included       
+#define PPI_CHG3_CH6_Pos        PPI_CHG_CH6_Pos             
+#define PPI_CHG3_CH6_Msk        PPI_CHG_CH6_Msk             
+#define PPI_CHG3_CH6_Excluded   PPI_CHG_CH6_Excluded       
+#define PPI_CHG3_CH6_Included   PPI_CHG_CH6_Included        
+#define PPI_CHG3_CH5_Pos        PPI_CHG_CH5_Pos             
+#define PPI_CHG3_CH5_Msk        PPI_CHG_CH5_Msk             
+#define PPI_CHG3_CH5_Excluded   PPI_CHG_CH5_Excluded        
+#define PPI_CHG3_CH5_Included   PPI_CHG_CH5_Included       
+#define PPI_CHG3_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG3_CH4_Msk        PPI_CHG_CH4_Msk            
+#define PPI_CHG3_CH4_Excluded   PPI_CHG_CH4_Excluded        
+#define PPI_CHG3_CH4_Included   PPI_CHG_CH4_Included        
+#define PPI_CHG3_CH3_Pos        PPI_CHG_CH3_Pos             
+#define PPI_CHG3_CH3_Msk        PPI_CHG_CH3_Msk            
+#define PPI_CHG3_CH3_Excluded   PPI_CHG_CH3_Excluded        
+#define PPI_CHG3_CH3_Included   PPI_CHG_CH3_Included        
+#define PPI_CHG3_CH2_Pos        PPI_CHG_CH2_Pos             
+#define PPI_CHG3_CH2_Msk        PPI_CHG_CH2_Msk             
+#define PPI_CHG3_CH2_Excluded   PPI_CHG_CH2_Excluded        
+#define PPI_CHG3_CH2_Included   PPI_CHG_CH2_Included       
+#define PPI_CHG3_CH1_Pos        PPI_CHG_CH1_Pos             
+#define PPI_CHG3_CH1_Msk        PPI_CHG_CH1_Msk             
+#define PPI_CHG3_CH1_Excluded   PPI_CHG_CH1_Excluded        
+#define PPI_CHG3_CH1_Included   PPI_CHG_CH1_Included        
+#define PPI_CHG3_CH0_Pos        PPI_CHG_CH0_Pos             
+#define PPI_CHG3_CH0_Msk        PPI_CHG_CH0_Msk             
+#define PPI_CHG3_CH0_Excluded   PPI_CHG_CH0_Excluded        
+#define PPI_CHG3_CH0_Included   PPI_CHG_CH0_Included        
+
+
+
+/*lint --flb "Leave library region" */
+
+#endif /* NRF51_DEPRECATED_H */
+

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf51_to_nrf52.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf51_to_nrf52.h
@@ -1,0 +1,935 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef NRF51_TO_NRF52_H
+#define NRF51_TO_NRF52_H
+
+/*lint ++flb "Enter library region */
+
+/* This file is given to prevent your SW from not compiling with the name changes between nRF51 and nRF52 devices. 
+ * It redefines the old nRF51 names into the new ones as long as the functionality is still supported. If the 
+ * functionality is gone, there old names are not define, so compilation will fail. Note that also includes macros 
+ * from the nrf51_deprecated.h file. */
+
+ 
+/* IRQ */
+/* Several peripherals have been added to several indexes. Names of IRQ handlers and IRQ numbers have changed. */
+#define UART0_IRQHandler        UARTE0_UART0_IRQHandler
+#define SPI0_TWI0_IRQHandler    SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler
+#define SPI1_TWI1_IRQHandler    SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler
+#define ADC_IRQHandler          SAADC_IRQHandler
+#define LPCOMP_IRQHandler       COMP_LPCOMP_IRQHandler
+#define SWI0_IRQHandler         SWI0_EGU0_IRQHandler
+#define SWI1_IRQHandler         SWI1_EGU1_IRQHandler
+#define SWI2_IRQHandler         SWI2_EGU2_IRQHandler
+#define SWI3_IRQHandler         SWI3_EGU3_IRQHandler
+#define SWI4_IRQHandler         SWI4_EGU4_IRQHandler
+#define SWI5_IRQHandler         SWI5_EGU5_IRQHandler
+
+#define UART0_IRQn              UARTE0_UART0_IRQn
+#define SPI0_TWI0_IRQn          SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn
+#define SPI1_TWI1_IRQn          SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn
+#define ADC_IRQn                SAADC_IRQn
+#define LPCOMP_IRQn             COMP_LPCOMP_IRQn
+#define SWI0_IRQn               SWI0_EGU0_IRQn
+#define SWI1_IRQn               SWI1_EGU1_IRQn
+#define SWI2_IRQn               SWI2_EGU2_IRQn
+#define SWI3_IRQn               SWI3_EGU3_IRQn
+#define SWI4_IRQn               SWI4_EGU4_IRQn
+#define SWI5_IRQn               SWI5_EGU5_IRQn
+
+
+/* UICR */
+/* Register RBPCONF was renamed to APPROTECT. */
+#define RBPCONF     APPROTECT
+
+#define UICR_RBPCONF_PALL_Pos           UICR_APPROTECT_PALL_Pos
+#define UICR_RBPCONF_PALL_Msk           UICR_APPROTECT_PALL_Msk
+#define UICR_RBPCONF_PALL_Enabled       UICR_APPROTECT_PALL_Enabled
+#define UICR_RBPCONF_PALL_Disabled      UICR_APPROTECT_PALL_Disabled
+
+
+/* GPIO */
+/* GPIO port was renamed to P0. */
+#define NRF_GPIO        NRF_P0
+#define NRF_GPIO_BASE   NRF_P0_BASE
+
+
+/* SPIS */
+/* The registers PSELSCK, PSELMISO, PSELMOSI, PSELCSN were restructured into a struct. */
+#define PSELSCK       PSEL.SCK
+#define PSELMISO      PSEL.MISO
+#define PSELMOSI      PSEL.MOSI
+#define PSELCSN       PSEL.CSN
+
+/* The registers RXDPTR, MAXRX, AMOUNTRX were restructured into a struct */
+#define RXDPTR        RXD.PTR
+#define MAXRX         RXD.MAXCNT
+#define AMOUNTRX      RXD.AMOUNT
+
+#define SPIS_MAXRX_MAXRX_Pos        SPIS_RXD_MAXCNT_MAXCNT_Pos
+#define SPIS_MAXRX_MAXRX_Msk        SPIS_RXD_MAXCNT_MAXCNT_Msk
+
+#define SPIS_AMOUNTRX_AMOUNTRX_Pos  SPIS_RXD_AMOUNT_AMOUNT_Pos
+#define SPIS_AMOUNTRX_AMOUNTRX_Msk  SPIS_RXD_AMOUNT_AMOUNT_Msk
+
+/* The registers TXDPTR, MAXTX, AMOUNTTX were restructured into a struct */
+#define TXDPTR        TXD.PTR
+#define MAXTX         TXD.MAXCNT
+#define AMOUNTTX      TXD.AMOUNT
+
+#define SPIS_MAXTX_MAXTX_Pos        SPIS_TXD_MAXCNT_MAXCNT_Pos
+#define SPIS_MAXTX_MAXTX_Msk        SPIS_TXD_MAXCNT_MAXCNT_Msk
+
+#define SPIS_AMOUNTTX_AMOUNTTX_Pos  SPIS_TXD_AMOUNT_AMOUNT_Pos
+#define SPIS_AMOUNTTX_AMOUNTTX_Msk  SPIS_TXD_AMOUNT_AMOUNT_Msk
+
+
+/* MPU */
+/* Part of MPU module was renamed BPROT, while the rest was eliminated. */
+#define NRF_MPU     NRF_BPROT
+
+/* Register DISABLEINDEBUG macros were affected. */
+#define MPU_DISABLEINDEBUG_DISABLEINDEBUG_Pos       BPROT_DISABLEINDEBUG_DISABLEINDEBUG_Pos
+#define MPU_DISABLEINDEBUG_DISABLEINDEBUG_Msk       BPROT_DISABLEINDEBUG_DISABLEINDEBUG_Msk
+#define MPU_DISABLEINDEBUG_DISABLEINDEBUG_Enabled   BPROT_DISABLEINDEBUG_DISABLEINDEBUG_Enabled
+#define MPU_DISABLEINDEBUG_DISABLEINDEBUG_Disabled  BPROT_DISABLEINDEBUG_DISABLEINDEBUG_Disabled
+
+/* Registers PROTENSET0 and PROTENSET1 were affected and renamed as CONFIG0 and CONFIG1. */
+#define PROTENSET0  CONFIG0
+#define PROTENSET1  CONFIG1
+
+#define MPU_PROTENSET1_PROTREG63_Pos        BPROT_CONFIG1_REGION63_Pos
+#define MPU_PROTENSET1_PROTREG63_Msk        BPROT_CONFIG1_REGION63_Msk
+#define MPU_PROTENSET1_PROTREG63_Disabled   BPROT_CONFIG1_REGION63_Disabled
+#define MPU_PROTENSET1_PROTREG63_Enabled    BPROT_CONFIG1_REGION63_Enabled
+#define MPU_PROTENSET1_PROTREG63_Set        BPROT_CONFIG1_REGION63_Enabled
+
+#define MPU_PROTENSET1_PROTREG62_Pos        BPROT_CONFIG1_REGION62_Pos
+#define MPU_PROTENSET1_PROTREG62_Msk        BPROT_CONFIG1_REGION62_Msk
+#define MPU_PROTENSET1_PROTREG62_Disabled   BPROT_CONFIG1_REGION62_Disabled
+#define MPU_PROTENSET1_PROTREG62_Enabled    BPROT_CONFIG1_REGION62_Enabled
+#define MPU_PROTENSET1_PROTREG62_Set        BPROT_CONFIG1_REGION62_Enabled
+
+#define MPU_PROTENSET1_PROTREG61_Pos        BPROT_CONFIG1_REGION61_Pos
+#define MPU_PROTENSET1_PROTREG61_Msk        BPROT_CONFIG1_REGION61_Msk
+#define MPU_PROTENSET1_PROTREG61_Disabled   BPROT_CONFIG1_REGION61_Disabled
+#define MPU_PROTENSET1_PROTREG61_Enabled    BPROT_CONFIG1_REGION61_Enabled
+#define MPU_PROTENSET1_PROTREG61_Set        BPROT_CONFIG1_REGION61_Enabled
+
+#define MPU_PROTENSET1_PROTREG60_Pos        BPROT_CONFIG1_REGION60_Pos
+#define MPU_PROTENSET1_PROTREG60_Msk        BPROT_CONFIG1_REGION60_Msk
+#define MPU_PROTENSET1_PROTREG60_Disabled   BPROT_CONFIG1_REGION60_Disabled
+#define MPU_PROTENSET1_PROTREG60_Enabled    BPROT_CONFIG1_REGION60_Enabled
+#define MPU_PROTENSET1_PROTREG60_Set        BPROT_CONFIG1_REGION60_Enabled
+
+#define MPU_PROTENSET1_PROTREG59_Pos        BPROT_CONFIG1_REGION59_Pos
+#define MPU_PROTENSET1_PROTREG59_Msk        BPROT_CONFIG1_REGION59_Msk
+#define MPU_PROTENSET1_PROTREG59_Disabled   BPROT_CONFIG1_REGION59_Disabled
+#define MPU_PROTENSET1_PROTREG59_Enabled    BPROT_CONFIG1_REGION59_Enabled
+#define MPU_PROTENSET1_PROTREG59_Set        BPROT_CONFIG1_REGION59_Enabled
+
+#define MPU_PROTENSET1_PROTREG58_Pos        BPROT_CONFIG1_REGION58_Pos
+#define MPU_PROTENSET1_PROTREG58_Msk        BPROT_CONFIG1_REGION58_Msk
+#define MPU_PROTENSET1_PROTREG58_Disabled   BPROT_CONFIG1_REGION58_Disabled
+#define MPU_PROTENSET1_PROTREG58_Enabled    BPROT_CONFIG1_REGION58_Enabled
+#define MPU_PROTENSET1_PROTREG58_Set        BPROT_CONFIG1_REGION58_Enabled
+
+#define MPU_PROTENSET1_PROTREG57_Pos        BPROT_CONFIG1_REGION57_Pos
+#define MPU_PROTENSET1_PROTREG57_Msk        BPROT_CONFIG1_REGION57_Msk
+#define MPU_PROTENSET1_PROTREG57_Disabled   BPROT_CONFIG1_REGION57_Disabled
+#define MPU_PROTENSET1_PROTREG57_Enabled    BPROT_CONFIG1_REGION57_Enabled
+#define MPU_PROTENSET1_PROTREG57_Set        BPROT_CONFIG1_REGION57_Enabled
+
+#define MPU_PROTENSET1_PROTREG56_Pos        BPROT_CONFIG1_REGION56_Pos
+#define MPU_PROTENSET1_PROTREG56_Msk        BPROT_CONFIG1_REGION56_Msk
+#define MPU_PROTENSET1_PROTREG56_Disabled   BPROT_CONFIG1_REGION56_Disabled
+#define MPU_PROTENSET1_PROTREG56_Enabled    BPROT_CONFIG1_REGION56_Enabled
+#define MPU_PROTENSET1_PROTREG56_Set        BPROT_CONFIG1_REGION56_Enabled
+
+#define MPU_PROTENSET1_PROTREG55_Pos        BPROT_CONFIG1_REGION55_Pos
+#define MPU_PROTENSET1_PROTREG55_Msk        BPROT_CONFIG1_REGION55_Msk
+#define MPU_PROTENSET1_PROTREG55_Disabled   BPROT_CONFIG1_REGION55_Disabled
+#define MPU_PROTENSET1_PROTREG55_Enabled    BPROT_CONFIG1_REGION55_Enabled
+#define MPU_PROTENSET1_PROTREG55_Set        BPROT_CONFIG1_REGION55_Enabled
+
+#define MPU_PROTENSET1_PROTREG54_Pos        BPROT_CONFIG1_REGION54_Pos
+#define MPU_PROTENSET1_PROTREG54_Msk        BPROT_CONFIG1_REGION54_Msk
+#define MPU_PROTENSET1_PROTREG54_Disabled   BPROT_CONFIG1_REGION54_Disabled
+#define MPU_PROTENSET1_PROTREG54_Enabled    BPROT_CONFIG1_REGION54_Enabled
+#define MPU_PROTENSET1_PROTREG54_Set        BPROT_CONFIG1_REGION54_Enabled
+
+#define MPU_PROTENSET1_PROTREG53_Pos        BPROT_CONFIG1_REGION53_Pos
+#define MPU_PROTENSET1_PROTREG53_Msk        BPROT_CONFIG1_REGION53_Msk
+#define MPU_PROTENSET1_PROTREG53_Disabled   BPROT_CONFIG1_REGION53_Disabled
+#define MPU_PROTENSET1_PROTREG53_Enabled    BPROT_CONFIG1_REGION53_Enabled
+#define MPU_PROTENSET1_PROTREG53_Set        BPROT_CONFIG1_REGION53_Enabled
+
+#define MPU_PROTENSET1_PROTREG52_Pos        BPROT_CONFIG1_REGION52_Pos
+#define MPU_PROTENSET1_PROTREG52_Msk        BPROT_CONFIG1_REGION52_Msk
+#define MPU_PROTENSET1_PROTREG52_Disabled   BPROT_CONFIG1_REGION52_Disabled
+#define MPU_PROTENSET1_PROTREG52_Enabled    BPROT_CONFIG1_REGION52_Enabled
+#define MPU_PROTENSET1_PROTREG52_Set        BPROT_CONFIG1_REGION52_Enabled
+
+#define MPU_PROTENSET1_PROTREG51_Pos        BPROT_CONFIG1_REGION51_Pos
+#define MPU_PROTENSET1_PROTREG51_Msk        BPROT_CONFIG1_REGION51_Msk
+#define MPU_PROTENSET1_PROTREG51_Disabled   BPROT_CONFIG1_REGION51_Disabled
+#define MPU_PROTENSET1_PROTREG51_Enabled    BPROT_CONFIG1_REGION51_Enabled
+#define MPU_PROTENSET1_PROTREG51_Set        BPROT_CONFIG1_REGION51_Enabled
+
+#define MPU_PROTENSET1_PROTREG50_Pos        BPROT_CONFIG1_REGION50_Pos
+#define MPU_PROTENSET1_PROTREG50_Msk        BPROT_CONFIG1_REGION50_Msk
+#define MPU_PROTENSET1_PROTREG50_Disabled   BPROT_CONFIG1_REGION50_Disabled
+#define MPU_PROTENSET1_PROTREG50_Enabled    BPROT_CONFIG1_REGION50_Enabled
+#define MPU_PROTENSET1_PROTREG50_Set        BPROT_CONFIG1_REGION50_Enabled
+
+#define MPU_PROTENSET1_PROTREG49_Pos        BPROT_CONFIG1_REGION49_Pos
+#define MPU_PROTENSET1_PROTREG49_Msk        BPROT_CONFIG1_REGION49_Msk
+#define MPU_PROTENSET1_PROTREG49_Disabled   BPROT_CONFIG1_REGION49_Disabled
+#define MPU_PROTENSET1_PROTREG49_Enabled    BPROT_CONFIG1_REGION49_Enabled
+#define MPU_PROTENSET1_PROTREG49_Set        BPROT_CONFIG1_REGION49_Enabled
+
+#define MPU_PROTENSET1_PROTREG48_Pos        BPROT_CONFIG1_REGION48_Pos
+#define MPU_PROTENSET1_PROTREG48_Msk        BPROT_CONFIG1_REGION48_Msk
+#define MPU_PROTENSET1_PROTREG48_Disabled   BPROT_CONFIG1_REGION48_Disabled
+#define MPU_PROTENSET1_PROTREG48_Enabled    BPROT_CONFIG1_REGION48_Enabled
+#define MPU_PROTENSET1_PROTREG48_Set        BPROT_CONFIG1_REGION48_Enabled
+
+#define MPU_PROTENSET1_PROTREG47_Pos        BPROT_CONFIG1_REGION47_Pos
+#define MPU_PROTENSET1_PROTREG47_Msk        BPROT_CONFIG1_REGION47_Msk
+#define MPU_PROTENSET1_PROTREG47_Disabled   BPROT_CONFIG1_REGION47_Disabled
+#define MPU_PROTENSET1_PROTREG47_Enabled    BPROT_CONFIG1_REGION47_Enabled
+#define MPU_PROTENSET1_PROTREG47_Set        BPROT_CONFIG1_REGION47_Enabled
+
+#define MPU_PROTENSET1_PROTREG46_Pos        BPROT_CONFIG1_REGION46_Pos
+#define MPU_PROTENSET1_PROTREG46_Msk        BPROT_CONFIG1_REGION46_Msk
+#define MPU_PROTENSET1_PROTREG46_Disabled   BPROT_CONFIG1_REGION46_Disabled
+#define MPU_PROTENSET1_PROTREG46_Enabled    BPROT_CONFIG1_REGION46_Enabled
+#define MPU_PROTENSET1_PROTREG46_Set        BPROT_CONFIG1_REGION46_Enabled
+
+#define MPU_PROTENSET1_PROTREG45_Pos        BPROT_CONFIG1_REGION45_Pos
+#define MPU_PROTENSET1_PROTREG45_Msk        BPROT_CONFIG1_REGION45_Msk
+#define MPU_PROTENSET1_PROTREG45_Disabled   BPROT_CONFIG1_REGION45_Disabled
+#define MPU_PROTENSET1_PROTREG45_Enabled    BPROT_CONFIG1_REGION45_Enabled
+#define MPU_PROTENSET1_PROTREG45_Set        BPROT_CONFIG1_REGION45_Enabled
+
+#define MPU_PROTENSET1_PROTREG44_Pos        BPROT_CONFIG1_REGION44_Pos
+#define MPU_PROTENSET1_PROTREG44_Msk        BPROT_CONFIG1_REGION44_Msk
+#define MPU_PROTENSET1_PROTREG44_Disabled   BPROT_CONFIG1_REGION44_Disabled
+#define MPU_PROTENSET1_PROTREG44_Enabled    BPROT_CONFIG1_REGION44_Enabled
+#define MPU_PROTENSET1_PROTREG44_Set        BPROT_CONFIG1_REGION44_Enabled
+
+#define MPU_PROTENSET1_PROTREG43_Pos        BPROT_CONFIG1_REGION43_Pos
+#define MPU_PROTENSET1_PROTREG43_Msk        BPROT_CONFIG1_REGION43_Msk
+#define MPU_PROTENSET1_PROTREG43_Disabled   BPROT_CONFIG1_REGION43_Disabled
+#define MPU_PROTENSET1_PROTREG43_Enabled    BPROT_CONFIG1_REGION43_Enabled
+#define MPU_PROTENSET1_PROTREG43_Set        BPROT_CONFIG1_REGION43_Enabled
+
+#define MPU_PROTENSET1_PROTREG42_Pos        BPROT_CONFIG1_REGION42_Pos
+#define MPU_PROTENSET1_PROTREG42_Msk        BPROT_CONFIG1_REGION42_Msk
+#define MPU_PROTENSET1_PROTREG42_Disabled   BPROT_CONFIG1_REGION42_Disabled
+#define MPU_PROTENSET1_PROTREG42_Enabled    BPROT_CONFIG1_REGION42_Enabled
+#define MPU_PROTENSET1_PROTREG42_Set        BPROT_CONFIG1_REGION42_Enabled
+
+#define MPU_PROTENSET1_PROTREG41_Pos        BPROT_CONFIG1_REGION41_Pos
+#define MPU_PROTENSET1_PROTREG41_Msk        BPROT_CONFIG1_REGION41_Msk
+#define MPU_PROTENSET1_PROTREG41_Disabled   BPROT_CONFIG1_REGION41_Disabled
+#define MPU_PROTENSET1_PROTREG41_Enabled    BPROT_CONFIG1_REGION41_Enabled
+#define MPU_PROTENSET1_PROTREG41_Set        BPROT_CONFIG1_REGION41_Enabled
+
+#define MPU_PROTENSET1_PROTREG40_Pos        BPROT_CONFIG1_REGION40_Pos
+#define MPU_PROTENSET1_PROTREG40_Msk        BPROT_CONFIG1_REGION40_Msk
+#define MPU_PROTENSET1_PROTREG40_Disabled   BPROT_CONFIG1_REGION40_Disabled
+#define MPU_PROTENSET1_PROTREG40_Enabled    BPROT_CONFIG1_REGION40_Enabled
+#define MPU_PROTENSET1_PROTREG40_Set        BPROT_CONFIG1_REGION40_Enabled
+
+#define MPU_PROTENSET1_PROTREG39_Pos        BPROT_CONFIG1_REGION39_Pos
+#define MPU_PROTENSET1_PROTREG39_Msk        BPROT_CONFIG1_REGION39_Msk
+#define MPU_PROTENSET1_PROTREG39_Disabled   BPROT_CONFIG1_REGION39_Disabled
+#define MPU_PROTENSET1_PROTREG39_Enabled    BPROT_CONFIG1_REGION39_Enabled
+#define MPU_PROTENSET1_PROTREG39_Set        BPROT_CONFIG1_REGION39_Enabled
+
+#define MPU_PROTENSET1_PROTREG38_Pos        BPROT_CONFIG1_REGION38_Pos
+#define MPU_PROTENSET1_PROTREG38_Msk        BPROT_CONFIG1_REGION38_Msk
+#define MPU_PROTENSET1_PROTREG38_Disabled   BPROT_CONFIG1_REGION38_Disabled
+#define MPU_PROTENSET1_PROTREG38_Enabled    BPROT_CONFIG1_REGION38_Enabled
+#define MPU_PROTENSET1_PROTREG38_Set        BPROT_CONFIG1_REGION38_Enabled
+
+#define MPU_PROTENSET1_PROTREG37_Pos        BPROT_CONFIG1_REGION37_Pos
+#define MPU_PROTENSET1_PROTREG37_Msk        BPROT_CONFIG1_REGION37_Msk
+#define MPU_PROTENSET1_PROTREG37_Disabled   BPROT_CONFIG1_REGION37_Disabled
+#define MPU_PROTENSET1_PROTREG37_Enabled    BPROT_CONFIG1_REGION37_Enabled
+#define MPU_PROTENSET1_PROTREG37_Set        BPROT_CONFIG1_REGION37_Enabled
+
+#define MPU_PROTENSET1_PROTREG36_Pos        BPROT_CONFIG1_REGION36_Pos
+#define MPU_PROTENSET1_PROTREG36_Msk        BPROT_CONFIG1_REGION36_Msk
+#define MPU_PROTENSET1_PROTREG36_Disabled   BPROT_CONFIG1_REGION36_Disabled
+#define MPU_PROTENSET1_PROTREG36_Enabled    BPROT_CONFIG1_REGION36_Enabled
+#define MPU_PROTENSET1_PROTREG36_Set        BPROT_CONFIG1_REGION36_Enabled
+
+#define MPU_PROTENSET1_PROTREG35_Pos        BPROT_CONFIG1_REGION35_Pos
+#define MPU_PROTENSET1_PROTREG35_Msk        BPROT_CONFIG1_REGION35_Msk
+#define MPU_PROTENSET1_PROTREG35_Disabled   BPROT_CONFIG1_REGION35_Disabled
+#define MPU_PROTENSET1_PROTREG35_Enabled    BPROT_CONFIG1_REGION35_Enabled
+#define MPU_PROTENSET1_PROTREG35_Set        BPROT_CONFIG1_REGION35_Enabled
+
+#define MPU_PROTENSET1_PROTREG34_Pos        BPROT_CONFIG1_REGION34_Pos
+#define MPU_PROTENSET1_PROTREG34_Msk        BPROT_CONFIG1_REGION34_Msk
+#define MPU_PROTENSET1_PROTREG34_Disabled   BPROT_CONFIG1_REGION34_Disabled
+#define MPU_PROTENSET1_PROTREG34_Enabled    BPROT_CONFIG1_REGION34_Enabled
+#define MPU_PROTENSET1_PROTREG34_Set        BPROT_CONFIG1_REGION34_Enabled
+
+#define MPU_PROTENSET1_PROTREG33_Pos        BPROT_CONFIG1_REGION33_Pos
+#define MPU_PROTENSET1_PROTREG33_Msk        BPROT_CONFIG1_REGION33_Msk
+#define MPU_PROTENSET1_PROTREG33_Disabled   BPROT_CONFIG1_REGION33_Disabled
+#define MPU_PROTENSET1_PROTREG33_Enabled    BPROT_CONFIG1_REGION33_Enabled
+#define MPU_PROTENSET1_PROTREG33_Set        BPROT_CONFIG1_REGION33_Enabled
+
+#define MPU_PROTENSET1_PROTREG32_Pos        BPROT_CONFIG1_REGION32_Pos
+#define MPU_PROTENSET1_PROTREG32_Msk        BPROT_CONFIG1_REGION32_Msk
+#define MPU_PROTENSET1_PROTREG32_Disabled   BPROT_CONFIG1_REGION32_Disabled
+#define MPU_PROTENSET1_PROTREG32_Enabled    BPROT_CONFIG1_REGION32_Enabled
+#define MPU_PROTENSET1_PROTREG32_Set        BPROT_CONFIG1_REGION32_Enabled
+
+#define MPU_PROTENSET0_PROTREG31_Pos        BPROT_CONFIG0_REGION31_Pos
+#define MPU_PROTENSET0_PROTREG31_Msk        BPROT_CONFIG0_REGION31_Msk
+#define MPU_PROTENSET0_PROTREG31_Disabled   BPROT_CONFIG0_REGION31_Disabled
+#define MPU_PROTENSET0_PROTREG31_Enabled    BPROT_CONFIG0_REGION31_Enabled
+#define MPU_PROTENSET0_PROTREG31_Set        BPROT_CONFIG0_REGION31_Enabled
+
+#define MPU_PROTENSET0_PROTREG30_Pos        BPROT_CONFIG0_REGION30_Pos
+#define MPU_PROTENSET0_PROTREG30_Msk        BPROT_CONFIG0_REGION30_Msk
+#define MPU_PROTENSET0_PROTREG30_Disabled   BPROT_CONFIG0_REGION30_Disabled
+#define MPU_PROTENSET0_PROTREG30_Enabled    BPROT_CONFIG0_REGION30_Enabled
+#define MPU_PROTENSET0_PROTREG30_Set        BPROT_CONFIG0_REGION30_Enabled
+
+#define MPU_PROTENSET0_PROTREG29_Pos        BPROT_CONFIG0_REGION29_Pos
+#define MPU_PROTENSET0_PROTREG29_Msk        BPROT_CONFIG0_REGION29_Msk
+#define MPU_PROTENSET0_PROTREG29_Disabled   BPROT_CONFIG0_REGION29_Disabled
+#define MPU_PROTENSET0_PROTREG29_Enabled    BPROT_CONFIG0_REGION29_Enabled
+#define MPU_PROTENSET0_PROTREG29_Set        BPROT_CONFIG0_REGION29_Enabled
+
+#define MPU_PROTENSET0_PROTREG28_Pos        BPROT_CONFIG0_REGION28_Pos
+#define MPU_PROTENSET0_PROTREG28_Msk        BPROT_CONFIG0_REGION28_Msk
+#define MPU_PROTENSET0_PROTREG28_Disabled   BPROT_CONFIG0_REGION28_Disabled
+#define MPU_PROTENSET0_PROTREG28_Enabled    BPROT_CONFIG0_REGION28_Enabled
+#define MPU_PROTENSET0_PROTREG28_Set        BPROT_CONFIG0_REGION28_Enabled
+
+#define MPU_PROTENSET0_PROTREG27_Pos        BPROT_CONFIG0_REGION27_Pos
+#define MPU_PROTENSET0_PROTREG27_Msk        BPROT_CONFIG0_REGION27_Msk
+#define MPU_PROTENSET0_PROTREG27_Disabled   BPROT_CONFIG0_REGION27_Disabled
+#define MPU_PROTENSET0_PROTREG27_Enabled    BPROT_CONFIG0_REGION27_Enabled
+#define MPU_PROTENSET0_PROTREG27_Set        BPROT_CONFIG0_REGION27_Enabled
+
+#define MPU_PROTENSET0_PROTREG26_Pos        BPROT_CONFIG0_REGION26_Pos
+#define MPU_PROTENSET0_PROTREG26_Msk        BPROT_CONFIG0_REGION26_Msk
+#define MPU_PROTENSET0_PROTREG26_Disabled   BPROT_CONFIG0_REGION26_Disabled
+#define MPU_PROTENSET0_PROTREG26_Enabled    BPROT_CONFIG0_REGION26_Enabled
+#define MPU_PROTENSET0_PROTREG26_Set        BPROT_CONFIG0_REGION26_Enabled
+
+#define MPU_PROTENSET0_PROTREG25_Pos        BPROT_CONFIG0_REGION25_Pos
+#define MPU_PROTENSET0_PROTREG25_Msk        BPROT_CONFIG0_REGION25_Msk
+#define MPU_PROTENSET0_PROTREG25_Disabled   BPROT_CONFIG0_REGION25_Disabled
+#define MPU_PROTENSET0_PROTREG25_Enabled    BPROT_CONFIG0_REGION25_Enabled
+#define MPU_PROTENSET0_PROTREG25_Set        BPROT_CONFIG0_REGION25_Enabled
+
+#define MPU_PROTENSET0_PROTREG24_Pos        BPROT_CONFIG0_REGION24_Pos
+#define MPU_PROTENSET0_PROTREG24_Msk        BPROT_CONFIG0_REGION24_Msk
+#define MPU_PROTENSET0_PROTREG24_Disabled   BPROT_CONFIG0_REGION24_Disabled
+#define MPU_PROTENSET0_PROTREG24_Enabled    BPROT_CONFIG0_REGION24_Enabled
+#define MPU_PROTENSET0_PROTREG24_Set        BPROT_CONFIG0_REGION24_Enabled
+
+#define MPU_PROTENSET0_PROTREG23_Pos        BPROT_CONFIG0_REGION23_Pos
+#define MPU_PROTENSET0_PROTREG23_Msk        BPROT_CONFIG0_REGION23_Msk
+#define MPU_PROTENSET0_PROTREG23_Disabled   BPROT_CONFIG0_REGION23_Disabled
+#define MPU_PROTENSET0_PROTREG23_Enabled    BPROT_CONFIG0_REGION23_Enabled
+#define MPU_PROTENSET0_PROTREG23_Set        BPROT_CONFIG0_REGION23_Enabled
+
+#define MPU_PROTENSET0_PROTREG22_Pos        BPROT_CONFIG0_REGION22_Pos
+#define MPU_PROTENSET0_PROTREG22_Msk        BPROT_CONFIG0_REGION22_Msk
+#define MPU_PROTENSET0_PROTREG22_Disabled   BPROT_CONFIG0_REGION22_Disabled
+#define MPU_PROTENSET0_PROTREG22_Enabled    BPROT_CONFIG0_REGION22_Enabled
+#define MPU_PROTENSET0_PROTREG22_Set        BPROT_CONFIG0_REGION22_Enabled
+
+#define MPU_PROTENSET0_PROTREG21_Pos        BPROT_CONFIG0_REGION21_Pos
+#define MPU_PROTENSET0_PROTREG21_Msk        BPROT_CONFIG0_REGION21_Msk
+#define MPU_PROTENSET0_PROTREG21_Disabled   BPROT_CONFIG0_REGION21_Disabled
+#define MPU_PROTENSET0_PROTREG21_Enabled    BPROT_CONFIG0_REGION21_Enabled
+#define MPU_PROTENSET0_PROTREG21_Set        BPROT_CONFIG0_REGION21_Enabled
+
+#define MPU_PROTENSET0_PROTREG20_Pos        BPROT_CONFIG0_REGION20_Pos
+#define MPU_PROTENSET0_PROTREG20_Msk        BPROT_CONFIG0_REGION20_Msk
+#define MPU_PROTENSET0_PROTREG20_Disabled   BPROT_CONFIG0_REGION20_Disabled
+#define MPU_PROTENSET0_PROTREG20_Enabled    BPROT_CONFIG0_REGION20_Enabled
+#define MPU_PROTENSET0_PROTREG20_Set        BPROT_CONFIG0_REGION20_Enabled
+
+#define MPU_PROTENSET0_PROTREG19_Pos        BPROT_CONFIG0_REGION19_Pos
+#define MPU_PROTENSET0_PROTREG19_Msk        BPROT_CONFIG0_REGION19_Msk
+#define MPU_PROTENSET0_PROTREG19_Disabled   BPROT_CONFIG0_REGION19_Disabled
+#define MPU_PROTENSET0_PROTREG19_Enabled    BPROT_CONFIG0_REGION19_Enabled
+#define MPU_PROTENSET0_PROTREG19_Set        BPROT_CONFIG0_REGION19_Enabled
+
+#define MPU_PROTENSET0_PROTREG18_Pos        BPROT_CONFIG0_REGION18_Pos
+#define MPU_PROTENSET0_PROTREG18_Msk        BPROT_CONFIG0_REGION18_Msk
+#define MPU_PROTENSET0_PROTREG18_Disabled   BPROT_CONFIG0_REGION18_Disabled
+#define MPU_PROTENSET0_PROTREG18_Enabled    BPROT_CONFIG0_REGION18_Enabled
+#define MPU_PROTENSET0_PROTREG18_Set        BPROT_CONFIG0_REGION18_Enabled
+
+#define MPU_PROTENSET0_PROTREG17_Pos        BPROT_CONFIG0_REGION17_Pos
+#define MPU_PROTENSET0_PROTREG17_Msk        BPROT_CONFIG0_REGION17_Msk
+#define MPU_PROTENSET0_PROTREG17_Disabled   BPROT_CONFIG0_REGION17_Disabled
+#define MPU_PROTENSET0_PROTREG17_Enabled    BPROT_CONFIG0_REGION17_Enabled
+#define MPU_PROTENSET0_PROTREG17_Set        BPROT_CONFIG0_REGION17_Enabled
+
+#define MPU_PROTENSET0_PROTREG16_Pos        BPROT_CONFIG0_REGION16_Pos
+#define MPU_PROTENSET0_PROTREG16_Msk        BPROT_CONFIG0_REGION16_Msk
+#define MPU_PROTENSET0_PROTREG16_Disabled   BPROT_CONFIG0_REGION16_Disabled
+#define MPU_PROTENSET0_PROTREG16_Enabled    BPROT_CONFIG0_REGION16_Enabled
+#define MPU_PROTENSET0_PROTREG16_Set        BPROT_CONFIG0_REGION16_Enabled
+
+#define MPU_PROTENSET0_PROTREG15_Pos        BPROT_CONFIG0_REGION15_Pos
+#define MPU_PROTENSET0_PROTREG15_Msk        BPROT_CONFIG0_REGION15_Msk
+#define MPU_PROTENSET0_PROTREG15_Disabled   BPROT_CONFIG0_REGION15_Disabled
+#define MPU_PROTENSET0_PROTREG15_Enabled    BPROT_CONFIG0_REGION15_Enabled
+#define MPU_PROTENSET0_PROTREG15_Set        BPROT_CONFIG0_REGION15_Enabled
+
+#define MPU_PROTENSET0_PROTREG14_Pos        BPROT_CONFIG0_REGION14_Pos
+#define MPU_PROTENSET0_PROTREG14_Msk        BPROT_CONFIG0_REGION14_Msk
+#define MPU_PROTENSET0_PROTREG14_Disabled   BPROT_CONFIG0_REGION14_Disabled
+#define MPU_PROTENSET0_PROTREG14_Enabled    BPROT_CONFIG0_REGION14_Enabled
+#define MPU_PROTENSET0_PROTREG14_Set        BPROT_CONFIG0_REGION14_Enabled
+
+#define MPU_PROTENSET0_PROTREG13_Pos        BPROT_CONFIG0_REGION13_Pos
+#define MPU_PROTENSET0_PROTREG13_Msk        BPROT_CONFIG0_REGION13_Msk
+#define MPU_PROTENSET0_PROTREG13_Disabled   BPROT_CONFIG0_REGION13_Disabled
+#define MPU_PROTENSET0_PROTREG13_Enabled    BPROT_CONFIG0_REGION13_Enabled
+#define MPU_PROTENSET0_PROTREG13_Set        BPROT_CONFIG0_REGION13_Enabled
+
+#define MPU_PROTENSET0_PROTREG12_Pos        BPROT_CONFIG0_REGION12_Pos
+#define MPU_PROTENSET0_PROTREG12_Msk        BPROT_CONFIG0_REGION12_Msk
+#define MPU_PROTENSET0_PROTREG12_Disabled   BPROT_CONFIG0_REGION12_Disabled
+#define MPU_PROTENSET0_PROTREG12_Enabled    BPROT_CONFIG0_REGION12_Enabled
+#define MPU_PROTENSET0_PROTREG12_Set        BPROT_CONFIG0_REGION12_Enabled
+
+#define MPU_PROTENSET0_PROTREG11_Pos        BPROT_CONFIG0_REGION11_Pos
+#define MPU_PROTENSET0_PROTREG11_Msk        BPROT_CONFIG0_REGION11_Msk
+#define MPU_PROTENSET0_PROTREG11_Disabled   BPROT_CONFIG0_REGION11_Disabled
+#define MPU_PROTENSET0_PROTREG11_Enabled    BPROT_CONFIG0_REGION11_Enabled
+#define MPU_PROTENSET0_PROTREG11_Set        BPROT_CONFIG0_REGION11_Enabled
+
+#define MPU_PROTENSET0_PROTREG10_Pos        BPROT_CONFIG0_REGION10_Pos
+#define MPU_PROTENSET0_PROTREG10_Msk        BPROT_CONFIG0_REGION10_Msk
+#define MPU_PROTENSET0_PROTREG10_Disabled   BPROT_CONFIG0_REGION10_Disabled
+#define MPU_PROTENSET0_PROTREG10_Enabled    BPROT_CONFIG0_REGION10_Enabled
+#define MPU_PROTENSET0_PROTREG10_Set        BPROT_CONFIG0_REGION10_Enabled
+
+#define MPU_PROTENSET0_PROTREG9_Pos        BPROT_CONFIG0_REGION9_Pos
+#define MPU_PROTENSET0_PROTREG9_Msk        BPROT_CONFIG0_REGION9_Msk
+#define MPU_PROTENSET0_PROTREG9_Disabled   BPROT_CONFIG0_REGION9_Disabled
+#define MPU_PROTENSET0_PROTREG9_Enabled    BPROT_CONFIG0_REGION9_Enabled
+#define MPU_PROTENSET0_PROTREG9_Set        BPROT_CONFIG0_REGION9_Enabled
+
+#define MPU_PROTENSET0_PROTREG8_Pos        BPROT_CONFIG0_REGION8_Pos
+#define MPU_PROTENSET0_PROTREG8_Msk        BPROT_CONFIG0_REGION8_Msk
+#define MPU_PROTENSET0_PROTREG8_Disabled   BPROT_CONFIG0_REGION8_Disabled
+#define MPU_PROTENSET0_PROTREG8_Enabled    BPROT_CONFIG0_REGION8_Enabled
+#define MPU_PROTENSET0_PROTREG8_Set        BPROT_CONFIG0_REGION8_Enabled
+
+#define MPU_PROTENSET0_PROTREG7_Pos        BPROT_CONFIG0_REGION7_Pos
+#define MPU_PROTENSET0_PROTREG7_Msk        BPROT_CONFIG0_REGION7_Msk
+#define MPU_PROTENSET0_PROTREG7_Disabled   BPROT_CONFIG0_REGION7_Disabled
+#define MPU_PROTENSET0_PROTREG7_Enabled    BPROT_CONFIG0_REGION7_Enabled
+#define MPU_PROTENSET0_PROTREG7_Set        BPROT_CONFIG0_REGION7_Enabled
+
+#define MPU_PROTENSET0_PROTREG6_Pos        BPROT_CONFIG0_REGION6_Pos
+#define MPU_PROTENSET0_PROTREG6_Msk        BPROT_CONFIG0_REGION6_Msk
+#define MPU_PROTENSET0_PROTREG6_Disabled   BPROT_CONFIG0_REGION6_Disabled
+#define MPU_PROTENSET0_PROTREG6_Enabled    BPROT_CONFIG0_REGION6_Enabled
+#define MPU_PROTENSET0_PROTREG6_Set        BPROT_CONFIG0_REGION6_Enabled
+
+#define MPU_PROTENSET0_PROTREG5_Pos        BPROT_CONFIG0_REGION5_Pos
+#define MPU_PROTENSET0_PROTREG5_Msk        BPROT_CONFIG0_REGION5_Msk
+#define MPU_PROTENSET0_PROTREG5_Disabled   BPROT_CONFIG0_REGION5_Disabled
+#define MPU_PROTENSET0_PROTREG5_Enabled    BPROT_CONFIG0_REGION5_Enabled
+#define MPU_PROTENSET0_PROTREG5_Set        BPROT_CONFIG0_REGION5_Enabled
+
+#define MPU_PROTENSET0_PROTREG4_Pos        BPROT_CONFIG0_REGION4_Pos
+#define MPU_PROTENSET0_PROTREG4_Msk        BPROT_CONFIG0_REGION4_Msk
+#define MPU_PROTENSET0_PROTREG4_Disabled   BPROT_CONFIG0_REGION4_Disabled
+#define MPU_PROTENSET0_PROTREG4_Enabled    BPROT_CONFIG0_REGION4_Enabled
+#define MPU_PROTENSET0_PROTREG4_Set        BPROT_CONFIG0_REGION4_Enabled
+
+#define MPU_PROTENSET0_PROTREG3_Pos        BPROT_CONFIG0_REGION3_Pos
+#define MPU_PROTENSET0_PROTREG3_Msk        BPROT_CONFIG0_REGION3_Msk
+#define MPU_PROTENSET0_PROTREG3_Disabled   BPROT_CONFIG0_REGION3_Disabled
+#define MPU_PROTENSET0_PROTREG3_Enabled    BPROT_CONFIG0_REGION3_Enabled
+#define MPU_PROTENSET0_PROTREG3_Set        BPROT_CONFIG0_REGION3_Enabled
+
+#define MPU_PROTENSET0_PROTREG2_Pos        BPROT_CONFIG0_REGION2_Pos
+#define MPU_PROTENSET0_PROTREG2_Msk        BPROT_CONFIG0_REGION2_Msk
+#define MPU_PROTENSET0_PROTREG2_Disabled   BPROT_CONFIG0_REGION2_Disabled
+#define MPU_PROTENSET0_PROTREG2_Enabled    BPROT_CONFIG0_REGION2_Enabled
+#define MPU_PROTENSET0_PROTREG2_Set        BPROT_CONFIG0_REGION2_Enabled
+
+#define MPU_PROTENSET0_PROTREG1_Pos        BPROT_CONFIG0_REGION1_Pos
+#define MPU_PROTENSET0_PROTREG1_Msk        BPROT_CONFIG0_REGION1_Msk
+#define MPU_PROTENSET0_PROTREG1_Disabled   BPROT_CONFIG0_REGION1_Disabled
+#define MPU_PROTENSET0_PROTREG1_Enabled    BPROT_CONFIG0_REGION1_Enabled
+#define MPU_PROTENSET0_PROTREG1_Set        BPROT_CONFIG0_REGION1_Enabled
+
+#define MPU_PROTENSET0_PROTREG0_Pos        BPROT_CONFIG0_REGION0_Pos
+#define MPU_PROTENSET0_PROTREG0_Msk        BPROT_CONFIG0_REGION0_Msk
+#define MPU_PROTENSET0_PROTREG0_Disabled   BPROT_CONFIG0_REGION0_Disabled
+#define MPU_PROTENSET0_PROTREG0_Enabled    BPROT_CONFIG0_REGION0_Enabled
+#define MPU_PROTENSET0_PROTREG0_Set        BPROT_CONFIG0_REGION0_Enabled
+
+
+/* From nrf51_deprecated.h */
+
+/* NVMC */
+/* The register ERASEPROTECTEDPAGE changed name to ERASEPCR0 in the documentation. */
+#define ERASEPROTECTEDPAGE      ERASEPCR0
+
+
+/* IRQ */
+/* COMP module was eliminated. Adapted to nrf52 headers. */
+#define LPCOMP_COMP_IRQHandler  COMP_LPCOMP_IRQHandler
+#define LPCOMP_COMP_IRQn        COMP_LPCOMP_IRQn
+
+
+/* RADIO */
+/* The name of the field SKIPADDR was corrected. Old macros added for compatibility. */
+#define RADIO_CRCCNF_SKIP_ADDR_Pos      RADIO_CRCCNF_SKIPADDR_Pos 
+#define RADIO_CRCCNF_SKIP_ADDR_Msk      RADIO_CRCCNF_SKIPADDR_Msk 
+#define RADIO_CRCCNF_SKIP_ADDR_Include  RADIO_CRCCNF_SKIPADDR_Include 
+#define RADIO_CRCCNF_SKIP_ADDR_Skip     RADIO_CRCCNF_SKIPADDR_Skip 
+
+
+/* FICR */
+/* The registers FICR.DEVICEID0 and FICR.DEVICEID1 were renamed into an array. */
+#define DEVICEID0       DEVICEID[0]                     
+#define DEVICEID1       DEVICEID[1]  
+
+/* The registers FICR.ER0, FICR.ER1, FICR.ER2 and FICR.ER3 were renamed into an array. */
+#define ER0             ER[0]                           
+#define ER1             ER[1]                          
+#define ER2             ER[2]                       
+#define ER3             ER[3]                      
+
+/* The registers FICR.IR0, FICR.IR1, FICR.IR2 and FICR.IR3 were renamed into an array. */
+#define IR0             IR[0]                         
+#define IR1             IR[1]                         
+#define IR2             IR[2]                         
+#define IR3             IR[3]                          
+
+/* The registers FICR.DEVICEADDR0 and FICR.DEVICEADDR1 were renamed into an array. */
+#define DEVICEADDR0     DEVICEADDR[0]                  
+#define DEVICEADDR1     DEVICEADDR[1] 
+
+
+/* PPI */
+/* The tasks PPI.TASKS_CHGxEN and PPI.TASKS_CHGxDIS were renamed into an array of structs. */
+#define TASKS_CHG0EN     TASKS_CHG[0].EN                    
+#define TASKS_CHG0DIS    TASKS_CHG[0].DIS                  
+#define TASKS_CHG1EN     TASKS_CHG[1].EN                    
+#define TASKS_CHG1DIS    TASKS_CHG[1].DIS                  
+#define TASKS_CHG2EN     TASKS_CHG[2].EN                   
+#define TASKS_CHG2DIS    TASKS_CHG[2].DIS                  
+#define TASKS_CHG3EN     TASKS_CHG[3].EN                    
+#define TASKS_CHG3DIS    TASKS_CHG[3].DIS                  
+
+/* The registers PPI.CHx_EEP and PPI.CHx_TEP were renamed into an array of structs. */
+#define CH0_EEP          CH[0].EEP                          
+#define CH0_TEP          CH[0].TEP                          
+#define CH1_EEP          CH[1].EEP                         
+#define CH1_TEP          CH[1].TEP                         
+#define CH2_EEP          CH[2].EEP                          
+#define CH2_TEP          CH[2].TEP                         
+#define CH3_EEP          CH[3].EEP                          
+#define CH3_TEP          CH[3].TEP                         
+#define CH4_EEP          CH[4].EEP                         
+#define CH4_TEP          CH[4].TEP                         
+#define CH5_EEP          CH[5].EEP                          
+#define CH5_TEP          CH[5].TEP                          
+#define CH6_EEP          CH[6].EEP                          
+#define CH6_TEP          CH[6].TEP                         
+#define CH7_EEP          CH[7].EEP                          
+#define CH7_TEP          CH[7].TEP                          
+#define CH8_EEP          CH[8].EEP                         
+#define CH8_TEP          CH[8].TEP                          
+#define CH9_EEP          CH[9].EEP                          
+#define CH9_TEP          CH[9].TEP                          
+#define CH10_EEP         CH[10].EEP                         
+#define CH10_TEP         CH[10].TEP                         
+#define CH11_EEP         CH[11].EEP                         
+#define CH11_TEP         CH[11].TEP                         
+#define CH12_EEP         CH[12].EEP                         
+#define CH12_TEP         CH[12].TEP                         
+#define CH13_EEP         CH[13].EEP                         
+#define CH13_TEP         CH[13].TEP                         
+#define CH14_EEP         CH[14].EEP                         
+#define CH14_TEP         CH[14].TEP                         
+#define CH15_EEP         CH[15].EEP                         
+#define CH15_TEP         CH[15].TEP                        
+
+/* The registers PPI.CHG0, PPI.CHG1, PPI.CHG2 and PPI.CHG3 were renamed into an array. */
+#define CHG0             CHG[0]                            
+#define CHG1             CHG[1]                            
+#define CHG2             CHG[2]                             
+#define CHG3             CHG[3]                           
+
+/* All bitfield macros for the CHGx registers therefore changed name. */
+#define PPI_CHG0_CH15_Pos       PPI_CHG_CH15_Pos            
+#define PPI_CHG0_CH15_Msk       PPI_CHG_CH15_Msk            
+#define PPI_CHG0_CH15_Excluded  PPI_CHG_CH15_Excluded       
+#define PPI_CHG0_CH15_Included  PPI_CHG_CH15_Included  
+     
+#define PPI_CHG0_CH14_Pos       PPI_CHG_CH14_Pos            
+#define PPI_CHG0_CH14_Msk       PPI_CHG_CH14_Msk           
+#define PPI_CHG0_CH14_Excluded  PPI_CHG_CH14_Excluded       
+#define PPI_CHG0_CH14_Included  PPI_CHG_CH14_Included     
+  
+#define PPI_CHG0_CH13_Pos       PPI_CHG_CH13_Pos            
+#define PPI_CHG0_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG0_CH13_Excluded  PPI_CHG_CH13_Excluded      
+#define PPI_CHG0_CH13_Included  PPI_CHG_CH13_Included   
+    
+#define PPI_CHG0_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG0_CH12_Msk       PPI_CHG_CH12_Msk            
+#define PPI_CHG0_CH12_Excluded  PPI_CHG_CH12_Excluded       
+#define PPI_CHG0_CH12_Included  PPI_CHG_CH12_Included   
+    
+#define PPI_CHG0_CH11_Pos       PPI_CHG_CH11_Pos            
+#define PPI_CHG0_CH11_Msk       PPI_CHG_CH11_Msk            
+#define PPI_CHG0_CH11_Excluded  PPI_CHG_CH11_Excluded       
+#define PPI_CHG0_CH11_Included  PPI_CHG_CH11_Included  
+     
+#define PPI_CHG0_CH10_Pos       PPI_CHG_CH10_Pos            
+#define PPI_CHG0_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG0_CH10_Excluded  PPI_CHG_CH10_Excluded       
+#define PPI_CHG0_CH10_Included  PPI_CHG_CH10_Included  
+     
+#define PPI_CHG0_CH9_Pos        PPI_CHG_CH9_Pos             
+#define PPI_CHG0_CH9_Msk        PPI_CHG_CH9_Msk             
+#define PPI_CHG0_CH9_Excluded   PPI_CHG_CH9_Excluded        
+#define PPI_CHG0_CH9_Included   PPI_CHG_CH9_Included  
+      
+#define PPI_CHG0_CH8_Pos        PPI_CHG_CH8_Pos             
+#define PPI_CHG0_CH8_Msk        PPI_CHG_CH8_Msk             
+#define PPI_CHG0_CH8_Excluded   PPI_CHG_CH8_Excluded        
+#define PPI_CHG0_CH8_Included   PPI_CHG_CH8_Included  
+      
+#define PPI_CHG0_CH7_Pos        PPI_CHG_CH7_Pos             
+#define PPI_CHG0_CH7_Msk        PPI_CHG_CH7_Msk             
+#define PPI_CHG0_CH7_Excluded   PPI_CHG_CH7_Excluded        
+#define PPI_CHG0_CH7_Included   PPI_CHG_CH7_Included  
+      
+#define PPI_CHG0_CH6_Pos        PPI_CHG_CH6_Pos             
+#define PPI_CHG0_CH6_Msk        PPI_CHG_CH6_Msk             
+#define PPI_CHG0_CH6_Excluded   PPI_CHG_CH6_Excluded        
+#define PPI_CHG0_CH6_Included   PPI_CHG_CH6_Included  
+      
+#define PPI_CHG0_CH5_Pos        PPI_CHG_CH5_Pos             
+#define PPI_CHG0_CH5_Msk        PPI_CHG_CH5_Msk             
+#define PPI_CHG0_CH5_Excluded   PPI_CHG_CH5_Excluded       
+#define PPI_CHG0_CH5_Included   PPI_CHG_CH5_Included   
+     
+#define PPI_CHG0_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG0_CH4_Msk        PPI_CHG_CH4_Msk             
+#define PPI_CHG0_CH4_Excluded   PPI_CHG_CH4_Excluded       
+#define PPI_CHG0_CH4_Included   PPI_CHG_CH4_Included  
+     
+#define PPI_CHG0_CH3_Pos        PPI_CHG_CH3_Pos             
+#define PPI_CHG0_CH3_Msk        PPI_CHG_CH3_Msk            
+#define PPI_CHG0_CH3_Excluded   PPI_CHG_CH3_Excluded        
+#define PPI_CHG0_CH3_Included   PPI_CHG_CH3_Included  
+     
+#define PPI_CHG0_CH2_Pos        PPI_CHG_CH2_Pos            
+#define PPI_CHG0_CH2_Msk        PPI_CHG_CH2_Msk             
+#define PPI_CHG0_CH2_Excluded   PPI_CHG_CH2_Excluded       
+#define PPI_CHG0_CH2_Included   PPI_CHG_CH2_Included  
+     
+#define PPI_CHG0_CH1_Pos        PPI_CHG_CH1_Pos            
+#define PPI_CHG0_CH1_Msk        PPI_CHG_CH1_Msk            
+#define PPI_CHG0_CH1_Excluded   PPI_CHG_CH1_Excluded        
+#define PPI_CHG0_CH1_Included   PPI_CHG_CH1_Included  
+     
+#define PPI_CHG0_CH0_Pos        PPI_CHG_CH0_Pos            
+#define PPI_CHG0_CH0_Msk        PPI_CHG_CH0_Msk            
+#define PPI_CHG0_CH0_Excluded   PPI_CHG_CH0_Excluded        
+#define PPI_CHG0_CH0_Included   PPI_CHG_CH0_Included  
+     
+#define PPI_CHG1_CH15_Pos       PPI_CHG_CH15_Pos           
+#define PPI_CHG1_CH15_Msk       PPI_CHG_CH15_Msk           
+#define PPI_CHG1_CH15_Excluded  PPI_CHG_CH15_Excluded       
+#define PPI_CHG1_CH15_Included  PPI_CHG_CH15_Included    
+  
+#define PPI_CHG1_CH14_Pos       PPI_CHG_CH14_Pos           
+#define PPI_CHG1_CH14_Msk       PPI_CHG_CH14_Msk            
+#define PPI_CHG1_CH14_Excluded  PPI_CHG_CH14_Excluded      
+#define PPI_CHG1_CH14_Included  PPI_CHG_CH14_Included   
+    
+#define PPI_CHG1_CH13_Pos       PPI_CHG_CH13_Pos           
+#define PPI_CHG1_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG1_CH13_Excluded  PPI_CHG_CH13_Excluded      
+#define PPI_CHG1_CH13_Included  PPI_CHG_CH13_Included   
+   
+#define PPI_CHG1_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG1_CH12_Msk       PPI_CHG_CH12_Msk           
+#define PPI_CHG1_CH12_Excluded  PPI_CHG_CH12_Excluded      
+#define PPI_CHG1_CH12_Included  PPI_CHG_CH12_Included   
+  
+#define PPI_CHG1_CH11_Pos       PPI_CHG_CH11_Pos            
+#define PPI_CHG1_CH11_Msk       PPI_CHG_CH11_Msk           
+#define PPI_CHG1_CH11_Excluded  PPI_CHG_CH11_Excluded      
+#define PPI_CHG1_CH11_Included  PPI_CHG_CH11_Included    
+  
+#define PPI_CHG1_CH10_Pos       PPI_CHG_CH10_Pos           
+#define PPI_CHG1_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG1_CH10_Excluded  PPI_CHG_CH10_Excluded      
+#define PPI_CHG1_CH10_Included  PPI_CHG_CH10_Included   
+   
+#define PPI_CHG1_CH9_Pos        PPI_CHG_CH9_Pos            
+#define PPI_CHG1_CH9_Msk        PPI_CHG_CH9_Msk            
+#define PPI_CHG1_CH9_Excluded   PPI_CHG_CH9_Excluded       
+#define PPI_CHG1_CH9_Included   PPI_CHG_CH9_Included    
+   
+#define PPI_CHG1_CH8_Pos        PPI_CHG_CH8_Pos            
+#define PPI_CHG1_CH8_Msk        PPI_CHG_CH8_Msk            
+#define PPI_CHG1_CH8_Excluded   PPI_CHG_CH8_Excluded       
+#define PPI_CHG1_CH8_Included   PPI_CHG_CH8_Included    
+   
+#define PPI_CHG1_CH7_Pos        PPI_CHG_CH7_Pos             
+#define PPI_CHG1_CH7_Msk        PPI_CHG_CH7_Msk            
+#define PPI_CHG1_CH7_Excluded   PPI_CHG_CH7_Excluded        
+#define PPI_CHG1_CH7_Included   PPI_CHG_CH7_Included     
+  
+#define PPI_CHG1_CH6_Pos        PPI_CHG_CH6_Pos             
+#define PPI_CHG1_CH6_Msk        PPI_CHG_CH6_Msk            
+#define PPI_CHG1_CH6_Excluded   PPI_CHG_CH6_Excluded       
+#define PPI_CHG1_CH6_Included   PPI_CHG_CH6_Included    
+   
+#define PPI_CHG1_CH5_Pos        PPI_CHG_CH5_Pos             
+#define PPI_CHG1_CH5_Msk        PPI_CHG_CH5_Msk             
+#define PPI_CHG1_CH5_Excluded   PPI_CHG_CH5_Excluded       
+#define PPI_CHG1_CH5_Included   PPI_CHG_CH5_Included   
+    
+#define PPI_CHG1_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG1_CH4_Msk        PPI_CHG_CH4_Msk             
+#define PPI_CHG1_CH4_Excluded   PPI_CHG_CH4_Excluded        
+#define PPI_CHG1_CH4_Included   PPI_CHG_CH4_Included    
+    
+#define PPI_CHG1_CH3_Pos        PPI_CHG_CH3_Pos            
+#define PPI_CHG1_CH3_Msk        PPI_CHG_CH3_Msk             
+#define PPI_CHG1_CH3_Excluded   PPI_CHG_CH3_Excluded        
+#define PPI_CHG1_CH3_Included   PPI_CHG_CH3_Included   
+    
+#define PPI_CHG1_CH2_Pos        PPI_CHG_CH2_Pos            
+#define PPI_CHG1_CH2_Msk        PPI_CHG_CH2_Msk             
+#define PPI_CHG1_CH2_Excluded   PPI_CHG_CH2_Excluded        
+#define PPI_CHG1_CH2_Included   PPI_CHG_CH2_Included    
+    
+#define PPI_CHG1_CH1_Pos        PPI_CHG_CH1_Pos             
+#define PPI_CHG1_CH1_Msk        PPI_CHG_CH1_Msk            
+#define PPI_CHG1_CH1_Excluded   PPI_CHG_CH1_Excluded        
+#define PPI_CHG1_CH1_Included   PPI_CHG_CH1_Included   
+    
+#define PPI_CHG1_CH0_Pos        PPI_CHG_CH0_Pos             
+#define PPI_CHG1_CH0_Msk        PPI_CHG_CH0_Msk            
+#define PPI_CHG1_CH0_Excluded   PPI_CHG_CH0_Excluded       
+#define PPI_CHG1_CH0_Included   PPI_CHG_CH0_Included   
+    
+#define PPI_CHG2_CH15_Pos       PPI_CHG_CH15_Pos           
+#define PPI_CHG2_CH15_Msk       PPI_CHG_CH15_Msk            
+#define PPI_CHG2_CH15_Excluded  PPI_CHG_CH15_Excluded      
+#define PPI_CHG2_CH15_Included  PPI_CHG_CH15_Included   
+   
+#define PPI_CHG2_CH14_Pos       PPI_CHG_CH14_Pos           
+#define PPI_CHG2_CH14_Msk       PPI_CHG_CH14_Msk           
+#define PPI_CHG2_CH14_Excluded  PPI_CHG_CH14_Excluded       
+#define PPI_CHG2_CH14_Included  PPI_CHG_CH14_Included    
+  
+#define PPI_CHG2_CH13_Pos       PPI_CHG_CH13_Pos           
+#define PPI_CHG2_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG2_CH13_Excluded  PPI_CHG_CH13_Excluded       
+#define PPI_CHG2_CH13_Included  PPI_CHG_CH13_Included  
+    
+#define PPI_CHG2_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG2_CH12_Msk       PPI_CHG_CH12_Msk            
+#define PPI_CHG2_CH12_Excluded  PPI_CHG_CH12_Excluded      
+#define PPI_CHG2_CH12_Included  PPI_CHG_CH12_Included     
+  
+#define PPI_CHG2_CH11_Pos       PPI_CHG_CH11_Pos           
+#define PPI_CHG2_CH11_Msk       PPI_CHG_CH11_Msk           
+#define PPI_CHG2_CH11_Excluded  PPI_CHG_CH11_Excluded       
+#define PPI_CHG2_CH11_Included  PPI_CHG_CH11_Included   
+    
+#define PPI_CHG2_CH10_Pos       PPI_CHG_CH10_Pos            
+#define PPI_CHG2_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG2_CH10_Excluded  PPI_CHG_CH10_Excluded      
+#define PPI_CHG2_CH10_Included  PPI_CHG_CH10_Included   
+   
+#define PPI_CHG2_CH9_Pos        PPI_CHG_CH9_Pos            
+#define PPI_CHG2_CH9_Msk        PPI_CHG_CH9_Msk            
+#define PPI_CHG2_CH9_Excluded   PPI_CHG_CH9_Excluded        
+#define PPI_CHG2_CH9_Included   PPI_CHG_CH9_Included   
+    
+#define PPI_CHG2_CH8_Pos        PPI_CHG_CH8_Pos            
+#define PPI_CHG2_CH8_Msk        PPI_CHG_CH8_Msk            
+#define PPI_CHG2_CH8_Excluded   PPI_CHG_CH8_Excluded       
+#define PPI_CHG2_CH8_Included   PPI_CHG_CH8_Included  
+      
+#define PPI_CHG2_CH7_Pos        PPI_CHG_CH7_Pos            
+#define PPI_CHG2_CH7_Msk        PPI_CHG_CH7_Msk            
+#define PPI_CHG2_CH7_Excluded   PPI_CHG_CH7_Excluded       
+#define PPI_CHG2_CH7_Included   PPI_CHG_CH7_Included   
+    
+#define PPI_CHG2_CH6_Pos        PPI_CHG_CH6_Pos            
+#define PPI_CHG2_CH6_Msk        PPI_CHG_CH6_Msk            
+#define PPI_CHG2_CH6_Excluded   PPI_CHG_CH6_Excluded       
+#define PPI_CHG2_CH6_Included   PPI_CHG_CH6_Included   
+    
+#define PPI_CHG2_CH5_Pos        PPI_CHG_CH5_Pos            
+#define PPI_CHG2_CH5_Msk        PPI_CHG_CH5_Msk            
+#define PPI_CHG2_CH5_Excluded   PPI_CHG_CH5_Excluded       
+#define PPI_CHG2_CH5_Included   PPI_CHG_CH5_Included  
+      
+#define PPI_CHG2_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG2_CH4_Msk        PPI_CHG_CH4_Msk             
+#define PPI_CHG2_CH4_Excluded   PPI_CHG_CH4_Excluded        
+#define PPI_CHG2_CH4_Included   PPI_CHG_CH4_Included   
+    
+#define PPI_CHG2_CH3_Pos        PPI_CHG_CH3_Pos            
+#define PPI_CHG2_CH3_Msk        PPI_CHG_CH3_Msk            
+#define PPI_CHG2_CH3_Excluded   PPI_CHG_CH3_Excluded       
+#define PPI_CHG2_CH3_Included   PPI_CHG_CH3_Included   
+    
+#define PPI_CHG2_CH2_Pos        PPI_CHG_CH2_Pos            
+#define PPI_CHG2_CH2_Msk        PPI_CHG_CH2_Msk           
+#define PPI_CHG2_CH2_Excluded   PPI_CHG_CH2_Excluded       
+#define PPI_CHG2_CH2_Included   PPI_CHG_CH2_Included   
+    
+#define PPI_CHG2_CH1_Pos        PPI_CHG_CH1_Pos             
+#define PPI_CHG2_CH1_Msk        PPI_CHG_CH1_Msk             
+#define PPI_CHG2_CH1_Excluded   PPI_CHG_CH1_Excluded       
+#define PPI_CHG2_CH1_Included   PPI_CHG_CH1_Included   
+    
+#define PPI_CHG2_CH0_Pos        PPI_CHG_CH0_Pos            
+#define PPI_CHG2_CH0_Msk        PPI_CHG_CH0_Msk            
+#define PPI_CHG2_CH0_Excluded   PPI_CHG_CH0_Excluded       
+#define PPI_CHG2_CH0_Included   PPI_CHG_CH0_Included    
+    
+#define PPI_CHG3_CH15_Pos       PPI_CHG_CH15_Pos           
+#define PPI_CHG3_CH15_Msk       PPI_CHG_CH15_Msk           
+#define PPI_CHG3_CH15_Excluded  PPI_CHG_CH15_Excluded     
+#define PPI_CHG3_CH15_Included  PPI_CHG_CH15_Included  
+    
+#define PPI_CHG3_CH14_Pos       PPI_CHG_CH14_Pos          
+#define PPI_CHG3_CH14_Msk       PPI_CHG_CH14_Msk           
+#define PPI_CHG3_CH14_Excluded  PPI_CHG_CH14_Excluded      
+#define PPI_CHG3_CH14_Included  PPI_CHG_CH14_Included   
+    
+#define PPI_CHG3_CH13_Pos       PPI_CHG_CH13_Pos           
+#define PPI_CHG3_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG3_CH13_Excluded  PPI_CHG_CH13_Excluded      
+#define PPI_CHG3_CH13_Included  PPI_CHG_CH13_Included   
+   
+#define PPI_CHG3_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG3_CH12_Msk       PPI_CHG_CH12_Msk            
+#define PPI_CHG3_CH12_Excluded  PPI_CHG_CH12_Excluded       
+#define PPI_CHG3_CH12_Included  PPI_CHG_CH12_Included   
+    
+#define PPI_CHG3_CH11_Pos       PPI_CHG_CH11_Pos            
+#define PPI_CHG3_CH11_Msk       PPI_CHG_CH11_Msk            
+#define PPI_CHG3_CH11_Excluded  PPI_CHG_CH11_Excluded      
+#define PPI_CHG3_CH11_Included  PPI_CHG_CH11_Included   
+    
+#define PPI_CHG3_CH10_Pos       PPI_CHG_CH10_Pos            
+#define PPI_CHG3_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG3_CH10_Excluded  PPI_CHG_CH10_Excluded      
+#define PPI_CHG3_CH10_Included  PPI_CHG_CH10_Included   
+   
+#define PPI_CHG3_CH9_Pos        PPI_CHG_CH9_Pos            
+#define PPI_CHG3_CH9_Msk        PPI_CHG_CH9_Msk            
+#define PPI_CHG3_CH9_Excluded   PPI_CHG_CH9_Excluded       
+#define PPI_CHG3_CH9_Included   PPI_CHG_CH9_Included   
+    
+#define PPI_CHG3_CH8_Pos        PPI_CHG_CH8_Pos            
+#define PPI_CHG3_CH8_Msk        PPI_CHG_CH8_Msk             
+#define PPI_CHG3_CH8_Excluded   PPI_CHG_CH8_Excluded       
+#define PPI_CHG3_CH8_Included   PPI_CHG_CH8_Included   
+    
+#define PPI_CHG3_CH7_Pos        PPI_CHG_CH7_Pos             
+#define PPI_CHG3_CH7_Msk        PPI_CHG_CH7_Msk            
+#define PPI_CHG3_CH7_Excluded   PPI_CHG_CH7_Excluded        
+#define PPI_CHG3_CH7_Included   PPI_CHG_CH7_Included   
+    
+#define PPI_CHG3_CH6_Pos        PPI_CHG_CH6_Pos             
+#define PPI_CHG3_CH6_Msk        PPI_CHG_CH6_Msk             
+#define PPI_CHG3_CH6_Excluded   PPI_CHG_CH6_Excluded       
+#define PPI_CHG3_CH6_Included   PPI_CHG_CH6_Included   
+     
+#define PPI_CHG3_CH5_Pos        PPI_CHG_CH5_Pos             
+#define PPI_CHG3_CH5_Msk        PPI_CHG_CH5_Msk             
+#define PPI_CHG3_CH5_Excluded   PPI_CHG_CH5_Excluded        
+#define PPI_CHG3_CH5_Included   PPI_CHG_CH5_Included  
+     
+#define PPI_CHG3_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG3_CH4_Msk        PPI_CHG_CH4_Msk            
+#define PPI_CHG3_CH4_Excluded   PPI_CHG_CH4_Excluded        
+#define PPI_CHG3_CH4_Included   PPI_CHG_CH4_Included  
+      
+#define PPI_CHG3_CH3_Pos        PPI_CHG_CH3_Pos             
+#define PPI_CHG3_CH3_Msk        PPI_CHG_CH3_Msk            
+#define PPI_CHG3_CH3_Excluded   PPI_CHG_CH3_Excluded        
+#define PPI_CHG3_CH3_Included   PPI_CHG_CH3_Included   
+     
+#define PPI_CHG3_CH2_Pos        PPI_CHG_CH2_Pos             
+#define PPI_CHG3_CH2_Msk        PPI_CHG_CH2_Msk             
+#define PPI_CHG3_CH2_Excluded   PPI_CHG_CH2_Excluded        
+#define PPI_CHG3_CH2_Included   PPI_CHG_CH2_Included  
+     
+#define PPI_CHG3_CH1_Pos        PPI_CHG_CH1_Pos             
+#define PPI_CHG3_CH1_Msk        PPI_CHG_CH1_Msk             
+#define PPI_CHG3_CH1_Excluded   PPI_CHG_CH1_Excluded        
+#define PPI_CHG3_CH1_Included   PPI_CHG_CH1_Included  
+      
+#define PPI_CHG3_CH0_Pos        PPI_CHG_CH0_Pos             
+#define PPI_CHG3_CH0_Msk        PPI_CHG_CH0_Msk             
+#define PPI_CHG3_CH0_Excluded   PPI_CHG_CH0_Excluded        
+#define PPI_CHG3_CH0_Included   PPI_CHG_CH0_Included        
+
+
+
+
+/*lint --flb "Leave library region" */
+
+#endif /* NRF51_TO_NRF52_H */
+

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf51_xxaa.ld
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf51_xxaa.ld
@@ -1,0 +1,13 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x40000
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x4000
+}
+
+
+INCLUDE "nrf51_common.ld"

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf51_xxab.ld
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf51_xxab.ld
@@ -1,0 +1,13 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x20000
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x4000
+}
+
+
+INCLUDE "nrf51_common.ld"

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf51_xxac.ld
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf51_xxac.ld
@@ -1,0 +1,13 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x40000
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x8000
+}
+
+
+INCLUDE "nrf51_common.ld"

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf52.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf52.h
@@ -1,0 +1,2070 @@
+
+/****************************************************************************************************//**
+ * @file     nrf52.h
+ *
+ * @brief    CMSIS Cortex-M4 Peripheral Access Layer Header File for
+ *           nrf52 from Nordic Semiconductor.
+ *
+ * @version  V1
+ * @date     9. October 2015
+ *
+ * @note     Generated with SVDConv V2.81d 
+ *           from CMSIS SVD File 'nrf52.svd' Version 1,
+ *
+ * @par      Copyright (c) 2015, Nordic Semiconductor ASA
+ *           All rights reserved.
+ *           
+ *           Redistribution and use in source and binary forms, with or without
+ *           modification, are permitted provided that the following conditions are met:
+ *           
+ *           * Redistributions of source code must retain the above copyright notice, this
+ *           list of conditions and the following disclaimer.
+ *           
+ *           * Redistributions in binary form must reproduce the above copyright notice,
+ *           this list of conditions and the following disclaimer in the documentation
+ *           and/or other materials provided with the distribution.
+ *           
+ *           * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *           contributors may be used to endorse or promote products derived from
+ *           this software without specific prior written permission.
+ *           
+ *           THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *           AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *           IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *           DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *           FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *           DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *           SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *           CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *           OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *           OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *           
+ *
+ *******************************************************************************************************/
+
+
+
+/** @addtogroup Nordic Semiconductor
+  * @{
+  */
+
+/** @addtogroup nrf52
+  * @{
+  */
+
+#ifndef NRF52_H
+#define NRF52_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* -------------------------  Interrupt Number Definition  ------------------------ */
+
+typedef enum {
+/* -------------------  Cortex-M4 Processor Exceptions Numbers  ------------------- */
+  Reset_IRQn                    = -15,              /*!<   1  Reset Vector, invoked on Power up and warm reset                 */
+  NonMaskableInt_IRQn           = -14,              /*!<   2  Non maskable Interrupt, cannot be stopped or preempted           */
+  HardFault_IRQn                = -13,              /*!<   3  Hard Fault, all classes of Fault                                 */
+  MemoryManagement_IRQn         = -12,              /*!<   4  Memory Management, MPU mismatch, including Access Violation
+                                                         and No Match                                                          */
+  BusFault_IRQn                 = -11,              /*!<   5  Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory
+                                                         related Fault                                                         */
+  UsageFault_IRQn               = -10,              /*!<   6  Usage Fault, i.e. Undef Instruction, Illegal State Transition    */
+  SVCall_IRQn                   =  -5,              /*!<  11  System Service Call via SVC instruction                          */
+  DebugMonitor_IRQn             =  -4,              /*!<  12  Debug Monitor                                                    */
+  PendSV_IRQn                   =  -2,              /*!<  14  Pendable request for system service                              */
+  SysTick_IRQn                  =  -1,              /*!<  15  System Tick Timer                                                */
+/* ----------------------  nrf52 Specific Interrupt Numbers  ---------------------- */
+  POWER_CLOCK_IRQn              =   0,              /*!<   0  POWER_CLOCK                                                      */
+  RADIO_IRQn                    =   1,              /*!<   1  RADIO                                                            */
+  UARTE0_UART0_IRQn             =   2,              /*!<   2  UARTE0_UART0                                                     */
+  SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn=   3,      /*!<   3  SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0                                */
+  SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn=   4,      /*!<   4  SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1                                */
+  NFCT_IRQn                     =   5,              /*!<   5  NFCT                                                             */
+  GPIOTE_IRQn                   =   6,              /*!<   6  GPIOTE                                                           */
+  SAADC_IRQn                    =   7,              /*!<   7  SAADC                                                            */
+  TIMER0_IRQn                   =   8,              /*!<   8  TIMER0                                                           */
+  TIMER1_IRQn                   =   9,              /*!<   9  TIMER1                                                           */
+  TIMER2_IRQn                   =  10,              /*!<  10  TIMER2                                                           */
+  RTC0_IRQn                     =  11,              /*!<  11  RTC0                                                             */
+  TEMP_IRQn                     =  12,              /*!<  12  TEMP                                                             */
+  RNG_IRQn                      =  13,              /*!<  13  RNG                                                              */
+  ECB_IRQn                      =  14,              /*!<  14  ECB                                                              */
+  CCM_AAR_IRQn                  =  15,              /*!<  15  CCM_AAR                                                          */
+  WDT_IRQn                      =  16,              /*!<  16  WDT                                                              */
+  RTC1_IRQn                     =  17,              /*!<  17  RTC1                                                             */
+  QDEC_IRQn                     =  18,              /*!<  18  QDEC                                                             */
+  COMP_LPCOMP_IRQn              =  19,              /*!<  19  COMP_LPCOMP                                                      */
+  SWI0_EGU0_IRQn                =  20,              /*!<  20  SWI0_EGU0                                                        */
+  SWI1_EGU1_IRQn                =  21,              /*!<  21  SWI1_EGU1                                                        */
+  SWI2_EGU2_IRQn                =  22,              /*!<  22  SWI2_EGU2                                                        */
+  SWI3_EGU3_IRQn                =  23,              /*!<  23  SWI3_EGU3                                                        */
+  SWI4_EGU4_IRQn                =  24,              /*!<  24  SWI4_EGU4                                                        */
+  SWI5_EGU5_IRQn                =  25,              /*!<  25  SWI5_EGU5                                                        */
+  TIMER3_IRQn                   =  26,              /*!<  26  TIMER3                                                           */
+  TIMER4_IRQn                   =  27,              /*!<  27  TIMER4                                                           */
+  PWM0_IRQn                     =  28,              /*!<  28  PWM0                                                             */
+  PDM_IRQn                      =  29,              /*!<  29  PDM                                                              */
+  MWU_IRQn                      =  32,              /*!<  32  MWU                                                              */
+  PWM1_IRQn                     =  33,              /*!<  33  PWM1                                                             */
+  PWM2_IRQn                     =  34,              /*!<  34  PWM2                                                             */
+  SPIM2_SPIS2_SPI2_IRQn         =  35,              /*!<  35  SPIM2_SPIS2_SPI2                                                 */
+  RTC2_IRQn                     =  36,              /*!<  36  RTC2                                                             */
+  I2S_IRQn                      =  37               /*!<  37  I2S                                                              */
+} IRQn_Type;
+
+
+/** @addtogroup Configuration_of_CMSIS
+  * @{
+  */
+
+
+/* ================================================================================ */
+/* ================      Processor and Core Peripheral Section     ================ */
+/* ================================================================================ */
+
+/* ----------------Configuration of the Cortex-M4 Processor and Core Peripherals---------------- */
+#define __CM4_REV                 0x0001            /*!< Cortex-M4 Core Revision                                               */
+#define __MPU_PRESENT                  1            /*!< MPU present or not                                                    */
+#define __NVIC_PRIO_BITS               3            /*!< Number of Bits used for Priority Levels                               */
+#define __Vendor_SysTickConfig         0            /*!< Set to 1 if different SysTick Config is used                          */
+#define __FPU_PRESENT                  1            /*!< FPU present or not                                                    */
+/** @} */ /* End of group Configuration_of_CMSIS */
+
+#include "core_cm4.h"                               /*!< Cortex-M4 processor and core peripherals                              */
+#include "system_nrf52.h"                           /*!< nrf52 System                                                          */
+
+
+/* ================================================================================ */
+/* ================       Device Specific Peripheral Section       ================ */
+/* ================================================================================ */
+
+
+/** @addtogroup Device_Peripheral_Registers
+  * @{
+  */
+
+
+/* -------------------  Start of section using anonymous unions  ------------------ */
+#if defined(__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined(__ICCARM__)
+  #pragma language=extended
+#elif defined(__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined(__TMS470__)
+/* anonymous unions are enabled by default */
+#elif defined(__TASKING__)
+  #pragma warning 586
+#else
+  #warning Not supported compiler type
+#endif
+
+
+typedef struct {
+  __I  uint32_t  PART;                              /*!< Part code                                                             */
+  __I  uint32_t  VARIANT;                           /*!< Part variant                                                          */
+  __I  uint32_t  PACKAGE;                           /*!< Package option                                                        */
+  __I  uint32_t  RAM;                               /*!< RAM variant                                                           */
+  __I  uint32_t  FLASH;                             /*!< Flash variant                                                         */
+  __IO uint32_t  UNUSED0[3];                        /*!< Description collection[0]: Unspecified                                */
+} FICR_INFO_Type;
+
+typedef struct {
+  __I  uint32_t  A0;                                /*!< Slope definition A0.                                                  */
+  __I  uint32_t  A1;                                /*!< Slope definition A1.                                                  */
+  __I  uint32_t  A2;                                /*!< Slope definition A2.                                                  */
+  __I  uint32_t  A3;                                /*!< Slope definition A3.                                                  */
+  __I  uint32_t  A4;                                /*!< Slope definition A4.                                                  */
+  __I  uint32_t  A5;                                /*!< Slope definition A5.                                                  */
+  __I  uint32_t  B0;                                /*!< y-intercept B0.                                                       */
+  __I  uint32_t  B1;                                /*!< y-intercept B1.                                                       */
+  __I  uint32_t  B2;                                /*!< y-intercept B2.                                                       */
+  __I  uint32_t  B3;                                /*!< y-intercept B3.                                                       */
+  __I  uint32_t  B4;                                /*!< y-intercept B4.                                                       */
+  __I  uint32_t  B5;                                /*!< y-intercept B5.                                                       */
+  __I  uint32_t  T0;                                /*!< Segment end T0.                                                       */
+  __I  uint32_t  T1;                                /*!< Segment end T1.                                                       */
+  __I  uint32_t  T2;                                /*!< Segment end T2.                                                       */
+  __I  uint32_t  T3;                                /*!< Segment end T3.                                                       */
+  __I  uint32_t  T4;                                /*!< Segment end T4.                                                       */
+} FICR_TEMP_Type;
+
+typedef struct {
+  __I  uint32_t  TAGHEADER0;                        /*!< Default header for NFC Tag. Software can read these values to
+                                                         populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST.            */
+  __I  uint32_t  TAGHEADER1;                        /*!< Default header for NFC Tag. Software can read these values to
+                                                         populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST.            */
+  __I  uint32_t  TAGHEADER2;                        /*!< Default header for NFC Tag. Software can read these values to
+                                                         populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST.            */
+  __I  uint32_t  TAGHEADER3;                        /*!< Default header for NFC Tag. Software can read these values to
+                                                         populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST.            */
+} FICR_NFC_Type;
+
+typedef struct {
+  __IO uint32_t  POWER;                             /*!< Description cluster[0]: RAM0 power control register                   */
+  __O  uint32_t  POWERSET;                          /*!< Description cluster[0]: RAM0 power control set register               */
+  __O  uint32_t  POWERCLR;                          /*!< Description cluster[0]: RAM0 power control clear register             */
+  __I  uint32_t  RESERVED0;
+} POWER_RAM_Type;
+
+typedef struct {
+  __IO uint32_t  RTS;                               /*!< Pin select for RTS signal                                             */
+  __IO uint32_t  TXD;                               /*!< Pin select for TXD signal                                             */
+  __IO uint32_t  CTS;                               /*!< Pin select for CTS signal                                             */
+  __IO uint32_t  RXD;                               /*!< Pin select for RXD signal                                             */
+} UARTE_PSEL_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Data pointer                                                          */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of bytes in receive buffer                             */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes transferred in the last transaction                   */
+} UARTE_RXD_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Data pointer                                                          */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of bytes in transmit buffer                            */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes transferred in the last transaction                   */
+} UARTE_TXD_Type;
+
+typedef struct {
+  __IO uint32_t  SCK;                               /*!< Pin select for SCK                                                    */
+  __IO uint32_t  MOSI;                              /*!< Pin select for MOSI signal                                            */
+  __IO uint32_t  MISO;                              /*!< Pin select for MISO signal                                            */
+} SPIM_PSEL_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Data pointer                                                          */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of bytes in receive buffer                             */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes transferred in the last transaction                   */
+  __IO uint32_t  LIST;                              /*!< EasyDMA list type                                                     */
+} SPIM_RXD_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Data pointer                                                          */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of bytes in transmit buffer                            */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes transferred in the last transaction                   */
+  __IO uint32_t  LIST;                              /*!< EasyDMA list type                                                     */
+} SPIM_TXD_Type;
+
+typedef struct {
+  __IO uint32_t  SCK;                               /*!< Pin select for SCK                                                    */
+  __IO uint32_t  MISO;                              /*!< Pin select for MISO signal                                            */
+  __IO uint32_t  MOSI;                              /*!< Pin select for MOSI signal                                            */
+  __IO uint32_t  CSN;                               /*!< Pin select for CSN signal                                             */
+} SPIS_PSEL_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< RXD data pointer                                                      */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of bytes in receive buffer                             */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes received in last granted transaction                  */
+} SPIS_RXD_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< TXD data pointer                                                      */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of bytes in transmit buffer                            */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes transmitted in last granted transaction               */
+} SPIS_TXD_Type;
+
+typedef struct {
+  __IO uint32_t  SCL;                               /*!< Pin select for SCL signal                                             */
+  __IO uint32_t  SDA;                               /*!< Pin select for SDA signal                                             */
+} TWIM_PSEL_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Data pointer                                                          */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of bytes in receive buffer                             */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes transferred in the last transaction                   */
+  __IO uint32_t  LIST;                              /*!< EasyDMA list type                                                     */
+} TWIM_RXD_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Data pointer                                                          */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of bytes in transmit buffer                            */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes transferred in the last transaction                   */
+  __IO uint32_t  LIST;                              /*!< EasyDMA list type                                                     */
+} TWIM_TXD_Type;
+
+typedef struct {
+  __IO uint32_t  SCL;                               /*!< Pin select for SCL signal                                             */
+  __IO uint32_t  SDA;                               /*!< Pin select for SDA signal                                             */
+} TWIS_PSEL_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< RXD Data pointer                                                      */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of bytes in RXD buffer                                 */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes transferred in the last RXD transaction               */
+} TWIS_RXD_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< TXD Data pointer                                                      */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of bytes in TXD buffer                                 */
+  __I  uint32_t  AMOUNT;                            /*!< Number of bytes transferred in the last TXD transaction               */
+} TWIS_TXD_Type;
+
+typedef struct {
+  __IO uint32_t  SCK;                               /*!< Pin select for SCK                                                    */
+  __IO uint32_t  MOSI;                              /*!< Pin select for MOSI                                                   */
+  __IO uint32_t  MISO;                              /*!< Pin select for MISO                                                   */
+} SPI_PSEL_Type;
+
+typedef struct {
+  __IO uint32_t  RX;                                /*!< Result of last incoming frames                                        */
+} NFCT_FRAMESTATUS_Type;
+
+typedef struct {
+  __IO uint32_t  FRAMECONFIG;                       /*!< Configuration of outgoing frames                                      */
+  __IO uint32_t  AMOUNT;                            /*!< Size of outgoing frame                                                */
+} NFCT_TXD_Type;
+
+typedef struct {
+  __IO uint32_t  FRAMECONFIG;                       /*!< Configuration of incoming frames                                      */
+  __I  uint32_t  AMOUNT;                            /*!< Size of last incoming frame                                           */
+} NFCT_RXD_Type;
+
+typedef struct {
+  __IO uint32_t  LIMITH;                            /*!< Description cluster[0]: Last results is equal or above CH[0].LIMIT.HIGH */
+  __IO uint32_t  LIMITL;                            /*!< Description cluster[0]: Last results is equal or below CH[0].LIMIT.LOW */
+} SAADC_EVENTS_CH_Type;
+
+typedef struct {
+  __IO uint32_t  PSELP;                             /*!< Description cluster[0]: Input positive pin selection for CH[0]        */
+  __IO uint32_t  PSELN;                             /*!< Description cluster[0]: Input negative pin selection for CH[0]        */
+  __IO uint32_t  CONFIG;                            /*!< Description cluster[0]: Input configuration for CH[0]                 */
+  __IO uint32_t  LIMIT;                             /*!< Description cluster[0]: High/low limits for event monitoring
+                                                         a channel                                                             */
+} SAADC_CH_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Data pointer                                                          */
+  __IO uint32_t  MAXCNT;                            /*!< Maximum number of buffer words to transfer                            */
+  __I  uint32_t  AMOUNT;                            /*!< Number of buffer words transferred since last START                   */
+} SAADC_RESULT_Type;
+
+typedef struct {
+  __IO uint32_t  LED;                               /*!< Pin select for LED signal                                             */
+  __IO uint32_t  A;                                 /*!< Pin select for A signal                                               */
+  __IO uint32_t  B;                                 /*!< Pin select for B signal                                               */
+} QDEC_PSEL_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Description cluster[0]: Beginning address in Data RAM of sequence
+                                                         A                                                                     */
+  __IO uint32_t  CNT;                               /*!< Description cluster[0]: Amount of values (duty cycles) in sequence
+                                                         A                                                                     */
+  __IO uint32_t  REFRESH;                           /*!< Description cluster[0]: Amount of additional PWM periods between
+                                                         samples loaded to compare register (load every CNT+1 PWM periods)     */
+  __IO uint32_t  ENDDELAY;                          /*!< Description cluster[0]: Time added after the sequence                 */
+  __I  uint32_t  RESERVED1[4];
+} PWM_SEQ_Type;
+
+typedef struct {
+  __IO uint32_t  OUT[4];                            /*!< Description collection[0]: Output pin select for PWM channel
+                                                         0                                                                     */
+} PWM_PSEL_Type;
+
+typedef struct {
+  __IO uint32_t  CLK;                               /*!< Pin number configuration for PDM CLK signal                           */
+  __IO uint32_t  DIN;                               /*!< Pin number configuration for PDM DIN signal                           */
+} PDM_PSEL_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< RAM address pointer to write samples to with EasyDMA                  */
+  __IO uint32_t  MAXCNT;                            /*!< Number of samples to allocate memory for in EasyDMA mode              */
+} PDM_SAMPLE_Type;
+
+typedef struct {
+  __O  uint32_t  EN;                                /*!< Description cluster[0]: Enable channel group 0                        */
+  __O  uint32_t  DIS;                               /*!< Description cluster[0]: Disable channel group 0                       */
+} PPI_TASKS_CHG_Type;
+
+typedef struct {
+  __IO uint32_t  EEP;                               /*!< Description cluster[0]: Channel 0 event end-point                     */
+  __IO uint32_t  TEP;                               /*!< Description cluster[0]: Channel 0 task end-point                      */
+} PPI_CH_Type;
+
+typedef struct {
+  __IO uint32_t  TEP;                               /*!< Description cluster[0]: Channel 0 task end-point                      */
+} PPI_FORK_Type;
+
+typedef struct {
+  __IO uint32_t  WA;                                /*!< Description cluster[0]: Write access to region 0 detected             */
+  __IO uint32_t  RA;                                /*!< Description cluster[0]: Read access to region 0 detected              */
+} MWU_EVENTS_REGION_Type;
+
+typedef struct {
+  __IO uint32_t  WA;                                /*!< Description cluster[0]: Write access to peripheral region 0
+                                                         detected                                                              */
+  __IO uint32_t  RA;                                /*!< Description cluster[0]: Read access to peripheral region 0 detected   */
+} MWU_EVENTS_PREGION_Type;
+
+typedef struct {
+  __IO uint32_t  SUBSTATWA;                         /*!< Description cluster[0]: Source of event/interrupt in region
+                                                         0, write access detected while corresponding subregion was enabled
+                                                          for watching                                                         */
+  __IO uint32_t  SUBSTATRA;                         /*!< Description cluster[0]: Source of event/interrupt in region
+                                                         0, read access detected while corresponding subregion was enabled
+                                                          for watching                                                         */
+} MWU_PERREGION_Type;
+
+typedef struct {
+  __IO uint32_t  START;                             /*!< Description cluster[0]: Start address for region 0                    */
+  __IO uint32_t  END;                               /*!< Description cluster[0]: End address of region 0                       */
+  __I  uint32_t  RESERVED2[2];
+} MWU_REGION_Type;
+
+typedef struct {
+  __I  uint32_t  START;                             /*!< Description cluster[0]: Reserved for future use                       */
+  __I  uint32_t  END;                               /*!< Description cluster[0]: Reserved for future use                       */
+  __IO uint32_t  SUBS;                              /*!< Description cluster[0]: Subregions of region 0                        */
+  __I  uint32_t  RESERVED3;
+} MWU_PREGION_Type;
+
+typedef struct {
+  __IO uint32_t  MODE;                              /*!< I2S mode.                                                             */
+  __IO uint32_t  RXEN;                              /*!< Reception (RX) enable.                                                */
+  __IO uint32_t  TXEN;                              /*!< Transmission (TX) enable.                                             */
+  __IO uint32_t  MCKEN;                             /*!< Master clock generator enable.                                        */
+  __IO uint32_t  MCKFREQ;                           /*!< Master clock generator frequency.                                     */
+  __IO uint32_t  RATIO;                             /*!< MCK / LRCK ratio.                                                     */
+  __IO uint32_t  SWIDTH;                            /*!< Sample width.                                                         */
+  __IO uint32_t  ALIGN;                             /*!< Alignment of sample within a frame.                                   */
+  __IO uint32_t  FORMAT;                            /*!< Frame format.                                                         */
+  __IO uint32_t  CHANNELS;                          /*!< Enable channels.                                                      */
+} I2S_CONFIG_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Receive buffer RAM start address.                                     */
+} I2S_RXD_Type;
+
+typedef struct {
+  __IO uint32_t  PTR;                               /*!< Transmit buffer RAM start address.                                    */
+} I2S_TXD_Type;
+
+typedef struct {
+  __IO uint32_t  MAXCNT;                            /*!< Size of RXD and TXD buffers.                                          */
+} I2S_RXTXD_Type;
+
+typedef struct {
+  __IO uint32_t  MCK;                               /*!< Pin select for MCK signal.                                            */
+  __IO uint32_t  SCK;                               /*!< Pin select for SCK signal.                                            */
+  __IO uint32_t  LRCK;                              /*!< Pin select for LRCK signal.                                           */
+  __IO uint32_t  SDIN;                              /*!< Pin select for SDIN signal.                                           */
+  __IO uint32_t  SDOUT;                             /*!< Pin select for SDOUT signal.                                          */
+} I2S_PSEL_Type;
+
+
+/* ================================================================================ */
+/* ================                      FICR                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Factory Information Configuration Registers (FICR)
+  */
+
+typedef struct {                                    /*!< FICR Structure                                                        */
+  __I  uint32_t  RESERVED0[4];
+  __I  uint32_t  CODEPAGESIZE;                      /*!< Code memory page size                                                 */
+  __I  uint32_t  CODESIZE;                          /*!< Code memory size                                                      */
+  __I  uint32_t  RESERVED1[17];
+  __I  uint32_t  CONFIGID;                          /*!< Configuration identifier                                              */
+  __I  uint32_t  DEVICEID[2];                       /*!< Description collection[0]: Device identifier                          */
+  __I  uint32_t  RESERVED2[6];
+  __I  uint32_t  ER[4];                             /*!< Description collection[0]: Encryption Root, word 0                    */
+  __I  uint32_t  IR[4];                             /*!< Description collection[0]: Identity Root, word 0                      */
+  __I  uint32_t  DEVICEADDRTYPE;                    /*!< Device address type                                                   */
+  __I  uint32_t  DEVICEADDR[2];                     /*!< Description collection[0]: Device address 0                           */
+  __I  uint32_t  RESERVED3[21];
+  FICR_INFO_Type INFO;                              /*!< Device info                                                           */
+  __I  uint32_t  RESERVED4[185];
+  FICR_TEMP_Type TEMP;                              /*!< Registers storing factory TEMP module linearization coefficients      */
+  __I  uint32_t  RESERVED5[2];
+  FICR_NFC_Type NFC;                                /*!< Unspecified                                                           */
+} NRF_FICR_Type;
+
+
+/* ================================================================================ */
+/* ================                      UICR                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief User Information Configuration Registers (UICR)
+  */
+
+typedef struct {                                    /*!< UICR Structure                                                        */
+  __IO uint32_t  UNUSED0;                           /*!< Unspecified                                                           */
+  __IO uint32_t  UNUSED1;                           /*!< Unspecified                                                           */
+  __IO uint32_t  UNUSED2;                           /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED0;
+  __IO uint32_t  UNUSED3;                           /*!< Unspecified                                                           */
+  __IO uint32_t  NRFFW[15];                         /*!< Description collection[0]: Reserved for Nordic firmware design        */
+  __IO uint32_t  NRFHW[12];                         /*!< Description collection[0]: Reserved for Nordic hardware design        */
+  __IO uint32_t  CUSTOMER[32];                      /*!< Description collection[0]: Reserved for customer                      */
+  __I  uint32_t  RESERVED1[64];
+  __IO uint32_t  PSELRESET[2];                      /*!< Description collection[0]: Mapping of the nRESET function (see
+                                                         POWER chapter for details)                                            */
+  __IO uint32_t  APPROTECT;                         /*!< Access port protection                                                */
+  __IO uint32_t  NFCPINS;                           /*!< Setting of pins dedicated to NFC functionality: NFC antenna
+                                                         or GPIO                                                               */
+} NRF_UICR_Type;
+
+
+/* ================================================================================ */
+/* ================                      BPROT                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Block Protect (BPROT)
+  */
+
+typedef struct {                                    /*!< BPROT Structure                                                       */
+  __I  uint32_t  RESERVED0[384];
+  __IO uint32_t  CONFIG0;                           /*!< Block protect configuration register 0                                */
+  __IO uint32_t  CONFIG1;                           /*!< Block protect configuration register 1                                */
+  __IO uint32_t  DISABLEINDEBUG;                    /*!< Disable protection mechanism in debug mode                            */
+  __IO uint32_t  UNUSED0;                           /*!< Unspecified                                                           */
+  __IO uint32_t  CONFIG2;                           /*!< Block protect configuration register 2                                */
+  __IO uint32_t  CONFIG3;                           /*!< Block protect configuration register 3                                */
+} NRF_BPROT_Type;
+
+
+/* ================================================================================ */
+/* ================                      POWER                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Power control (POWER)
+  */
+
+typedef struct {                                    /*!< POWER Structure                                                       */
+  __I  uint32_t  RESERVED0[30];
+  __O  uint32_t  TASKS_CONSTLAT;                    /*!< Enable constant latency mode                                          */
+  __O  uint32_t  TASKS_LOWPWR;                      /*!< Enable low power mode (variable latency)                              */
+  __I  uint32_t  RESERVED1[34];
+  __IO uint32_t  EVENTS_POFWARN;                    /*!< Power failure warning                                                 */
+  __I  uint32_t  RESERVED2[2];
+  __IO uint32_t  EVENTS_SLEEPENTER;                 /*!< CPU entered WFI/WFE sleep                                             */
+  __IO uint32_t  EVENTS_SLEEPEXIT;                  /*!< CPU exited WFI/WFE sleep                                              */
+  __I  uint32_t  RESERVED3[122];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED4[61];
+  __IO uint32_t  RESETREAS;                         /*!< Reset reason                                                          */
+  __I  uint32_t  RESERVED5[9];
+  __I  uint32_t  RAMSTATUS;                         /*!< Deprecated register - RAM status register                             */
+  __I  uint32_t  RESERVED6[53];
+  __O  uint32_t  SYSTEMOFF;                         /*!< System OFF register                                                   */
+  __I  uint32_t  RESERVED7[3];
+  __IO uint32_t  POFCON;                            /*!< Power failure comparator configuration                                */
+  __I  uint32_t  RESERVED8[2];
+  __IO uint32_t  GPREGRET;                          /*!< General purpose retention register                                    */
+  __IO uint32_t  GPREGRET2;                         /*!< General purpose retention register                                    */
+  __IO uint32_t  RAMON;                             /*!< Deprecated register - RAM on/off register (this register is
+                                                         retained)                                                             */
+  __I  uint32_t  RESERVED9[11];
+  __IO uint32_t  RAMONB;                            /*!< Deprecated register - RAM on/off register (this register is
+                                                         retained)                                                             */
+  __I  uint32_t  RESERVED10[8];
+  __IO uint32_t  DCDCEN;                            /*!< DC/DC enable register                                                 */
+  __I  uint32_t  RESERVED11[225];
+  POWER_RAM_Type RAM[8];                            /*!< Unspecified                                                           */
+} NRF_POWER_Type;
+
+
+/* ================================================================================ */
+/* ================                      CLOCK                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Clock control (CLOCK)
+  */
+
+typedef struct {                                    /*!< CLOCK Structure                                                       */
+  __O  uint32_t  TASKS_HFCLKSTART;                  /*!< Start HFCLK crystal oscillator                                        */
+  __O  uint32_t  TASKS_HFCLKSTOP;                   /*!< Stop HFCLK crystal oscillator                                         */
+  __O  uint32_t  TASKS_LFCLKSTART;                  /*!< Start LFCLK source                                                    */
+  __O  uint32_t  TASKS_LFCLKSTOP;                   /*!< Stop LFCLK source                                                     */
+  __O  uint32_t  TASKS_CAL;                         /*!< Start calibration of LFRC or LFULP oscillator                         */
+  __O  uint32_t  TASKS_CTSTART;                     /*!< Start calibration timer                                               */
+  __O  uint32_t  TASKS_CTSTOP;                      /*!< Stop calibration timer                                                */
+  __I  uint32_t  RESERVED0[57];
+  __IO uint32_t  EVENTS_HFCLKSTARTED;               /*!< HFCLK oscillator started                                              */
+  __IO uint32_t  EVENTS_LFCLKSTARTED;               /*!< LFCLK started                                                         */
+  __I  uint32_t  RESERVED1;
+  __IO uint32_t  EVENTS_DONE;                       /*!< Calibration of LFCLK RC oscillator complete event                     */
+  __IO uint32_t  EVENTS_CTTO;                       /*!< Calibration timer timeout                                             */
+  __I  uint32_t  RESERVED2[124];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED3[63];
+  __I  uint32_t  HFCLKRUN;                          /*!< Status indicating that HFCLKSTART task has been triggered             */
+  __I  uint32_t  HFCLKSTAT;                         /*!< HFCLK status                                                          */
+  __I  uint32_t  RESERVED4;
+  __I  uint32_t  LFCLKRUN;                          /*!< Status indicating that LFCLKSTART task has been triggered             */
+  __I  uint32_t  LFCLKSTAT;                         /*!< LFCLK status                                                          */
+  __I  uint32_t  LFCLKSRCCOPY;                      /*!< Copy of LFCLKSRC register, set when LFCLKSTART task was triggered     */
+  __I  uint32_t  RESERVED5[62];
+  __IO uint32_t  LFCLKSRC;                          /*!< Clock source for the LFCLK                                            */
+  __I  uint32_t  RESERVED6[7];
+  __IO uint32_t  CTIV;                              /*!< Calibration timer interval (retained register, same reset behaviour
+                                                         as RESETREAS)                                                         */
+  __I  uint32_t  RESERVED7[8];
+  __IO uint32_t  TRACECONFIG;                       /*!< Clocking options for the Trace Port debug interface                   */
+} NRF_CLOCK_Type;
+
+
+/* ================================================================================ */
+/* ================                      RADIO                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief 2.4 GHz Radio (RADIO)
+  */
+
+typedef struct {                                    /*!< RADIO Structure                                                       */
+  __O  uint32_t  TASKS_TXEN;                        /*!< Enable RADIO in TX mode                                               */
+  __O  uint32_t  TASKS_RXEN;                        /*!< Enable RADIO in RX mode                                               */
+  __O  uint32_t  TASKS_START;                       /*!< Start RADIO                                                           */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop RADIO                                                            */
+  __O  uint32_t  TASKS_DISABLE;                     /*!< Disable RADIO                                                         */
+  __O  uint32_t  TASKS_RSSISTART;                   /*!< Start the RSSI and take one single sample of the receive signal
+                                                         strength.                                                             */
+  __O  uint32_t  TASKS_RSSISTOP;                    /*!< Stop the RSSI measurement                                             */
+  __O  uint32_t  TASKS_BCSTART;                     /*!< Start the bit counter                                                 */
+  __O  uint32_t  TASKS_BCSTOP;                      /*!< Stop the bit counter                                                  */
+  __I  uint32_t  RESERVED0[55];
+  __IO uint32_t  EVENTS_READY;                      /*!< RADIO has ramped up and is ready to be started                        */
+  __IO uint32_t  EVENTS_ADDRESS;                    /*!< Address sent or received                                              */
+  __IO uint32_t  EVENTS_PAYLOAD;                    /*!< Packet payload sent or received                                       */
+  __IO uint32_t  EVENTS_END;                        /*!< Packet sent or received                                               */
+  __IO uint32_t  EVENTS_DISABLED;                   /*!< RADIO has been disabled                                               */
+  __IO uint32_t  EVENTS_DEVMATCH;                   /*!< A device address match occurred on the last received packet           */
+  __IO uint32_t  EVENTS_DEVMISS;                    /*!< No device address match occurred on the last received packet          */
+  __IO uint32_t  EVENTS_RSSIEND;                    /*!< Sampling of receive signal strength complete.                         */
+  __I  uint32_t  RESERVED1[2];
+  __IO uint32_t  EVENTS_BCMATCH;                    /*!< Bit counter reached bit count value.                                  */
+  __I  uint32_t  RESERVED2;
+  __IO uint32_t  EVENTS_CRCOK;                      /*!< Packet received with CRC ok                                           */
+  __IO uint32_t  EVENTS_CRCERROR;                   /*!< Packet received with CRC error                                        */
+  __I  uint32_t  RESERVED3[50];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED4[64];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED5[61];
+  __I  uint32_t  CRCSTATUS;                         /*!< CRC status                                                            */
+  __I  uint32_t  RESERVED6;
+  __I  uint32_t  RXMATCH;                           /*!< Received address                                                      */
+  __I  uint32_t  RXCRC;                             /*!< CRC field of previously received packet                               */
+  __I  uint32_t  DAI;                               /*!< Device address match index                                            */
+  __I  uint32_t  RESERVED7[60];
+  __IO uint32_t  PACKETPTR;                         /*!< Packet pointer                                                        */
+  __IO uint32_t  FREQUENCY;                         /*!< Frequency                                                             */
+  __IO uint32_t  TXPOWER;                           /*!< Output power                                                          */
+  __IO uint32_t  MODE;                              /*!< Data rate and modulation                                              */
+  __IO uint32_t  PCNF0;                             /*!< Packet configuration register 0                                       */
+  __IO uint32_t  PCNF1;                             /*!< Packet configuration register 1                                       */
+  __IO uint32_t  BASE0;                             /*!< Base address 0                                                        */
+  __IO uint32_t  BASE1;                             /*!< Base address 1                                                        */
+  __IO uint32_t  PREFIX0;                           /*!< Prefixes bytes for logical addresses 0-3                              */
+  __IO uint32_t  PREFIX1;                           /*!< Prefixes bytes for logical addresses 4-7                              */
+  __IO uint32_t  TXADDRESS;                         /*!< Transmit address select                                               */
+  __IO uint32_t  RXADDRESSES;                       /*!< Receive address select                                                */
+  __IO uint32_t  CRCCNF;                            /*!< CRC configuration                                                     */
+  __IO uint32_t  CRCPOLY;                           /*!< CRC polynomial                                                        */
+  __IO uint32_t  CRCINIT;                           /*!< CRC initial value                                                     */
+  __IO uint32_t  UNUSED0;                           /*!< Unspecified                                                           */
+  __IO uint32_t  TIFS;                              /*!< Inter Frame Spacing in us                                             */
+  __I  uint32_t  RSSISAMPLE;                        /*!< RSSI sample                                                           */
+  __I  uint32_t  RESERVED8;
+  __I  uint32_t  STATE;                             /*!< Current radio state                                                   */
+  __IO uint32_t  DATAWHITEIV;                       /*!< Data whitening initial value                                          */
+  __I  uint32_t  RESERVED9[2];
+  __IO uint32_t  BCC;                               /*!< Bit counter compare                                                   */
+  __I  uint32_t  RESERVED10[39];
+  __IO uint32_t  DAB[8];                            /*!< Description collection[0]: Device address base segment 0              */
+  __IO uint32_t  DAP[8];                            /*!< Description collection[0]: Device address prefix 0                    */
+  __IO uint32_t  DACNF;                             /*!< Device address match configuration                                    */
+  __I  uint32_t  RESERVED11[3];
+  __IO uint32_t  MODECNF0;                          /*!< Radio mode configuration register 0                                   */
+  __I  uint32_t  RESERVED12[618];
+  __IO uint32_t  POWER;                             /*!< Peripheral power control                                              */
+} NRF_RADIO_Type;
+
+
+/* ================================================================================ */
+/* ================                      UARTE                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief UART with EasyDMA (UARTE)
+  */
+
+typedef struct {                                    /*!< UARTE Structure                                                       */
+  __O  uint32_t  TASKS_STARTRX;                     /*!< Start UART receiver                                                   */
+  __O  uint32_t  TASKS_STOPRX;                      /*!< Stop UART receiver                                                    */
+  __O  uint32_t  TASKS_STARTTX;                     /*!< Start UART transmitter                                                */
+  __O  uint32_t  TASKS_STOPTX;                      /*!< Stop UART transmitter                                                 */
+  __I  uint32_t  RESERVED0[7];
+  __O  uint32_t  TASKS_FLUSHRX;                     /*!< Flush RX FIFO into RX buffer                                          */
+  __I  uint32_t  RESERVED1[52];
+  __IO uint32_t  EVENTS_CTS;                        /*!< CTS is activated (set low). Clear To Send.                            */
+  __IO uint32_t  EVENTS_NCTS;                       /*!< CTS is deactivated (set high). Not Clear To Send.                     */
+  __I  uint32_t  RESERVED2[2];
+  __IO uint32_t  EVENTS_ENDRX;                      /*!< Receive buffer is filled up                                           */
+  __I  uint32_t  RESERVED3[3];
+  __IO uint32_t  EVENTS_ENDTX;                      /*!< Last TX byte transmitted                                              */
+  __IO uint32_t  EVENTS_ERROR;                      /*!< Error detected                                                        */
+  __I  uint32_t  RESERVED4[7];
+  __IO uint32_t  EVENTS_RXTO;                       /*!< Receiver timeout                                                      */
+  __I  uint32_t  RESERVED5;
+  __IO uint32_t  EVENTS_RXSTARTED;                  /*!< UART receiver has started                                             */
+  __IO uint32_t  EVENTS_TXSTARTED;                  /*!< UART transmitter has started                                          */
+  __I  uint32_t  RESERVED6;
+  __IO uint32_t  EVENTS_TXSTOPPED;                  /*!< Transmitter stopped                                                   */
+  __I  uint32_t  RESERVED7[41];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED8[63];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED9[93];
+  __IO uint32_t  ERRORSRC;                          /*!< Error source                                                          */
+  __I  uint32_t  RESERVED10[31];
+  __IO uint32_t  ENABLE;                            /*!< Enable UART                                                           */
+  __I  uint32_t  RESERVED11;
+  UARTE_PSEL_Type PSEL;                             /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED12[3];
+  __IO uint32_t  BAUDRATE;                          /*!< Baud rate                                                             */
+  __I  uint32_t  RESERVED13[3];
+  UARTE_RXD_Type RXD;                               /*!< RXD EasyDMA channel                                                   */
+  __I  uint32_t  RESERVED14;
+  UARTE_TXD_Type TXD;                               /*!< TXD EasyDMA channel                                                   */
+  __I  uint32_t  RESERVED15[7];
+  __IO uint32_t  CONFIG;                            /*!< Configuration of parity and hardware flow control                     */
+} NRF_UARTE_Type;
+
+
+/* ================================================================================ */
+/* ================                      UART                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Universal Asynchronous Receiver/Transmitter (UART)
+  */
+
+typedef struct {                                    /*!< UART Structure                                                        */
+  __O  uint32_t  TASKS_STARTRX;                     /*!< Start UART receiver                                                   */
+  __O  uint32_t  TASKS_STOPRX;                      /*!< Stop UART receiver                                                    */
+  __O  uint32_t  TASKS_STARTTX;                     /*!< Start UART transmitter                                                */
+  __O  uint32_t  TASKS_STOPTX;                      /*!< Stop UART transmitter                                                 */
+  __I  uint32_t  RESERVED0[3];
+  __O  uint32_t  TASKS_SUSPEND;                     /*!< Suspend UART                                                          */
+  __I  uint32_t  RESERVED1[56];
+  __IO uint32_t  EVENTS_CTS;                        /*!< CTS is activated (set low). Clear To Send.                            */
+  __IO uint32_t  EVENTS_NCTS;                       /*!< CTS is deactivated (set high). Not Clear To Send.                     */
+  __IO uint32_t  EVENTS_RXDRDY;                     /*!< Data received in RXD                                                  */
+  __I  uint32_t  RESERVED2[4];
+  __IO uint32_t  EVENTS_TXDRDY;                     /*!< Data sent from TXD                                                    */
+  __I  uint32_t  RESERVED3;
+  __IO uint32_t  EVENTS_ERROR;                      /*!< Error detected                                                        */
+  __I  uint32_t  RESERVED4[7];
+  __IO uint32_t  EVENTS_RXTO;                       /*!< Receiver timeout                                                      */
+  __I  uint32_t  RESERVED5[46];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED6[64];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED7[93];
+  __IO uint32_t  ERRORSRC;                          /*!< Error source                                                          */
+  __I  uint32_t  RESERVED8[31];
+  __IO uint32_t  ENABLE;                            /*!< Enable UART                                                           */
+  __I  uint32_t  RESERVED9;
+  __IO uint32_t  PSELRTS;                           /*!< Pin select for RTS                                                    */
+  __IO uint32_t  PSELTXD;                           /*!< Pin select for TXD                                                    */
+  __IO uint32_t  PSELCTS;                           /*!< Pin select for CTS                                                    */
+  __IO uint32_t  PSELRXD;                           /*!< Pin select for RXD                                                    */
+  __I  uint32_t  RXD;                               /*!< RXD register                                                          */
+  __O  uint32_t  TXD;                               /*!< TXD register                                                          */
+  __I  uint32_t  RESERVED10;
+  __IO uint32_t  BAUDRATE;                          /*!< Baud rate                                                             */
+  __I  uint32_t  RESERVED11[17];
+  __IO uint32_t  CONFIG;                            /*!< Configuration of parity and hardware flow control                     */
+} NRF_UART_Type;
+
+
+/* ================================================================================ */
+/* ================                      SPIM                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Serial Peripheral Interface Master with EasyDMA 0 (SPIM)
+  */
+
+typedef struct {                                    /*!< SPIM Structure                                                        */
+  __I  uint32_t  RESERVED0[4];
+  __O  uint32_t  TASKS_START;                       /*!< Start SPI transaction                                                 */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop SPI transaction                                                  */
+  __I  uint32_t  RESERVED1;
+  __O  uint32_t  TASKS_SUSPEND;                     /*!< Suspend SPI transaction                                               */
+  __O  uint32_t  TASKS_RESUME;                      /*!< Resume SPI transaction                                                */
+  __I  uint32_t  RESERVED2[56];
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< SPI transaction has stopped                                           */
+  __I  uint32_t  RESERVED3[2];
+  __IO uint32_t  EVENTS_ENDRX;                      /*!< End of RXD buffer reached                                             */
+  __I  uint32_t  RESERVED4;
+  __IO uint32_t  EVENTS_END;                        /*!< End of RXD buffer and TXD buffer reached                              */
+  __I  uint32_t  RESERVED5;
+  __IO uint32_t  EVENTS_ENDTX;                      /*!< End of TXD buffer reached                                             */
+  __I  uint32_t  RESERVED6[10];
+  __IO uint32_t  EVENTS_STARTED;                    /*!< Transaction started                                                   */
+  __I  uint32_t  RESERVED7[44];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED8[64];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED9[125];
+  __IO uint32_t  ENABLE;                            /*!< Enable SPIM                                                           */
+  __I  uint32_t  RESERVED10;
+  SPIM_PSEL_Type PSEL;                              /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED11[4];
+  __IO uint32_t  FREQUENCY;                         /*!< SPI frequency                                                         */
+  __I  uint32_t  RESERVED12[3];
+  SPIM_RXD_Type RXD;                                /*!< RXD EasyDMA channel                                                   */
+  SPIM_TXD_Type TXD;                                /*!< TXD EasyDMA channel                                                   */
+  __IO uint32_t  CONFIG;                            /*!< Configuration register                                                */
+  __I  uint32_t  RESERVED13[26];
+  __IO uint32_t  ORC;                               /*!< Over-read character. Character clocked out in case and over-read
+                                                         of the TXD buffer.                                                    */
+} NRF_SPIM_Type;
+
+
+/* ================================================================================ */
+/* ================                      SPIS                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief SPI Slave 0 (SPIS)
+  */
+
+typedef struct {                                    /*!< SPIS Structure                                                        */
+  __I  uint32_t  RESERVED0[9];
+  __O  uint32_t  TASKS_ACQUIRE;                     /*!< Acquire SPI semaphore                                                 */
+  __O  uint32_t  TASKS_RELEASE;                     /*!< Release SPI semaphore, enabling the SPI slave to acquire it           */
+  __I  uint32_t  RESERVED1[54];
+  __IO uint32_t  EVENTS_END;                        /*!< Granted transaction completed                                         */
+  __I  uint32_t  RESERVED2[2];
+  __IO uint32_t  EVENTS_ENDRX;                      /*!< End of RXD buffer reached                                             */
+  __I  uint32_t  RESERVED3[5];
+  __IO uint32_t  EVENTS_ACQUIRED;                   /*!< Semaphore acquired                                                    */
+  __I  uint32_t  RESERVED4[53];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED5[64];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED6[61];
+  __I  uint32_t  SEMSTAT;                           /*!< Semaphore status register                                             */
+  __I  uint32_t  RESERVED7[15];
+  __IO uint32_t  STATUS;                            /*!< Status from last transaction                                          */
+  __I  uint32_t  RESERVED8[47];
+  __IO uint32_t  ENABLE;                            /*!< Enable SPI slave                                                      */
+  __I  uint32_t  RESERVED9;
+  SPIS_PSEL_Type PSEL;                              /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED10[7];
+  SPIS_RXD_Type RXD;                                /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED11;
+  SPIS_TXD_Type TXD;                                /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED12;
+  __IO uint32_t  CONFIG;                            /*!< Configuration register                                                */
+  __I  uint32_t  RESERVED13;
+  __IO uint32_t  DEF;                               /*!< Default character. Character clocked out in case of an ignored
+                                                         transaction.                                                          */
+  __I  uint32_t  RESERVED14[24];
+  __IO uint32_t  ORC;                               /*!< Over-read character                                                   */
+} NRF_SPIS_Type;
+
+
+/* ================================================================================ */
+/* ================                      TWIM                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief I2C compatible Two-Wire Master Interface with EasyDMA 0 (TWIM)
+  */
+
+typedef struct {                                    /*!< TWIM Structure                                                        */
+  __O  uint32_t  TASKS_STARTRX;                     /*!< Start TWI receive sequence                                            */
+  __I  uint32_t  RESERVED0;
+  __O  uint32_t  TASKS_STARTTX;                     /*!< Start TWI transmit sequence                                           */
+  __I  uint32_t  RESERVED1[2];
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop TWI transaction                                                  */
+  __I  uint32_t  RESERVED2;
+  __O  uint32_t  TASKS_SUSPEND;                     /*!< Suspend TWI transaction                                               */
+  __O  uint32_t  TASKS_RESUME;                      /*!< Resume TWI transaction                                                */
+  __I  uint32_t  RESERVED3[56];
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< TWI stopped                                                           */
+  __I  uint32_t  RESERVED4[7];
+  __IO uint32_t  EVENTS_ERROR;                      /*!< TWI error                                                             */
+  __I  uint32_t  RESERVED5[9];
+  __IO uint32_t  EVENTS_RXSTARTED;                  /*!< Receive sequence started                                              */
+  __IO uint32_t  EVENTS_TXSTARTED;                  /*!< Transmit sequence started                                             */
+  __I  uint32_t  RESERVED6[2];
+  __IO uint32_t  EVENTS_LASTRX;                     /*!< Byte boundary, starting to receive the last byte                      */
+  __IO uint32_t  EVENTS_LASTTX;                     /*!< Byte boundary, starting to transmit the last byte                     */
+  __I  uint32_t  RESERVED7[39];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED8[63];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED9[110];
+  __IO uint32_t  ERRORSRC;                          /*!< Error source                                                          */
+  __I  uint32_t  RESERVED10[14];
+  __IO uint32_t  ENABLE;                            /*!< Enable TWIM                                                           */
+  __I  uint32_t  RESERVED11;
+  TWIM_PSEL_Type PSEL;                              /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED12[5];
+  __IO uint32_t  FREQUENCY;                         /*!< TWI frequency                                                         */
+  __I  uint32_t  RESERVED13[3];
+  TWIM_RXD_Type RXD;                                /*!< RXD EasyDMA channel                                                   */
+  TWIM_TXD_Type TXD;                                /*!< TXD EasyDMA channel                                                   */
+  __I  uint32_t  RESERVED14[13];
+  __IO uint32_t  ADDRESS;                           /*!< Address used in the TWI transfer                                      */
+} NRF_TWIM_Type;
+
+
+/* ================================================================================ */
+/* ================                      TWIS                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief I2C compatible Two-Wire Slave Interface with EasyDMA 0 (TWIS)
+  */
+
+typedef struct {                                    /*!< TWIS Structure                                                        */
+  __I  uint32_t  RESERVED0[5];
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop TWI transaction                                                  */
+  __I  uint32_t  RESERVED1;
+  __O  uint32_t  TASKS_SUSPEND;                     /*!< Suspend TWI transaction                                               */
+  __O  uint32_t  TASKS_RESUME;                      /*!< Resume TWI transaction                                                */
+  __I  uint32_t  RESERVED2[3];
+  __O  uint32_t  TASKS_PREPARERX;                   /*!< Prepare the TWI slave to respond to a write command                   */
+  __O  uint32_t  TASKS_PREPARETX;                   /*!< Prepare the TWI slave to respond to a read command                    */
+  __I  uint32_t  RESERVED3[51];
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< TWI stopped                                                           */
+  __I  uint32_t  RESERVED4[7];
+  __IO uint32_t  EVENTS_ERROR;                      /*!< TWI error                                                             */
+  __I  uint32_t  RESERVED5[9];
+  __IO uint32_t  EVENTS_RXSTARTED;                  /*!< Receive sequence started                                              */
+  __IO uint32_t  EVENTS_TXSTARTED;                  /*!< Transmit sequence started                                             */
+  __I  uint32_t  RESERVED6[4];
+  __IO uint32_t  EVENTS_WRITE;                      /*!< Write command received                                                */
+  __IO uint32_t  EVENTS_READ;                       /*!< Read command received                                                 */
+  __I  uint32_t  RESERVED7[37];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED8[63];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED9[113];
+  __IO uint32_t  ERRORSRC;                          /*!< Error source                                                          */
+  __I  uint32_t  MATCH;                             /*!< Status register indicating which address had a match                  */
+  __I  uint32_t  RESERVED10[10];
+  __IO uint32_t  ENABLE;                            /*!< Enable TWIS                                                           */
+  __I  uint32_t  RESERVED11;
+  TWIS_PSEL_Type PSEL;                              /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED12[9];
+  TWIS_RXD_Type RXD;                                /*!< RXD EasyDMA channel                                                   */
+  __I  uint32_t  RESERVED13;
+  TWIS_TXD_Type TXD;                                /*!< TXD EasyDMA channel                                                   */
+  __I  uint32_t  RESERVED14[14];
+  __IO uint32_t  ADDRESS[2];                        /*!< Description collection[0]: TWI slave address 0                        */
+  __I  uint32_t  RESERVED15;
+  __IO uint32_t  CONFIG;                            /*!< Configuration register for the address match mechanism                */
+  __I  uint32_t  RESERVED16[10];
+  __IO uint32_t  ORC;                               /*!< Over-read character. Character sent out in case of an over-read
+                                                         of the transmit buffer.                                               */
+} NRF_TWIS_Type;
+
+
+/* ================================================================================ */
+/* ================                       SPI                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Serial Peripheral Interface 0 (SPI)
+  */
+
+typedef struct {                                    /*!< SPI Structure                                                         */
+  __I  uint32_t  RESERVED0[66];
+  __IO uint32_t  EVENTS_READY;                      /*!< TXD byte sent and RXD byte received                                   */
+  __I  uint32_t  RESERVED1[126];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED2[125];
+  __IO uint32_t  ENABLE;                            /*!< Enable SPI                                                            */
+  __I  uint32_t  RESERVED3;
+  SPI_PSEL_Type PSEL;                               /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED4;
+  __I  uint32_t  RXD;                               /*!< RXD register                                                          */
+  __IO uint32_t  TXD;                               /*!< TXD register                                                          */
+  __I  uint32_t  RESERVED5;
+  __IO uint32_t  FREQUENCY;                         /*!< SPI frequency                                                         */
+  __I  uint32_t  RESERVED6[11];
+  __IO uint32_t  CONFIG;                            /*!< Configuration register                                                */
+} NRF_SPI_Type;
+
+
+/* ================================================================================ */
+/* ================                       TWI                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief I2C compatible Two-Wire Interface 0 (TWI)
+  */
+
+typedef struct {                                    /*!< TWI Structure                                                         */
+  __O  uint32_t  TASKS_STARTRX;                     /*!< Start TWI receive sequence                                            */
+  __I  uint32_t  RESERVED0;
+  __O  uint32_t  TASKS_STARTTX;                     /*!< Start TWI transmit sequence                                           */
+  __I  uint32_t  RESERVED1[2];
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop TWI transaction                                                  */
+  __I  uint32_t  RESERVED2;
+  __O  uint32_t  TASKS_SUSPEND;                     /*!< Suspend TWI transaction                                               */
+  __O  uint32_t  TASKS_RESUME;                      /*!< Resume TWI transaction                                                */
+  __I  uint32_t  RESERVED3[56];
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< TWI stopped                                                           */
+  __IO uint32_t  EVENTS_RXDREADY;                   /*!< TWI RXD byte received                                                 */
+  __I  uint32_t  RESERVED4[4];
+  __IO uint32_t  EVENTS_TXDSENT;                    /*!< TWI TXD byte sent                                                     */
+  __I  uint32_t  RESERVED5;
+  __IO uint32_t  EVENTS_ERROR;                      /*!< TWI error                                                             */
+  __I  uint32_t  RESERVED6[4];
+  __IO uint32_t  EVENTS_BB;                         /*!< TWI byte boundary, generated before each byte that is sent or
+                                                         received                                                              */
+  __I  uint32_t  RESERVED7[3];
+  __IO uint32_t  EVENTS_SUSPENDED;                  /*!< TWI entered the suspended state                                       */
+  __I  uint32_t  RESERVED8[45];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED9[64];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED10[110];
+  __IO uint32_t  ERRORSRC;                          /*!< Error source                                                          */
+  __I  uint32_t  RESERVED11[14];
+  __IO uint32_t  ENABLE;                            /*!< Enable TWI                                                            */
+  __I  uint32_t  RESERVED12;
+  __IO uint32_t  PSELSCL;                           /*!< Pin select for SCL                                                    */
+  __IO uint32_t  PSELSDA;                           /*!< Pin select for SDA                                                    */
+  __I  uint32_t  RESERVED13[2];
+  __I  uint32_t  RXD;                               /*!< RXD register                                                          */
+  __IO uint32_t  TXD;                               /*!< TXD register                                                          */
+  __I  uint32_t  RESERVED14;
+  __IO uint32_t  FREQUENCY;                         /*!< TWI frequency                                                         */
+  __I  uint32_t  RESERVED15[24];
+  __IO uint32_t  ADDRESS;                           /*!< Address used in the TWI transfer                                      */
+} NRF_TWI_Type;
+
+
+/* ================================================================================ */
+/* ================                      NFCT                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief NFC-A compatible radio (NFCT)
+  */
+
+typedef struct {                                    /*!< NFCT Structure                                                        */
+  __O  uint32_t  TASKS_ACTIVATE;                    /*!< Activate NFC peripheral for incoming and outgoing frames, change
+                                                         state to activated                                                    */
+  __O  uint32_t  TASKS_DISABLE;                     /*!< Disable NFC peripheral                                                */
+  __O  uint32_t  TASKS_SENSE;                       /*!< Enable NFC sense field mode, change state to sense mode               */
+  __O  uint32_t  TASKS_STARTTX;                     /*!< Start transmission of a outgoing frame, change state to transmit      */
+  __I  uint32_t  RESERVED0[3];
+  __O  uint32_t  TASKS_ENABLERXDATA;                /*!< Initializes the EasyDMA for receive.                                  */
+  __I  uint32_t  RESERVED1;
+  __O  uint32_t  TASKS_GOIDLE;                      /*!< Force state machine to IDLE state                                     */
+  __O  uint32_t  TASKS_GOSLEEP;                     /*!< Force state machine to SLEEP_A state                                  */
+  __I  uint32_t  RESERVED2[53];
+  __IO uint32_t  EVENTS_READY;                      /*!< The NFC peripheral is ready to receive and send frames                */
+  __IO uint32_t  EVENTS_FIELDDETECTED;              /*!< Remote NFC field detected                                             */
+  __IO uint32_t  EVENTS_FIELDLOST;                  /*!< Remote NFC field lost                                                 */
+  __IO uint32_t  EVENTS_TXFRAMESTART;               /*!< Marks the start of the first symbol of a transmitted frame            */
+  __IO uint32_t  EVENTS_TXFRAMEEND;                 /*!< Marks the end of the last transmitted on-air symbol of a frame        */
+  __IO uint32_t  EVENTS_RXFRAMESTART;               /*!< Marks the end of the first symbol of a received frame                 */
+  __IO uint32_t  EVENTS_RXFRAMEEND;                 /*!< Received data have been checked (CRC, parity) and transferred
+                                                         to RAM, and EasyDMA has ended accessing the RX buffer                 */
+  __IO uint32_t  EVENTS_ERROR;                      /*!< NFC error reported. The ERRORSTATUS register contains details
+                                                         on the source of the error.                                           */
+  __I  uint32_t  RESERVED3[2];
+  __IO uint32_t  EVENTS_RXERROR;                    /*!< NFC RX frame error reported. The FRAMESTATUS.RX register contains
+                                                         details on the source of the error.                                   */
+  __IO uint32_t  EVENTS_ENDRX;                      /*!< RX buffer (as defined by PACKETPTR and MAXLEN) in Data RAM full.      */
+  __IO uint32_t  EVENTS_ENDTX;                      /*!< Transmission of data in RAM has ended, and EasyDMA has ended
+                                                         accessing the TX buffer                                               */
+  __I  uint32_t  RESERVED4;
+  __IO uint32_t  EVENTS_AUTOCOLRESSTARTED;          /*!< Auto collision resolution process has started                         */
+  __I  uint32_t  RESERVED5[3];
+  __IO uint32_t  EVENTS_COLLISION;                  /*!< NFC Auto collision resolution error reported.                         */
+  __IO uint32_t  EVENTS_SELECTED;                   /*!< NFC Auto collision resolution successfully completed                  */
+  __IO uint32_t  EVENTS_STARTED;                    /*!< EasyDMA is ready to receive or send frames.                           */
+  __I  uint32_t  RESERVED6[43];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED7[63];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED8[62];
+  __IO uint32_t  ERRORSTATUS;                       /*!< NFC Error Status register                                             */
+  __I  uint32_t  RESERVED9;
+  NFCT_FRAMESTATUS_Type FRAMESTATUS;                /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED10[8];
+  __I  uint32_t  CURRENTLOADCTRL;                   /*!< Current value driven to the NFC Load Control                          */
+  __I  uint32_t  RESERVED11[2];
+  __I  uint32_t  FIELDPRESENT;                      /*!< Indicates the presence or not of a valid field                        */
+  __I  uint32_t  RESERVED12[49];
+  __IO uint32_t  FRAMEDELAYMIN;                     /*!< Minimum frame delay                                                   */
+  __IO uint32_t  FRAMEDELAYMAX;                     /*!< Maximum frame delay                                                   */
+  __IO uint32_t  FRAMEDELAYMODE;                    /*!< Configuration register for the Frame Delay Timer                      */
+  __IO uint32_t  PACKETPTR;                         /*!< Packet pointer for TXD and RXD data storage in Data RAM               */
+  __IO uint32_t  MAXLEN;                            /*!< Size of allocated for TXD and RXD data storage buffer in Data
+                                                         RAM                                                                   */
+  NFCT_TXD_Type TXD;                                /*!< Unspecified                                                           */
+  NFCT_RXD_Type RXD;                                /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED13[26];
+  __IO uint32_t  NFCID1_LAST;                       /*!< Last NFCID1 part (4, 7 or 10 bytes ID)                                */
+  __IO uint32_t  NFCID1_2ND_LAST;                   /*!< Second last NFCID1 part (7 or 10 bytes ID)                            */
+  __IO uint32_t  NFCID1_3RD_LAST;                   /*!< Third last NFCID1 part (10 bytes ID)                                  */
+  __I  uint32_t  RESERVED14;
+  __IO uint32_t  SENSRES;                           /*!< NFC-A SENS_RES auto-response settings                                 */
+  __IO uint32_t  SELRES;                            /*!< NFC-A SEL_RES auto-response settings                                  */
+} NRF_NFCT_Type;
+
+
+/* ================================================================================ */
+/* ================                     GPIOTE                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief GPIO Tasks and Events (GPIOTE)
+  */
+
+typedef struct {                                    /*!< GPIOTE Structure                                                      */
+  __O  uint32_t  TASKS_OUT[8];                      /*!< Description collection[0]: Task for writing to pin specified
+                                                         in CONFIG[0].PSEL. Action on pin is configured in CONFIG[0].POLARITY. */
+  __I  uint32_t  RESERVED0[4];
+  __O  uint32_t  TASKS_SET[8];                      /*!< Description collection[0]: Task for writing to pin specified
+                                                         in CONFIG[0].PSEL. Action on pin is to set it high.                   */
+  __I  uint32_t  RESERVED1[4];
+  __O  uint32_t  TASKS_CLR[8];                      /*!< Description collection[0]: Task for writing to pin specified
+                                                         in CONFIG[0].PSEL. Action on pin is to set it low.                    */
+  __I  uint32_t  RESERVED2[32];
+  __IO uint32_t  EVENTS_IN[8];                      /*!< Description collection[0]: Event generated from pin specified
+                                                         in CONFIG[0].PSEL                                                     */
+  __I  uint32_t  RESERVED3[23];
+  __IO uint32_t  EVENTS_PORT;                       /*!< Event generated from multiple input GPIO pins with SENSE mechanism
+                                                         enabled                                                               */
+  __I  uint32_t  RESERVED4[97];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED5[129];
+  __IO uint32_t  CONFIG[8];                         /*!< Description collection[0]: Configuration for OUT[n], SET[n]
+                                                         and CLR[n] tasks and IN[n] event                                      */
+} NRF_GPIOTE_Type;
+
+
+/* ================================================================================ */
+/* ================                      SAADC                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Analog to Digital Converter (SAADC)
+  */
+
+typedef struct {                                    /*!< SAADC Structure                                                       */
+  __O  uint32_t  TASKS_START;                       /*!< Start the ADC and prepare the result buffer in RAM                    */
+  __O  uint32_t  TASKS_SAMPLE;                      /*!< Take one ADC sample, if scan is enabled all channels are sampled      */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop the ADC and terminate any on-going conversion                    */
+  __O  uint32_t  TASKS_CALIBRATEOFFSET;             /*!< Starts offset auto-calibration                                        */
+  __I  uint32_t  RESERVED0[60];
+  __IO uint32_t  EVENTS_STARTED;                    /*!< The ADC has started                                                   */
+  __IO uint32_t  EVENTS_END;                        /*!< The ADC has filled up the Result buffer                               */
+  __IO uint32_t  EVENTS_DONE;                       /*!< A conversion task has been completed. Depending on the mode,
+                                                         multiple conversions might be needed for a result to be transferred
+                                                          to RAM.                                                              */
+  __IO uint32_t  EVENTS_RESULTDONE;                 /*!< A result is ready to get transferred to RAM.                          */
+  __IO uint32_t  EVENTS_CALIBRATEDONE;              /*!< Calibration is complete                                               */
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< The ADC has stopped                                                   */
+  SAADC_EVENTS_CH_Type EVENTS_CH[8];                /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED1[106];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED2[61];
+  __I  uint32_t  STATUS;                            /*!< Status                                                                */
+  __I  uint32_t  RESERVED3[63];
+  __IO uint32_t  ENABLE;                            /*!< Enable or disable ADC                                                 */
+  __I  uint32_t  RESERVED4[3];
+  SAADC_CH_Type CH[8];                              /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED5[24];
+  __IO uint32_t  RESOLUTION;                        /*!< Resolution configuration                                              */
+  __IO uint32_t  OVERSAMPLE;                        /*!< Oversampling configuration. OVERSAMPLE should not be combined
+                                                         with SCAN. The RESOLUTION is applied before averaging, thus
+                                                          for high OVERSAMPLE a higher RESOLUTION should be used.              */
+  __IO uint32_t  SAMPLERATE;                        /*!< Controls normal or continuous sample rate                             */
+  __I  uint32_t  RESERVED6[12];
+  SAADC_RESULT_Type RESULT;                         /*!< RESULT EasyDMA channel                                                */
+} NRF_SAADC_Type;
+
+
+/* ================================================================================ */
+/* ================                      TIMER                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Timer/Counter 0 (TIMER)
+  */
+
+typedef struct {                                    /*!< TIMER Structure                                                       */
+  __O  uint32_t  TASKS_START;                       /*!< Start Timer                                                           */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop Timer                                                            */
+  __O  uint32_t  TASKS_COUNT;                       /*!< Increment Timer (Counter mode only)                                   */
+  __O  uint32_t  TASKS_CLEAR;                       /*!< Clear time                                                            */
+  __O  uint32_t  TASKS_SHUTDOWN;                    /*!< Shut down timer                                                       */
+  __I  uint32_t  RESERVED0[11];
+  __O  uint32_t  TASKS_CAPTURE[6];                  /*!< Description collection[0]: Capture Timer value to CC[0] register      */
+  __I  uint32_t  RESERVED1[58];
+  __IO uint32_t  EVENTS_COMPARE[6];                 /*!< Description collection[0]: Compare event on CC[0] match               */
+  __I  uint32_t  RESERVED2[42];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED3[64];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED4[126];
+  __IO uint32_t  MODE;                              /*!< Timer mode selection                                                  */
+  __IO uint32_t  BITMODE;                           /*!< Configure the number of bits used by the TIMER                        */
+  __I  uint32_t  RESERVED5;
+  __IO uint32_t  PRESCALER;                         /*!< Timer prescaler register                                              */
+  __I  uint32_t  RESERVED6[11];
+  __IO uint32_t  CC[6];                             /*!< Description collection[0]: Capture/Compare register 0                 */
+} NRF_TIMER_Type;
+
+
+/* ================================================================================ */
+/* ================                       RTC                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Real time counter 0 (RTC)
+  */
+
+typedef struct {                                    /*!< RTC Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Start RTC COUNTER                                                     */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop RTC COUNTER                                                      */
+  __O  uint32_t  TASKS_CLEAR;                       /*!< Clear RTC COUNTER                                                     */
+  __O  uint32_t  TASKS_TRIGOVRFLW;                  /*!< Set COUNTER to 0xFFFFF0                                               */
+  __I  uint32_t  RESERVED0[60];
+  __IO uint32_t  EVENTS_TICK;                       /*!< Event on COUNTER increment                                            */
+  __IO uint32_t  EVENTS_OVRFLW;                     /*!< Event on COUNTER overflow                                             */
+  __I  uint32_t  RESERVED1[14];
+  __IO uint32_t  EVENTS_COMPARE[4];                 /*!< Description collection[0]: Compare event on CC[0] match               */
+  __I  uint32_t  RESERVED2[109];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED3[13];
+  __IO uint32_t  EVTEN;                             /*!< Enable or disable event routing                                       */
+  __IO uint32_t  EVTENSET;                          /*!< Enable event routing                                                  */
+  __IO uint32_t  EVTENCLR;                          /*!< Disable event routing                                                 */
+  __I  uint32_t  RESERVED4[110];
+  __I  uint32_t  COUNTER;                           /*!< Current COUNTER value                                                 */
+  __IO uint32_t  PRESCALER;                         /*!< 12 bit prescaler for COUNTER frequency (32768/(PRESCALER+1)).Must
+                                                         be written when RTC is stopped                                        */
+  __I  uint32_t  RESERVED5[13];
+  __IO uint32_t  CC[4];                             /*!< Description collection[0]: Compare register 0                         */
+} NRF_RTC_Type;
+
+
+/* ================================================================================ */
+/* ================                      TEMP                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Temperature Sensor (TEMP)
+  */
+
+typedef struct {                                    /*!< TEMP Structure                                                        */
+  __O  uint32_t  TASKS_START;                       /*!< Start temperature measurement                                         */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop temperature measurement                                          */
+  __I  uint32_t  RESERVED0[62];
+  __IO uint32_t  EVENTS_DATARDY;                    /*!< Temperature measurement complete, data ready                          */
+  __I  uint32_t  RESERVED1[128];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED2[127];
+  __I  int32_t   TEMP;                              /*!< Temperature in degC (0.25deg steps)                                   */
+  __I  uint32_t  RESERVED3[5];
+  __IO uint32_t  A0;                                /*!< Slope of 1st piece wise linear function                               */
+  __IO uint32_t  A1;                                /*!< Slope of 2nd piece wise linear function                               */
+  __IO uint32_t  A2;                                /*!< Slope of 3rd piece wise linear function                               */
+  __IO uint32_t  A3;                                /*!< Slope of 4th piece wise linear function                               */
+  __IO uint32_t  A4;                                /*!< Slope of 5th piece wise linear function                               */
+  __IO uint32_t  A5;                                /*!< Slope of 6th piece wise linear function                               */
+  __I  uint32_t  RESERVED4[2];
+  __IO uint32_t  B0;                                /*!< y-intercept of 1st piece wise linear function                         */
+  __IO uint32_t  B1;                                /*!< y-intercept of 2nd piece wise linear function                         */
+  __IO uint32_t  B2;                                /*!< y-intercept of 3rd piece wise linear function                         */
+  __IO uint32_t  B3;                                /*!< y-intercept of 4th piece wise linear function                         */
+  __IO uint32_t  B4;                                /*!< y-intercept of 5th piece wise linear function                         */
+  __IO uint32_t  B5;                                /*!< y-intercept of 6th piece wise linear function                         */
+  __I  uint32_t  RESERVED5[2];
+  __IO uint32_t  T0;                                /*!< End point of 1st piece wise linear function                           */
+  __IO uint32_t  T1;                                /*!< End point of 2nd piece wise linear function                           */
+  __IO uint32_t  T2;                                /*!< End point of 3rd piece wise linear function                           */
+  __IO uint32_t  T3;                                /*!< End point of 4th piece wise linear function                           */
+  __IO uint32_t  T4;                                /*!< End point of 5th piece wise linear function                           */
+} NRF_TEMP_Type;
+
+
+/* ================================================================================ */
+/* ================                       RNG                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Random Number Generator (RNG)
+  */
+
+typedef struct {                                    /*!< RNG Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Task starting the random number generator                             */
+  __O  uint32_t  TASKS_STOP;                        /*!< Task stopping the random number generator                             */
+  __I  uint32_t  RESERVED0[62];
+  __IO uint32_t  EVENTS_VALRDY;                     /*!< Event being generated for every new random number written to
+                                                         the VALUE register                                                    */
+  __I  uint32_t  RESERVED1[63];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED2[64];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED3[126];
+  __IO uint32_t  CONFIG;                            /*!< Configuration register                                                */
+  __I  uint32_t  VALUE;                             /*!< Output random number                                                  */
+} NRF_RNG_Type;
+
+
+/* ================================================================================ */
+/* ================                       ECB                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief AES ECB Mode Encryption (ECB)
+  */
+
+typedef struct {                                    /*!< ECB Structure                                                         */
+  __O  uint32_t  TASKS_STARTECB;                    /*!< Start ECB block encrypt                                               */
+  __O  uint32_t  TASKS_STOPECB;                     /*!< Abort a possible executing ECB operation                              */
+  __I  uint32_t  RESERVED0[62];
+  __IO uint32_t  EVENTS_ENDECB;                     /*!< ECB block encrypt complete                                            */
+  __IO uint32_t  EVENTS_ERRORECB;                   /*!< ECB block encrypt aborted because of a STOPECB task or due to
+                                                         an error                                                              */
+  __I  uint32_t  RESERVED1[127];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED2[126];
+  __IO uint32_t  ECBDATAPTR;                        /*!< ECB block encrypt memory pointers                                     */
+} NRF_ECB_Type;
+
+
+/* ================================================================================ */
+/* ================                       CCM                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief AES CCM Mode Encryption (CCM)
+  */
+
+typedef struct {                                    /*!< CCM Structure                                                         */
+  __O  uint32_t  TASKS_KSGEN;                       /*!< Start generation of key-stream. This operation will stop by
+                                                         itself when completed.                                                */
+  __O  uint32_t  TASKS_CRYPT;                       /*!< Start encryption/decryption. This operation will stop by itself
+                                                         when completed.                                                       */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop encryption/decryption                                            */
+  __I  uint32_t  RESERVED0[61];
+  __IO uint32_t  EVENTS_ENDKSGEN;                   /*!< Key-stream generation complete                                        */
+  __IO uint32_t  EVENTS_ENDCRYPT;                   /*!< Encrypt/decrypt complete                                              */
+  __IO uint32_t  EVENTS_ERROR;                      /*!< CCM error event                                                       */
+  __I  uint32_t  RESERVED1[61];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED2[64];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED3[61];
+  __I  uint32_t  MICSTATUS;                         /*!< MIC check result                                                      */
+  __I  uint32_t  RESERVED4[63];
+  __IO uint32_t  ENABLE;                            /*!< Enable                                                                */
+  __IO uint32_t  MODE;                              /*!< Operation mode                                                        */
+  __IO uint32_t  CNFPTR;                            /*!< Pointer to data structure holding AES key and NONCE vector            */
+  __IO uint32_t  INPTR;                             /*!< Input pointer                                                         */
+  __IO uint32_t  OUTPTR;                            /*!< Output pointer                                                        */
+  __IO uint32_t  SCRATCHPTR;                        /*!< Pointer to data area used for temporary storage                       */
+} NRF_CCM_Type;
+
+
+/* ================================================================================ */
+/* ================                       AAR                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Accelerated Address Resolver (AAR)
+  */
+
+typedef struct {                                    /*!< AAR Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Start resolving addresses based on IRKs specified in the IRK
+                                                         data structure                                                        */
+  __I  uint32_t  RESERVED0;
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop resolving addresses                                              */
+  __I  uint32_t  RESERVED1[61];
+  __IO uint32_t  EVENTS_END;                        /*!< Address resolution procedure complete                                 */
+  __IO uint32_t  EVENTS_RESOLVED;                   /*!< Address resolved                                                      */
+  __IO uint32_t  EVENTS_NOTRESOLVED;                /*!< Address not resolved                                                  */
+  __I  uint32_t  RESERVED2[126];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED3[61];
+  __I  uint32_t  STATUS;                            /*!< Resolution status                                                     */
+  __I  uint32_t  RESERVED4[63];
+  __IO uint32_t  ENABLE;                            /*!< Enable AAR                                                            */
+  __IO uint32_t  NIRK;                              /*!< Number of IRKs                                                        */
+  __IO uint32_t  IRKPTR;                            /*!< Pointer to IRK data structure                                         */
+  __I  uint32_t  RESERVED5;
+  __IO uint32_t  ADDRPTR;                           /*!< Pointer to the resolvable address                                     */
+  __IO uint32_t  SCRATCHPTR;                        /*!< Pointer to data area used for temporary storage                       */
+} NRF_AAR_Type;
+
+
+/* ================================================================================ */
+/* ================                       WDT                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Watchdog Timer (WDT)
+  */
+
+typedef struct {                                    /*!< WDT Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Start the watchdog                                                    */
+  __I  uint32_t  RESERVED0[63];
+  __IO uint32_t  EVENTS_TIMEOUT;                    /*!< Watchdog timeout                                                      */
+  __I  uint32_t  RESERVED1[128];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED2[61];
+  __I  uint32_t  RUNSTATUS;                         /*!< Run status                                                            */
+  __I  uint32_t  REQSTATUS;                         /*!< Request status                                                        */
+  __I  uint32_t  RESERVED3[63];
+  __IO uint32_t  CRV;                               /*!< Counter reload value                                                  */
+  __IO uint32_t  RREN;                              /*!< Enable register for reload request registers                          */
+  __IO uint32_t  CONFIG;                            /*!< Configuration register                                                */
+  __I  uint32_t  RESERVED4[60];
+  __O  uint32_t  RR[8];                             /*!< Description collection[0]: Reload request 0                           */
+} NRF_WDT_Type;
+
+
+/* ================================================================================ */
+/* ================                      QDEC                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Quadrature Decoder (QDEC)
+  */
+
+typedef struct {                                    /*!< QDEC Structure                                                        */
+  __O  uint32_t  TASKS_START;                       /*!< Task starting the quadrature decoder                                  */
+  __O  uint32_t  TASKS_STOP;                        /*!< Task stopping the quadrature decoder                                  */
+  __O  uint32_t  TASKS_READCLRACC;                  /*!< Read and clear ACC and ACCDBL                                         */
+  __O  uint32_t  TASKS_RDCLRACC;                    /*!< Read and clear ACC                                                    */
+  __O  uint32_t  TASKS_RDCLRDBL;                    /*!< Read and clear ACCDBL                                                 */
+  __I  uint32_t  RESERVED0[59];
+  __IO uint32_t  EVENTS_SAMPLERDY;                  /*!< Event being generated for every new sample value written to
+                                                         the SAMPLE register                                                   */
+  __IO uint32_t  EVENTS_REPORTRDY;                  /*!< Non-null report ready                                                 */
+  __IO uint32_t  EVENTS_ACCOF;                      /*!< ACC or ACCDBL register overflow                                       */
+  __IO uint32_t  EVENTS_DBLRDY;                     /*!< Double displacement(s) detected                                       */
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< QDEC has been stopped                                                 */
+  __I  uint32_t  RESERVED1[59];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED2[64];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED3[125];
+  __IO uint32_t  ENABLE;                            /*!< Enable the quadrature decoder                                         */
+  __IO uint32_t  LEDPOL;                            /*!< LED output pin polarity                                               */
+  __IO uint32_t  SAMPLEPER;                         /*!< Sample period                                                         */
+  __I  int32_t   SAMPLE;                            /*!< Motion sample value                                                   */
+  __IO uint32_t  REPORTPER;                         /*!< Number of samples to be taken before REPORTRDY and DBLRDY events
+                                                         can be generated                                                      */
+  __I  int32_t   ACC;                               /*!< Register accumulating the valid transitions                           */
+  __I  int32_t   ACCREAD;                           /*!< Snapshot of the ACC register, updated by the READCLRACC or RDCLRACC
+                                                         task                                                                  */
+  QDEC_PSEL_Type PSEL;                              /*!< Unspecified                                                           */
+  __IO uint32_t  DBFEN;                             /*!< Enable input debounce filters                                         */
+  __I  uint32_t  RESERVED4[5];
+  __IO uint32_t  LEDPRE;                            /*!< Time period the LED is switched ON prior to sampling                  */
+  __I  uint32_t  ACCDBL;                            /*!< Register accumulating the number of detected double transitions       */
+  __I  uint32_t  ACCDBLREAD;                        /*!< Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL
+                                                         task                                                                  */
+} NRF_QDEC_Type;
+
+
+/* ================================================================================ */
+/* ================                      COMP                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Comparator (COMP)
+  */
+
+typedef struct {                                    /*!< COMP Structure                                                        */
+  __O  uint32_t  TASKS_START;                       /*!< Start comparator                                                      */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop comparator                                                       */
+  __O  uint32_t  TASKS_SAMPLE;                      /*!< Sample comparator value                                               */
+  __I  uint32_t  RESERVED0[61];
+  __IO uint32_t  EVENTS_READY;                      /*!< COMP is ready and output is valid                                     */
+  __IO uint32_t  EVENTS_DOWN;                       /*!< Downward crossing                                                     */
+  __IO uint32_t  EVENTS_UP;                         /*!< Upward crossing                                                       */
+  __IO uint32_t  EVENTS_CROSS;                      /*!< Downward or upward crossing                                           */
+  __I  uint32_t  RESERVED1[60];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED2[63];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED3[61];
+  __I  uint32_t  RESULT;                            /*!< Compare result                                                        */
+  __I  uint32_t  RESERVED4[63];
+  __IO uint32_t  ENABLE;                            /*!< COMP enable                                                           */
+  __IO uint32_t  PSEL;                              /*!< Pin select                                                            */
+  __IO uint32_t  REFSEL;                            /*!< Reference source select                                               */
+  __IO uint32_t  EXTREFSEL;                         /*!< External reference select                                             */
+  __I  uint32_t  RESERVED5[8];
+  __IO uint32_t  TH;                                /*!< Threshold configuration for hysteresis unit                           */
+  __IO uint32_t  MODE;                              /*!< Mode configuration                                                    */
+  __IO uint32_t  HYST;                              /*!< Comparator hysteresis enable                                          */
+  __IO uint32_t  ISOURCE;                           /*!< Current source select on analog input                                 */
+} NRF_COMP_Type;
+
+
+/* ================================================================================ */
+/* ================                     LPCOMP                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Low Power Comparator (LPCOMP)
+  */
+
+typedef struct {                                    /*!< LPCOMP Structure                                                      */
+  __O  uint32_t  TASKS_START;                       /*!< Start comparator                                                      */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stop comparator                                                       */
+  __O  uint32_t  TASKS_SAMPLE;                      /*!< Sample comparator value                                               */
+  __I  uint32_t  RESERVED0[61];
+  __IO uint32_t  EVENTS_READY;                      /*!< LPCOMP is ready and output is valid                                   */
+  __IO uint32_t  EVENTS_DOWN;                       /*!< Downward crossing                                                     */
+  __IO uint32_t  EVENTS_UP;                         /*!< Upward crossing                                                       */
+  __IO uint32_t  EVENTS_CROSS;                      /*!< Downward or upward crossing                                           */
+  __I  uint32_t  RESERVED1[60];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED2[64];
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED3[61];
+  __I  uint32_t  RESULT;                            /*!< Compare result                                                        */
+  __I  uint32_t  RESERVED4[63];
+  __IO uint32_t  ENABLE;                            /*!< Enable LPCOMP                                                         */
+  __IO uint32_t  PSEL;                              /*!< Input pin select                                                      */
+  __IO uint32_t  REFSEL;                            /*!< Reference select                                                      */
+  __IO uint32_t  EXTREFSEL;                         /*!< External reference select                                             */
+  __I  uint32_t  RESERVED5[4];
+  __IO uint32_t  ANADETECT;                         /*!< Analog detect configuration                                           */
+  __I  uint32_t  RESERVED6[5];
+  __IO uint32_t  HYST;                              /*!< Comparator hysteresis enable                                          */
+} NRF_LPCOMP_Type;
+
+
+/* ================================================================================ */
+/* ================                       SWI                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Software interrupt 0 (SWI)
+  */
+
+typedef struct {                                    /*!< SWI Structure                                                         */
+  __I  uint32_t  UNUSED;                            /*!< Unused.                                                               */
+} NRF_SWI_Type;
+
+
+/* ================================================================================ */
+/* ================                       EGU                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Event Generator Unit 0 (EGU)
+  */
+
+typedef struct {                                    /*!< EGU Structure                                                         */
+  __O  uint32_t  TASKS_TRIGGER[16];                 /*!< Description collection[0]: Trigger 0 for triggering the corresponding
+                                                         TRIGGERED[0] event                                                    */
+  __I  uint32_t  RESERVED0[48];
+  __IO uint32_t  EVENTS_TRIGGERED[16];              /*!< Description collection[0]: Event number 0 generated by triggering
+                                                         the corresponding TRIGGER[0] task                                     */
+  __I  uint32_t  RESERVED1[112];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+} NRF_EGU_Type;
+
+
+/* ================================================================================ */
+/* ================                       PWM                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Pulse Width Modulation Unit 0 (PWM)
+  */
+
+typedef struct {                                    /*!< PWM Structure                                                         */
+  __I  uint32_t  RESERVED0;
+  __O  uint32_t  TASKS_STOP;                        /*!< Stops PWM pulse generation on all channels at the end of current
+                                                         PWM period, and stops sequence playback                               */
+  __O  uint32_t  TASKS_SEQSTART[2];                 /*!< Description collection[0]: Loads the first PWM value on all
+                                                         enabled channels from sequence 0, and starts playing that sequence
+                                                          at the rate defined in SEQ[0]REFRESH and/or DECODER.MODE. Causes
+                                                          PWM generation to start it was not running.                          */
+  __O  uint32_t  TASKS_NEXTSTEP;                    /*!< Steps by one value in the current sequence on all enabled channels
+                                                         if DECODER.MODE=NextStep. Does not cause PWM generation to start
+                                                          it was not running.                                                  */
+  __I  uint32_t  RESERVED1[60];
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< Response to STOP task, emitted when PWM pulses are no longer
+                                                         generated                                                             */
+  __IO uint32_t  EVENTS_SEQSTARTED[2];              /*!< Description collection[0]: First PWM period started on sequence
+                                                         0                                                                     */
+  __IO uint32_t  EVENTS_SEQEND[2];                  /*!< Description collection[0]: Emitted at end of every sequence
+                                                         0, when last value from RAM has been applied to wave counter          */
+  __IO uint32_t  EVENTS_PWMPERIODEND;               /*!< Emitted at the end of each PWM period                                 */
+  __IO uint32_t  EVENTS_LOOPSDONE;                  /*!< Concatenated sequences have been played the amount of times
+                                                         defined in LOOP.CNT                                                   */
+  __I  uint32_t  RESERVED2[56];
+  __IO uint32_t  SHORTS;                            /*!< Shortcut register                                                     */
+  __I  uint32_t  RESERVED3[63];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED4[125];
+  __IO uint32_t  ENABLE;                            /*!< PWM module enable register                                            */
+  __IO uint32_t  MODE;                              /*!< Selects operating mode of the wave counter                            */
+  __IO uint32_t  COUNTERTOP;                        /*!< Value up to which the pulse generator counter counts                  */
+  __IO uint32_t  PRESCALER;                         /*!< Configuration for PWM_CLK                                             */
+  __IO uint32_t  DECODER;                           /*!< Configuration of the decoder                                          */
+  __IO uint32_t  LOOP;                              /*!< Amount of playback of a loop                                          */
+  __I  uint32_t  RESERVED5[2];
+  PWM_SEQ_Type SEQ[2];                              /*!< Unspecified                                                           */
+  PWM_PSEL_Type PSEL;                               /*!< Unspecified                                                           */
+} NRF_PWM_Type;
+
+
+/* ================================================================================ */
+/* ================                       PDM                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Pulse Density Modulation (Digital Microphone) Interface (PDM)
+  */
+
+typedef struct {                                    /*!< PDM Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Starts continuous PDM transfer                                        */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stops PDM transfer                                                    */
+  __I  uint32_t  RESERVED0[62];
+  __IO uint32_t  EVENTS_STARTED;                    /*!< PDM transfer has started                                              */
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< PDM transfer has finished                                             */
+  __IO uint32_t  EVENTS_END;                        /*!< The PDM has written the last sample specified by SAMPLE.MAXCNT
+                                                         (or the last sample after a STOP task has been received) to
+                                                          Data RAM                                                             */
+  __I  uint32_t  RESERVED1[125];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED2[125];
+  __IO uint32_t  ENABLE;                            /*!< PDM module enable register                                            */
+  __IO uint32_t  PDMCLKCTRL;                        /*!< PDM clock generator control                                           */
+  __IO uint32_t  MODE;                              /*!< Defines the routing of the connected PDM microphones' signals         */
+  __I  uint32_t  RESERVED3[3];
+  __IO uint32_t  GAINL;                             /*!< Left output gain adjustment                                           */
+  __IO uint32_t  GAINR;                             /*!< Right output gain adjustment                                          */
+  __I  uint32_t  RESERVED4[8];
+  PDM_PSEL_Type PSEL;                               /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED5[6];
+  PDM_SAMPLE_Type SAMPLE;                           /*!< Unspecified                                                           */
+} NRF_PDM_Type;
+
+
+/* ================================================================================ */
+/* ================                      NVMC                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Non Volatile Memory Controller (NVMC)
+  */
+
+typedef struct {                                    /*!< NVMC Structure                                                        */
+  __I  uint32_t  RESERVED0[256];
+  __I  uint32_t  READY;                             /*!< Ready flag                                                            */
+  __I  uint32_t  RESERVED1[64];
+  __IO uint32_t  CONFIG;                            /*!< Configuration register                                                */
+  
+  union {
+    __IO uint32_t  ERASEPCR1;                       /*!< Deprecated register - Register for erasing a page in Code area.
+                                                         Equivalent to ERASEPAGE.                                              */
+    __IO uint32_t  ERASEPAGE;                       /*!< Register for erasing a page in Code area                              */
+  };
+  __IO uint32_t  ERASEALL;                          /*!< Register for erasing all non-volatile user memory                     */
+  __IO uint32_t  ERASEPCR0;                         /*!< Deprecated register - Register for erasing a page in Code area.
+                                                         Equivalent to ERASEPAGE.                                              */
+  __IO uint32_t  ERASEUICR;                         /*!< Register for erasing User Information Configuration Registers         */
+  __I  uint32_t  RESERVED2[10];
+  __IO uint32_t  ICACHECNF;                         /*!< I-Code cache configuration register.                                  */
+  __I  uint32_t  RESERVED3;
+  __IO uint32_t  IHIT;                              /*!< I-Code cache hit counter.                                             */
+  __IO uint32_t  IMISS;                             /*!< I-Code cache miss counter.                                            */
+} NRF_NVMC_Type;
+
+
+/* ================================================================================ */
+/* ================                       PPI                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Programmable Peripheral Interconnect (PPI)
+  */
+
+typedef struct {                                    /*!< PPI Structure                                                         */
+  PPI_TASKS_CHG_Type TASKS_CHG[6];                  /*!< Channel group tasks                                                   */
+  __I  uint32_t  RESERVED0[308];
+  __IO uint32_t  CHEN;                              /*!< Channel enable register                                               */
+  __IO uint32_t  CHENSET;                           /*!< Channel enable set register                                           */
+  __IO uint32_t  CHENCLR;                           /*!< Channel enable clear register                                         */
+  __I  uint32_t  RESERVED1;
+  PPI_CH_Type CH[20];                               /*!< PPI Channel                                                           */
+  __I  uint32_t  RESERVED2[148];
+  __IO uint32_t  CHG[6];                            /*!< Description collection[0]: Channel group 0                            */
+  __I  uint32_t  RESERVED3[62];
+  PPI_FORK_Type FORK[32];                           /*!< Fork                                                                  */
+} NRF_PPI_Type;
+
+
+/* ================================================================================ */
+/* ================                       MWU                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Memory Watch Unit (MWU)
+  */
+
+typedef struct {                                    /*!< MWU Structure                                                         */
+  __I  uint32_t  RESERVED0[64];
+  MWU_EVENTS_REGION_Type EVENTS_REGION[4];          /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED1[16];
+  MWU_EVENTS_PREGION_Type EVENTS_PREGION[2];        /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED2[100];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED3[5];
+  __IO uint32_t  NMIEN;                             /*!< Enable or disable non-maskable interrupt                              */
+  __IO uint32_t  NMIENSET;                          /*!< Enable non-maskable interrupt                                         */
+  __IO uint32_t  NMIENCLR;                          /*!< Disable non-maskable interrupt                                        */
+  __I  uint32_t  RESERVED4[53];
+  MWU_PERREGION_Type PERREGION[2];                  /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED5[64];
+  __IO uint32_t  REGIONEN;                          /*!< Enable/disable regions watch                                          */
+  __IO uint32_t  REGIONENSET;                       /*!< Enable regions watch                                                  */
+  __IO uint32_t  REGIONENCLR;                       /*!< Disable regions watch                                                 */
+  __I  uint32_t  RESERVED6[57];
+  MWU_REGION_Type REGION[4];                        /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED7[32];
+  MWU_PREGION_Type PREGION[2];                      /*!< Unspecified                                                           */
+} NRF_MWU_Type;
+
+
+/* ================================================================================ */
+/* ================                       I2S                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Inter-IC Sound (I2S)
+  */
+
+typedef struct {                                    /*!< I2S Structure                                                         */
+  __O  uint32_t  TASKS_START;                       /*!< Starts continuous I2S transfer. Also starts MCK generator when
+                                                         this is enabled.                                                      */
+  __O  uint32_t  TASKS_STOP;                        /*!< Stops I2S transfer. Also stops MCK generator. Triggering this
+                                                         task will cause the {event:STOPPED} event to be generated.            */
+  __I  uint32_t  RESERVED0[63];
+  __IO uint32_t  EVENTS_RXPTRUPD;                   /*!< The RXD.PTR register has been copied to internal double-buffers.
+                                                         When the I2S module is started and RX is enabled, this event
+                                                          will be generated for every RXTXD.MAXCNT words that are received
+                                                          on the SDIN pin.                                                     */
+  __IO uint32_t  EVENTS_STOPPED;                    /*!< I2S transfer stopped.                                                 */
+  __I  uint32_t  RESERVED1[2];
+  __IO uint32_t  EVENTS_TXPTRUPD;                   /*!< The TDX.PTR register has been copied to internal double-buffers.
+                                                         When the I2S module is started and TX is enabled, this event
+                                                          will be generated for every RXTXD.MAXCNT words that are sent
+                                                          on the SDOUT pin.                                                    */
+  __I  uint32_t  RESERVED2[122];
+  __IO uint32_t  INTEN;                             /*!< Enable or disable interrupt                                           */
+  __IO uint32_t  INTENSET;                          /*!< Enable interrupt                                                      */
+  __IO uint32_t  INTENCLR;                          /*!< Disable interrupt                                                     */
+  __I  uint32_t  RESERVED3[125];
+  __IO uint32_t  ENABLE;                            /*!< Enable I2S module.                                                    */
+  I2S_CONFIG_Type CONFIG;                           /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED4[3];
+  I2S_RXD_Type RXD;                                 /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED5;
+  I2S_TXD_Type TXD;                                 /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED6[3];
+  I2S_RXTXD_Type RXTXD;                             /*!< Unspecified                                                           */
+  __I  uint32_t  RESERVED7[3];
+  I2S_PSEL_Type PSEL;                               /*!< Unspecified                                                           */
+} NRF_I2S_Type;
+
+
+/* ================================================================================ */
+/* ================                      GPIO                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief GPIO Port 1 (GPIO)
+  */
+
+typedef struct {                                    /*!< GPIO Structure                                                        */
+  __I  uint32_t  RESERVED0[321];
+  __IO uint32_t  OUT;                               /*!< Write GPIO port                                                       */
+  __IO uint32_t  OUTSET;                            /*!< Set individual bits in GPIO port                                      */
+  __IO uint32_t  OUTCLR;                            /*!< Clear individual bits in GPIO port                                    */
+  __I  uint32_t  IN;                                /*!< Read GPIO port                                                        */
+  __IO uint32_t  DIR;                               /*!< Direction of GPIO pins                                                */
+  __IO uint32_t  DIRSET;                            /*!< DIR set register                                                      */
+  __IO uint32_t  DIRCLR;                            /*!< DIR clear register                                                    */
+  __IO uint32_t  LATCH;                             /*!< Latch indicating which GPIO pins have met the criteria set in
+                                                         PIN_CNF[n].SENSE register                                             */
+  __IO uint32_t  DETECTMODE;                        /*!< Select between default DETECT signal behaviour and LDETECT mode       */
+  __I  uint32_t  RESERVED1[118];
+  __IO uint32_t  PIN_CNF[32];                       /*!< Description collection[0]: Configuration of GPIO pins                 */
+} NRF_GPIO_Type;
+
+
+/* --------------------  End of section using anonymous unions  ------------------- */
+#if defined(__CC_ARM)
+  #pragma pop
+#elif defined(__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif defined(__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined(__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined(__TASKING__)
+  #pragma warning restore
+#else
+  #warning Not supported compiler type
+#endif
+
+
+
+
+/* ================================================================================ */
+/* ================              Peripheral memory map             ================ */
+/* ================================================================================ */
+
+#define NRF_FICR_BASE                   0x10000000UL
+#define NRF_UICR_BASE                   0x10001000UL
+#define NRF_BPROT_BASE                  0x40000000UL
+#define NRF_POWER_BASE                  0x40000000UL
+#define NRF_CLOCK_BASE                  0x40000000UL
+#define NRF_RADIO_BASE                  0x40001000UL
+#define NRF_UARTE0_BASE                 0x40002000UL
+#define NRF_UART0_BASE                  0x40002000UL
+#define NRF_SPIM0_BASE                  0x40003000UL
+#define NRF_SPIS0_BASE                  0x40003000UL
+#define NRF_TWIM0_BASE                  0x40003000UL
+#define NRF_TWIS0_BASE                  0x40003000UL
+#define NRF_SPI0_BASE                   0x40003000UL
+#define NRF_TWI0_BASE                   0x40003000UL
+#define NRF_SPIM1_BASE                  0x40004000UL
+#define NRF_SPIS1_BASE                  0x40004000UL
+#define NRF_TWIM1_BASE                  0x40004000UL
+#define NRF_TWIS1_BASE                  0x40004000UL
+#define NRF_SPI1_BASE                   0x40004000UL
+#define NRF_TWI1_BASE                   0x40004000UL
+#define NRF_NFCT_BASE                   0x40005000UL
+#define NRF_GPIOTE_BASE                 0x40006000UL
+#define NRF_SAADC_BASE                  0x40007000UL
+#define NRF_TIMER0_BASE                 0x40008000UL
+#define NRF_TIMER1_BASE                 0x40009000UL
+#define NRF_TIMER2_BASE                 0x4000A000UL
+#define NRF_RTC0_BASE                   0x4000B000UL
+#define NRF_TEMP_BASE                   0x4000C000UL
+#define NRF_RNG_BASE                    0x4000D000UL
+#define NRF_ECB_BASE                    0x4000E000UL
+#define NRF_CCM_BASE                    0x4000F000UL
+#define NRF_AAR_BASE                    0x4000F000UL
+#define NRF_WDT_BASE                    0x40010000UL
+#define NRF_RTC1_BASE                   0x40011000UL
+#define NRF_QDEC_BASE                   0x40012000UL
+#define NRF_COMP_BASE                   0x40013000UL
+#define NRF_LPCOMP_BASE                 0x40013000UL
+#define NRF_SWI0_BASE                   0x40014000UL
+#define NRF_EGU0_BASE                   0x40014000UL
+#define NRF_SWI1_BASE                   0x40015000UL
+#define NRF_EGU1_BASE                   0x40015000UL
+#define NRF_SWI2_BASE                   0x40016000UL
+#define NRF_EGU2_BASE                   0x40016000UL
+#define NRF_SWI3_BASE                   0x40017000UL
+#define NRF_EGU3_BASE                   0x40017000UL
+#define NRF_SWI4_BASE                   0x40018000UL
+#define NRF_EGU4_BASE                   0x40018000UL
+#define NRF_SWI5_BASE                   0x40019000UL
+#define NRF_EGU5_BASE                   0x40019000UL
+#define NRF_TIMER3_BASE                 0x4001A000UL
+#define NRF_TIMER4_BASE                 0x4001B000UL
+#define NRF_PWM0_BASE                   0x4001C000UL
+#define NRF_PDM_BASE                    0x4001D000UL
+#define NRF_NVMC_BASE                   0x4001E000UL
+#define NRF_PPI_BASE                    0x4001F000UL
+#define NRF_MWU_BASE                    0x40020000UL
+#define NRF_PWM1_BASE                   0x40021000UL
+#define NRF_PWM2_BASE                   0x40022000UL
+#define NRF_SPIM2_BASE                  0x40023000UL
+#define NRF_SPIS2_BASE                  0x40023000UL
+#define NRF_SPI2_BASE                   0x40023000UL
+#define NRF_RTC2_BASE                   0x40024000UL
+#define NRF_I2S_BASE                    0x40025000UL
+#define NRF_P0_BASE                     0x50000000UL
+
+
+/* ================================================================================ */
+/* ================             Peripheral declaration             ================ */
+/* ================================================================================ */
+
+#define NRF_FICR                        ((NRF_FICR_Type           *) NRF_FICR_BASE)
+#define NRF_UICR                        ((NRF_UICR_Type           *) NRF_UICR_BASE)
+#define NRF_BPROT                       ((NRF_BPROT_Type          *) NRF_BPROT_BASE)
+#define NRF_POWER                       ((NRF_POWER_Type          *) NRF_POWER_BASE)
+#define NRF_CLOCK                       ((NRF_CLOCK_Type          *) NRF_CLOCK_BASE)
+#define NRF_RADIO                       ((NRF_RADIO_Type          *) NRF_RADIO_BASE)
+#define NRF_UARTE0                      ((NRF_UARTE_Type          *) NRF_UARTE0_BASE)
+#define NRF_UART0                       ((NRF_UART_Type           *) NRF_UART0_BASE)
+#define NRF_SPIM0                       ((NRF_SPIM_Type           *) NRF_SPIM0_BASE)
+#define NRF_SPIS0                       ((NRF_SPIS_Type           *) NRF_SPIS0_BASE)
+#define NRF_TWIM0                       ((NRF_TWIM_Type           *) NRF_TWIM0_BASE)
+#define NRF_TWIS0                       ((NRF_TWIS_Type           *) NRF_TWIS0_BASE)
+#define NRF_SPI0                        ((NRF_SPI_Type            *) NRF_SPI0_BASE)
+#define NRF_TWI0                        ((NRF_TWI_Type            *) NRF_TWI0_BASE)
+#define NRF_SPIM1                       ((NRF_SPIM_Type           *) NRF_SPIM1_BASE)
+#define NRF_SPIS1                       ((NRF_SPIS_Type           *) NRF_SPIS1_BASE)
+#define NRF_TWIM1                       ((NRF_TWIM_Type           *) NRF_TWIM1_BASE)
+#define NRF_TWIS1                       ((NRF_TWIS_Type           *) NRF_TWIS1_BASE)
+#define NRF_SPI1                        ((NRF_SPI_Type            *) NRF_SPI1_BASE)
+#define NRF_TWI1                        ((NRF_TWI_Type            *) NRF_TWI1_BASE)
+#define NRF_NFCT                        ((NRF_NFCT_Type           *) NRF_NFCT_BASE)
+#define NRF_GPIOTE                      ((NRF_GPIOTE_Type         *) NRF_GPIOTE_BASE)
+#define NRF_SAADC                       ((NRF_SAADC_Type          *) NRF_SAADC_BASE)
+#define NRF_TIMER0                      ((NRF_TIMER_Type          *) NRF_TIMER0_BASE)
+#define NRF_TIMER1                      ((NRF_TIMER_Type          *) NRF_TIMER1_BASE)
+#define NRF_TIMER2                      ((NRF_TIMER_Type          *) NRF_TIMER2_BASE)
+#define NRF_RTC0                        ((NRF_RTC_Type            *) NRF_RTC0_BASE)
+#define NRF_TEMP                        ((NRF_TEMP_Type           *) NRF_TEMP_BASE)
+#define NRF_RNG                         ((NRF_RNG_Type            *) NRF_RNG_BASE)
+#define NRF_ECB                         ((NRF_ECB_Type            *) NRF_ECB_BASE)
+#define NRF_CCM                         ((NRF_CCM_Type            *) NRF_CCM_BASE)
+#define NRF_AAR                         ((NRF_AAR_Type            *) NRF_AAR_BASE)
+#define NRF_WDT                         ((NRF_WDT_Type            *) NRF_WDT_BASE)
+#define NRF_RTC1                        ((NRF_RTC_Type            *) NRF_RTC1_BASE)
+#define NRF_QDEC                        ((NRF_QDEC_Type           *) NRF_QDEC_BASE)
+#define NRF_COMP                        ((NRF_COMP_Type           *) NRF_COMP_BASE)
+#define NRF_LPCOMP                      ((NRF_LPCOMP_Type         *) NRF_LPCOMP_BASE)
+#define NRF_SWI0                        ((NRF_SWI_Type            *) NRF_SWI0_BASE)
+#define NRF_EGU0                        ((NRF_EGU_Type            *) NRF_EGU0_BASE)
+#define NRF_SWI1                        ((NRF_SWI_Type            *) NRF_SWI1_BASE)
+#define NRF_EGU1                        ((NRF_EGU_Type            *) NRF_EGU1_BASE)
+#define NRF_SWI2                        ((NRF_SWI_Type            *) NRF_SWI2_BASE)
+#define NRF_EGU2                        ((NRF_EGU_Type            *) NRF_EGU2_BASE)
+#define NRF_SWI3                        ((NRF_SWI_Type            *) NRF_SWI3_BASE)
+#define NRF_EGU3                        ((NRF_EGU_Type            *) NRF_EGU3_BASE)
+#define NRF_SWI4                        ((NRF_SWI_Type            *) NRF_SWI4_BASE)
+#define NRF_EGU4                        ((NRF_EGU_Type            *) NRF_EGU4_BASE)
+#define NRF_SWI5                        ((NRF_SWI_Type            *) NRF_SWI5_BASE)
+#define NRF_EGU5                        ((NRF_EGU_Type            *) NRF_EGU5_BASE)
+#define NRF_TIMER3                      ((NRF_TIMER_Type          *) NRF_TIMER3_BASE)
+#define NRF_TIMER4                      ((NRF_TIMER_Type          *) NRF_TIMER4_BASE)
+#define NRF_PWM0                        ((NRF_PWM_Type            *) NRF_PWM0_BASE)
+#define NRF_PDM                         ((NRF_PDM_Type            *) NRF_PDM_BASE)
+#define NRF_NVMC                        ((NRF_NVMC_Type           *) NRF_NVMC_BASE)
+#define NRF_PPI                         ((NRF_PPI_Type            *) NRF_PPI_BASE)
+#define NRF_MWU                         ((NRF_MWU_Type            *) NRF_MWU_BASE)
+#define NRF_PWM1                        ((NRF_PWM_Type            *) NRF_PWM1_BASE)
+#define NRF_PWM2                        ((NRF_PWM_Type            *) NRF_PWM2_BASE)
+#define NRF_SPIM2                       ((NRF_SPIM_Type           *) NRF_SPIM2_BASE)
+#define NRF_SPIS2                       ((NRF_SPIS_Type           *) NRF_SPIS2_BASE)
+#define NRF_SPI2                        ((NRF_SPI_Type            *) NRF_SPI2_BASE)
+#define NRF_RTC2                        ((NRF_RTC_Type            *) NRF_RTC2_BASE)
+#define NRF_I2S                         ((NRF_I2S_Type            *) NRF_I2S_BASE)
+#define NRF_P0                          ((NRF_GPIO_Type           *) NRF_P0_BASE)
+
+
+/** @} */ /* End of group Device_Peripheral_Registers */
+/** @} */ /* End of group nrf52 */
+/** @} */ /* End of group Nordic Semiconductor */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  /* nrf52_H */
+

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf52832_peripherals.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf52832_peripherals.h
@@ -1,0 +1,177 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _NRF52832_PERIPHERALS_H
+#define _NRF52832_PERIPHERALS_H
+
+
+/* Software Interrupts */
+#define SWI_PRESENT
+#define SWI_COUNT 6
+
+/* Radio */
+#define RADIO_PRESENT
+#define RADIO_COUNT 1
+
+/* NFC Tag */
+#define NFCT_PRESENT
+#define NFCT_COUNT 1
+
+/* Peripheral to Peripheral Interconnect */
+#define PPI_PRESENT
+#define PPI_COUNT 1
+
+#define PPI_CH_NUM 20
+#define PPI_GROUP_NUM 6
+#define PPI_FEATURE_FORKS_PRESENT
+
+/* Event Generator Unit */
+#define EGU_PRESENT
+#define EGU_COUNT 6
+
+#define EGU0_CH_NUM 16
+#define EGU1_CH_NUM 16
+#define EGU2_CH_NUM 16
+#define EGU3_CH_NUM 16
+#define EGU4_CH_NUM 16
+#define EGU5_CH_NUM 16
+
+/* Timer/Counter */
+#define TIMER_PRESENT
+#define TIMER_COUNT 5
+
+#define TIMER0_MAX_SIZE 32
+#define TIMER1_MAX_SIZE 32
+#define TIMER2_MAX_SIZE 32
+#define TIMER3_MAX_SIZE 32
+#define TIMER4_MAX_SIZE 32
+
+#define TIMER0_CC_NUM 4
+#define TIMER1_CC_NUM 4
+#define TIMER2_CC_NUM 4
+#define TIMER3_CC_NUM 6
+#define TIMER4_CC_NUM 6
+
+/* Real Time Counter */
+#define RTC_PRESENT
+#define RTC_COUNT 3
+
+#define RTC0_CC_NUM 3
+#define RTC1_CC_NUM 4
+#define RTC2_CC_NUM 4
+
+/* RNG */
+#define RNG_PRESENT
+#define RNG_COUNT 1
+
+/* Watchdog Timer */
+#define WDT_PRESENT
+#define WDT_COUNT 1
+
+/* Temperature Sensor */
+#define TEMP_PRESENT
+#define TEMP_COUNT 1
+
+/* Serial Peripheral Interface Master */
+#define SPI_PRESENT
+#define SPI_COUNT 3
+
+/* Serial Peripheral Interface Master with DMA */
+#define SPIM_PRESENT
+#define SPIM_COUNT 3
+
+/* Serial Peripheral Interface Slave with DMA*/
+#define SPIS_PRESENT
+#define SPIS_COUNT 3
+
+/* Two Wire Interface Master */
+#define TWI_PRESENT
+#define TWI_COUNT 2
+
+/* Two Wire Interface Master with DMA */
+#define TWIM_PRESENT
+#define TWIM_COUNT 2
+
+/* Two Wire Interface Slave with DMA */
+#define TWIS_PRESENT
+#define TWIS_COUNT 2
+
+/* Universal Asynchronous Receiver-Transmitter */
+#define UART_PRESENT
+#define UART_COUNT 1
+
+/* Universal Asynchronous Receiver-Transmitter with DMA */
+#define UARTE_PRESENT
+#define UARTE_COUNT 1
+
+/* Quadrature Decoder */
+#define QDEC_PRESENT
+#define QDEC_COUNT 1
+
+/* Successive Approximation Analog to Digital Converter */
+#define SAADC_PRESENT
+#define SAADC_COUNT 1
+
+/* GPIO Tasks and Events */
+#define GPIOTE_PRESENT
+#define GPIOTE_COUNT 1
+
+#define GPIOTE_CH_NUM 8
+
+/* Low Power Comparator */
+#define LPCOMP_PRESENT
+#define LPCOMP_COUNT 1
+
+/* Comparator */
+#define COMP_PRESENT
+#define COMP_COUNT 1
+
+/* Pulse Width Modulator */
+#define PWM_PRESENT
+#define PWM_COUNT 3
+
+#define PWM0_CH_NUM 4
+#define PWM1_CH_NUM 4
+#define PWM0_CH_NUM 4
+
+/* Pulse Density Modulator */
+#define PDM_PRESENT
+#define PDM_COUNT 1
+
+/* Inter-IC Sound Interface */
+#define I2S_PRESENT
+#define I2S_COUNT 1
+
+/* Memory Watch Unit */
+#define MWU_PRESENT
+#define MWU_COUNT 1
+
+
+#endif      // _NRF52832_PERIPHERALS_H

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf52_bitfields.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf52_bitfields.h
@@ -1,0 +1,12369 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef __NRF52_BITS_H
+#define __NRF52_BITS_H
+
+/*lint ++flb "Enter library region" */
+
+/* Peripheral: AAR */
+/* Description: Accelerated Address Resolver */
+
+/* Register: AAR_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 2 : Write '1' to Enable interrupt for NOTRESOLVED event */
+#define AAR_INTENSET_NOTRESOLVED_Pos (2UL) /*!< Position of NOTRESOLVED field. */
+#define AAR_INTENSET_NOTRESOLVED_Msk (0x1UL << AAR_INTENSET_NOTRESOLVED_Pos) /*!< Bit mask of NOTRESOLVED field. */
+#define AAR_INTENSET_NOTRESOLVED_Disabled (0UL) /*!< Read: Disabled */
+#define AAR_INTENSET_NOTRESOLVED_Enabled (1UL) /*!< Read: Enabled */
+#define AAR_INTENSET_NOTRESOLVED_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for RESOLVED event */
+#define AAR_INTENSET_RESOLVED_Pos (1UL) /*!< Position of RESOLVED field. */
+#define AAR_INTENSET_RESOLVED_Msk (0x1UL << AAR_INTENSET_RESOLVED_Pos) /*!< Bit mask of RESOLVED field. */
+#define AAR_INTENSET_RESOLVED_Disabled (0UL) /*!< Read: Disabled */
+#define AAR_INTENSET_RESOLVED_Enabled (1UL) /*!< Read: Enabled */
+#define AAR_INTENSET_RESOLVED_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for END event */
+#define AAR_INTENSET_END_Pos (0UL) /*!< Position of END field. */
+#define AAR_INTENSET_END_Msk (0x1UL << AAR_INTENSET_END_Pos) /*!< Bit mask of END field. */
+#define AAR_INTENSET_END_Disabled (0UL) /*!< Read: Disabled */
+#define AAR_INTENSET_END_Enabled (1UL) /*!< Read: Enabled */
+#define AAR_INTENSET_END_Set (1UL) /*!< Enable */
+
+/* Register: AAR_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 2 : Write '1' to Disable interrupt for NOTRESOLVED event */
+#define AAR_INTENCLR_NOTRESOLVED_Pos (2UL) /*!< Position of NOTRESOLVED field. */
+#define AAR_INTENCLR_NOTRESOLVED_Msk (0x1UL << AAR_INTENCLR_NOTRESOLVED_Pos) /*!< Bit mask of NOTRESOLVED field. */
+#define AAR_INTENCLR_NOTRESOLVED_Disabled (0UL) /*!< Read: Disabled */
+#define AAR_INTENCLR_NOTRESOLVED_Enabled (1UL) /*!< Read: Enabled */
+#define AAR_INTENCLR_NOTRESOLVED_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for RESOLVED event */
+#define AAR_INTENCLR_RESOLVED_Pos (1UL) /*!< Position of RESOLVED field. */
+#define AAR_INTENCLR_RESOLVED_Msk (0x1UL << AAR_INTENCLR_RESOLVED_Pos) /*!< Bit mask of RESOLVED field. */
+#define AAR_INTENCLR_RESOLVED_Disabled (0UL) /*!< Read: Disabled */
+#define AAR_INTENCLR_RESOLVED_Enabled (1UL) /*!< Read: Enabled */
+#define AAR_INTENCLR_RESOLVED_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for END event */
+#define AAR_INTENCLR_END_Pos (0UL) /*!< Position of END field. */
+#define AAR_INTENCLR_END_Msk (0x1UL << AAR_INTENCLR_END_Pos) /*!< Bit mask of END field. */
+#define AAR_INTENCLR_END_Disabled (0UL) /*!< Read: Disabled */
+#define AAR_INTENCLR_END_Enabled (1UL) /*!< Read: Enabled */
+#define AAR_INTENCLR_END_Clear (1UL) /*!< Disable */
+
+/* Register: AAR_STATUS */
+/* Description: Resolution status */
+
+/* Bits 3..0 : The IRK that was used last time an address was resolved */
+#define AAR_STATUS_STATUS_Pos (0UL) /*!< Position of STATUS field. */
+#define AAR_STATUS_STATUS_Msk (0xFUL << AAR_STATUS_STATUS_Pos) /*!< Bit mask of STATUS field. */
+
+/* Register: AAR_ENABLE */
+/* Description: Enable AAR */
+
+/* Bits 1..0 : Enable or disable AAR */
+#define AAR_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define AAR_ENABLE_ENABLE_Msk (0x3UL << AAR_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define AAR_ENABLE_ENABLE_Disabled (0UL) /*!< Disable */
+#define AAR_ENABLE_ENABLE_Enabled (3UL) /*!< Enable */
+
+/* Register: AAR_NIRK */
+/* Description: Number of IRKs */
+
+/* Bits 4..0 : Number of Identity root keys available in the IRK data structure */
+#define AAR_NIRK_NIRK_Pos (0UL) /*!< Position of NIRK field. */
+#define AAR_NIRK_NIRK_Msk (0x1FUL << AAR_NIRK_NIRK_Pos) /*!< Bit mask of NIRK field. */
+
+/* Register: AAR_IRKPTR */
+/* Description: Pointer to IRK data structure */
+
+/* Bits 31..0 : Pointer to the IRK data structure */
+#define AAR_IRKPTR_IRKPTR_Pos (0UL) /*!< Position of IRKPTR field. */
+#define AAR_IRKPTR_IRKPTR_Msk (0xFFFFFFFFUL << AAR_IRKPTR_IRKPTR_Pos) /*!< Bit mask of IRKPTR field. */
+
+/* Register: AAR_ADDRPTR */
+/* Description: Pointer to the resolvable address */
+
+/* Bits 31..0 : Pointer to the resolvable address (6-bytes) */
+#define AAR_ADDRPTR_ADDRPTR_Pos (0UL) /*!< Position of ADDRPTR field. */
+#define AAR_ADDRPTR_ADDRPTR_Msk (0xFFFFFFFFUL << AAR_ADDRPTR_ADDRPTR_Pos) /*!< Bit mask of ADDRPTR field. */
+
+/* Register: AAR_SCRATCHPTR */
+/* Description: Pointer to data area used for temporary storage */
+
+/* Bits 31..0 : Pointer to a "scratch" data area used for temporary storage during resolution.A space of minimum 3 bytes must be reserved. */
+#define AAR_SCRATCHPTR_SCRATCHPTR_Pos (0UL) /*!< Position of SCRATCHPTR field. */
+#define AAR_SCRATCHPTR_SCRATCHPTR_Msk (0xFFFFFFFFUL << AAR_SCRATCHPTR_SCRATCHPTR_Pos) /*!< Bit mask of SCRATCHPTR field. */
+
+
+/* Peripheral: BPROT */
+/* Description: Block Protect */
+
+/* Register: BPROT_CONFIG0 */
+/* Description: Block protect configuration register 0 */
+
+/* Bit 31 : Enable protection for region 31. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION31_Pos (31UL) /*!< Position of REGION31 field. */
+#define BPROT_CONFIG0_REGION31_Msk (0x1UL << BPROT_CONFIG0_REGION31_Pos) /*!< Bit mask of REGION31 field. */
+#define BPROT_CONFIG0_REGION31_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION31_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 30 : Enable protection for region 30. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION30_Pos (30UL) /*!< Position of REGION30 field. */
+#define BPROT_CONFIG0_REGION30_Msk (0x1UL << BPROT_CONFIG0_REGION30_Pos) /*!< Bit mask of REGION30 field. */
+#define BPROT_CONFIG0_REGION30_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION30_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 29 : Enable protection for region 29. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION29_Pos (29UL) /*!< Position of REGION29 field. */
+#define BPROT_CONFIG0_REGION29_Msk (0x1UL << BPROT_CONFIG0_REGION29_Pos) /*!< Bit mask of REGION29 field. */
+#define BPROT_CONFIG0_REGION29_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION29_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 28 : Enable protection for region 28. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION28_Pos (28UL) /*!< Position of REGION28 field. */
+#define BPROT_CONFIG0_REGION28_Msk (0x1UL << BPROT_CONFIG0_REGION28_Pos) /*!< Bit mask of REGION28 field. */
+#define BPROT_CONFIG0_REGION28_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION28_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 27 : Enable protection for region 27. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION27_Pos (27UL) /*!< Position of REGION27 field. */
+#define BPROT_CONFIG0_REGION27_Msk (0x1UL << BPROT_CONFIG0_REGION27_Pos) /*!< Bit mask of REGION27 field. */
+#define BPROT_CONFIG0_REGION27_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION27_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 26 : Enable protection for region 26. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION26_Pos (26UL) /*!< Position of REGION26 field. */
+#define BPROT_CONFIG0_REGION26_Msk (0x1UL << BPROT_CONFIG0_REGION26_Pos) /*!< Bit mask of REGION26 field. */
+#define BPROT_CONFIG0_REGION26_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION26_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 25 : Enable protection for region 25. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION25_Pos (25UL) /*!< Position of REGION25 field. */
+#define BPROT_CONFIG0_REGION25_Msk (0x1UL << BPROT_CONFIG0_REGION25_Pos) /*!< Bit mask of REGION25 field. */
+#define BPROT_CONFIG0_REGION25_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION25_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 24 : Enable protection for region 24. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION24_Pos (24UL) /*!< Position of REGION24 field. */
+#define BPROT_CONFIG0_REGION24_Msk (0x1UL << BPROT_CONFIG0_REGION24_Pos) /*!< Bit mask of REGION24 field. */
+#define BPROT_CONFIG0_REGION24_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION24_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 23 : Enable protection for region 23. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION23_Pos (23UL) /*!< Position of REGION23 field. */
+#define BPROT_CONFIG0_REGION23_Msk (0x1UL << BPROT_CONFIG0_REGION23_Pos) /*!< Bit mask of REGION23 field. */
+#define BPROT_CONFIG0_REGION23_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION23_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 22 : Enable protection for region 22. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION22_Pos (22UL) /*!< Position of REGION22 field. */
+#define BPROT_CONFIG0_REGION22_Msk (0x1UL << BPROT_CONFIG0_REGION22_Pos) /*!< Bit mask of REGION22 field. */
+#define BPROT_CONFIG0_REGION22_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION22_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 21 : Enable protection for region 21. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION21_Pos (21UL) /*!< Position of REGION21 field. */
+#define BPROT_CONFIG0_REGION21_Msk (0x1UL << BPROT_CONFIG0_REGION21_Pos) /*!< Bit mask of REGION21 field. */
+#define BPROT_CONFIG0_REGION21_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION21_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 20 : Enable protection for region 20. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION20_Pos (20UL) /*!< Position of REGION20 field. */
+#define BPROT_CONFIG0_REGION20_Msk (0x1UL << BPROT_CONFIG0_REGION20_Pos) /*!< Bit mask of REGION20 field. */
+#define BPROT_CONFIG0_REGION20_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION20_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 19 : Enable protection for region 19. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION19_Pos (19UL) /*!< Position of REGION19 field. */
+#define BPROT_CONFIG0_REGION19_Msk (0x1UL << BPROT_CONFIG0_REGION19_Pos) /*!< Bit mask of REGION19 field. */
+#define BPROT_CONFIG0_REGION19_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION19_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 18 : Enable protection for region 18. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION18_Pos (18UL) /*!< Position of REGION18 field. */
+#define BPROT_CONFIG0_REGION18_Msk (0x1UL << BPROT_CONFIG0_REGION18_Pos) /*!< Bit mask of REGION18 field. */
+#define BPROT_CONFIG0_REGION18_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION18_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 17 : Enable protection for region 17. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION17_Pos (17UL) /*!< Position of REGION17 field. */
+#define BPROT_CONFIG0_REGION17_Msk (0x1UL << BPROT_CONFIG0_REGION17_Pos) /*!< Bit mask of REGION17 field. */
+#define BPROT_CONFIG0_REGION17_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION17_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 16 : Enable protection for region 16. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION16_Pos (16UL) /*!< Position of REGION16 field. */
+#define BPROT_CONFIG0_REGION16_Msk (0x1UL << BPROT_CONFIG0_REGION16_Pos) /*!< Bit mask of REGION16 field. */
+#define BPROT_CONFIG0_REGION16_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION16_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 15 : Enable protection for region 15. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION15_Pos (15UL) /*!< Position of REGION15 field. */
+#define BPROT_CONFIG0_REGION15_Msk (0x1UL << BPROT_CONFIG0_REGION15_Pos) /*!< Bit mask of REGION15 field. */
+#define BPROT_CONFIG0_REGION15_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION15_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 14 : Enable protection for region 14. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION14_Pos (14UL) /*!< Position of REGION14 field. */
+#define BPROT_CONFIG0_REGION14_Msk (0x1UL << BPROT_CONFIG0_REGION14_Pos) /*!< Bit mask of REGION14 field. */
+#define BPROT_CONFIG0_REGION14_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION14_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 13 : Enable protection for region 13. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION13_Pos (13UL) /*!< Position of REGION13 field. */
+#define BPROT_CONFIG0_REGION13_Msk (0x1UL << BPROT_CONFIG0_REGION13_Pos) /*!< Bit mask of REGION13 field. */
+#define BPROT_CONFIG0_REGION13_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION13_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 12 : Enable protection for region 12. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION12_Pos (12UL) /*!< Position of REGION12 field. */
+#define BPROT_CONFIG0_REGION12_Msk (0x1UL << BPROT_CONFIG0_REGION12_Pos) /*!< Bit mask of REGION12 field. */
+#define BPROT_CONFIG0_REGION12_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION12_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 11 : Enable protection for region 11. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION11_Pos (11UL) /*!< Position of REGION11 field. */
+#define BPROT_CONFIG0_REGION11_Msk (0x1UL << BPROT_CONFIG0_REGION11_Pos) /*!< Bit mask of REGION11 field. */
+#define BPROT_CONFIG0_REGION11_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION11_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 10 : Enable protection for region 10. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION10_Pos (10UL) /*!< Position of REGION10 field. */
+#define BPROT_CONFIG0_REGION10_Msk (0x1UL << BPROT_CONFIG0_REGION10_Pos) /*!< Bit mask of REGION10 field. */
+#define BPROT_CONFIG0_REGION10_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION10_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 9 : Enable protection for region 9. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION9_Pos (9UL) /*!< Position of REGION9 field. */
+#define BPROT_CONFIG0_REGION9_Msk (0x1UL << BPROT_CONFIG0_REGION9_Pos) /*!< Bit mask of REGION9 field. */
+#define BPROT_CONFIG0_REGION9_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION9_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 8 : Enable protection for region 8. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION8_Pos (8UL) /*!< Position of REGION8 field. */
+#define BPROT_CONFIG0_REGION8_Msk (0x1UL << BPROT_CONFIG0_REGION8_Pos) /*!< Bit mask of REGION8 field. */
+#define BPROT_CONFIG0_REGION8_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION8_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 7 : Enable protection for region 7. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION7_Pos (7UL) /*!< Position of REGION7 field. */
+#define BPROT_CONFIG0_REGION7_Msk (0x1UL << BPROT_CONFIG0_REGION7_Pos) /*!< Bit mask of REGION7 field. */
+#define BPROT_CONFIG0_REGION7_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION7_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 6 : Enable protection for region 6. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION6_Pos (6UL) /*!< Position of REGION6 field. */
+#define BPROT_CONFIG0_REGION6_Msk (0x1UL << BPROT_CONFIG0_REGION6_Pos) /*!< Bit mask of REGION6 field. */
+#define BPROT_CONFIG0_REGION6_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION6_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 5 : Enable protection for region 5. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION5_Pos (5UL) /*!< Position of REGION5 field. */
+#define BPROT_CONFIG0_REGION5_Msk (0x1UL << BPROT_CONFIG0_REGION5_Pos) /*!< Bit mask of REGION5 field. */
+#define BPROT_CONFIG0_REGION5_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION5_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 4 : Enable protection for region 4. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION4_Pos (4UL) /*!< Position of REGION4 field. */
+#define BPROT_CONFIG0_REGION4_Msk (0x1UL << BPROT_CONFIG0_REGION4_Pos) /*!< Bit mask of REGION4 field. */
+#define BPROT_CONFIG0_REGION4_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION4_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 3 : Enable protection for region 3. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION3_Pos (3UL) /*!< Position of REGION3 field. */
+#define BPROT_CONFIG0_REGION3_Msk (0x1UL << BPROT_CONFIG0_REGION3_Pos) /*!< Bit mask of REGION3 field. */
+#define BPROT_CONFIG0_REGION3_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION3_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 2 : Enable protection for region 2. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION2_Pos (2UL) /*!< Position of REGION2 field. */
+#define BPROT_CONFIG0_REGION2_Msk (0x1UL << BPROT_CONFIG0_REGION2_Pos) /*!< Bit mask of REGION2 field. */
+#define BPROT_CONFIG0_REGION2_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION2_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 1 : Enable protection for region 1. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION1_Pos (1UL) /*!< Position of REGION1 field. */
+#define BPROT_CONFIG0_REGION1_Msk (0x1UL << BPROT_CONFIG0_REGION1_Pos) /*!< Bit mask of REGION1 field. */
+#define BPROT_CONFIG0_REGION1_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION1_Enabled (1UL) /*!< Protection enable */
+
+/* Bit 0 : Enable protection for region 0. Write '0' has no effect. */
+#define BPROT_CONFIG0_REGION0_Pos (0UL) /*!< Position of REGION0 field. */
+#define BPROT_CONFIG0_REGION0_Msk (0x1UL << BPROT_CONFIG0_REGION0_Pos) /*!< Bit mask of REGION0 field. */
+#define BPROT_CONFIG0_REGION0_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG0_REGION0_Enabled (1UL) /*!< Protection enable */
+
+/* Register: BPROT_CONFIG1 */
+/* Description: Block protect configuration register 1 */
+
+/* Bit 31 : Enable protection for region 63. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION63_Pos (31UL) /*!< Position of REGION63 field. */
+#define BPROT_CONFIG1_REGION63_Msk (0x1UL << BPROT_CONFIG1_REGION63_Pos) /*!< Bit mask of REGION63 field. */
+#define BPROT_CONFIG1_REGION63_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION63_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 30 : Enable protection for region 62. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION62_Pos (30UL) /*!< Position of REGION62 field. */
+#define BPROT_CONFIG1_REGION62_Msk (0x1UL << BPROT_CONFIG1_REGION62_Pos) /*!< Bit mask of REGION62 field. */
+#define BPROT_CONFIG1_REGION62_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION62_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 29 : Enable protection for region 61. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION61_Pos (29UL) /*!< Position of REGION61 field. */
+#define BPROT_CONFIG1_REGION61_Msk (0x1UL << BPROT_CONFIG1_REGION61_Pos) /*!< Bit mask of REGION61 field. */
+#define BPROT_CONFIG1_REGION61_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION61_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 28 : Enable protection for region 60. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION60_Pos (28UL) /*!< Position of REGION60 field. */
+#define BPROT_CONFIG1_REGION60_Msk (0x1UL << BPROT_CONFIG1_REGION60_Pos) /*!< Bit mask of REGION60 field. */
+#define BPROT_CONFIG1_REGION60_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION60_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 27 : Enable protection for region 59. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION59_Pos (27UL) /*!< Position of REGION59 field. */
+#define BPROT_CONFIG1_REGION59_Msk (0x1UL << BPROT_CONFIG1_REGION59_Pos) /*!< Bit mask of REGION59 field. */
+#define BPROT_CONFIG1_REGION59_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION59_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 26 : Enable protection for region 58. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION58_Pos (26UL) /*!< Position of REGION58 field. */
+#define BPROT_CONFIG1_REGION58_Msk (0x1UL << BPROT_CONFIG1_REGION58_Pos) /*!< Bit mask of REGION58 field. */
+#define BPROT_CONFIG1_REGION58_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION58_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 25 : Enable protection for region 57. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION57_Pos (25UL) /*!< Position of REGION57 field. */
+#define BPROT_CONFIG1_REGION57_Msk (0x1UL << BPROT_CONFIG1_REGION57_Pos) /*!< Bit mask of REGION57 field. */
+#define BPROT_CONFIG1_REGION57_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION57_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 24 : Enable protection for region 56. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION56_Pos (24UL) /*!< Position of REGION56 field. */
+#define BPROT_CONFIG1_REGION56_Msk (0x1UL << BPROT_CONFIG1_REGION56_Pos) /*!< Bit mask of REGION56 field. */
+#define BPROT_CONFIG1_REGION56_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION56_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 23 : Enable protection for region 55. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION55_Pos (23UL) /*!< Position of REGION55 field. */
+#define BPROT_CONFIG1_REGION55_Msk (0x1UL << BPROT_CONFIG1_REGION55_Pos) /*!< Bit mask of REGION55 field. */
+#define BPROT_CONFIG1_REGION55_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION55_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 22 : Enable protection for region 54. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION54_Pos (22UL) /*!< Position of REGION54 field. */
+#define BPROT_CONFIG1_REGION54_Msk (0x1UL << BPROT_CONFIG1_REGION54_Pos) /*!< Bit mask of REGION54 field. */
+#define BPROT_CONFIG1_REGION54_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION54_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 21 : Enable protection for region 53. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION53_Pos (21UL) /*!< Position of REGION53 field. */
+#define BPROT_CONFIG1_REGION53_Msk (0x1UL << BPROT_CONFIG1_REGION53_Pos) /*!< Bit mask of REGION53 field. */
+#define BPROT_CONFIG1_REGION53_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION53_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 20 : Enable protection for region 52. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION52_Pos (20UL) /*!< Position of REGION52 field. */
+#define BPROT_CONFIG1_REGION52_Msk (0x1UL << BPROT_CONFIG1_REGION52_Pos) /*!< Bit mask of REGION52 field. */
+#define BPROT_CONFIG1_REGION52_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION52_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 19 : Enable protection for region 51. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION51_Pos (19UL) /*!< Position of REGION51 field. */
+#define BPROT_CONFIG1_REGION51_Msk (0x1UL << BPROT_CONFIG1_REGION51_Pos) /*!< Bit mask of REGION51 field. */
+#define BPROT_CONFIG1_REGION51_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION51_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 18 : Enable protection for region 50. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION50_Pos (18UL) /*!< Position of REGION50 field. */
+#define BPROT_CONFIG1_REGION50_Msk (0x1UL << BPROT_CONFIG1_REGION50_Pos) /*!< Bit mask of REGION50 field. */
+#define BPROT_CONFIG1_REGION50_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION50_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 17 : Enable protection for region 49. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION49_Pos (17UL) /*!< Position of REGION49 field. */
+#define BPROT_CONFIG1_REGION49_Msk (0x1UL << BPROT_CONFIG1_REGION49_Pos) /*!< Bit mask of REGION49 field. */
+#define BPROT_CONFIG1_REGION49_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION49_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 16 : Enable protection for region 48. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION48_Pos (16UL) /*!< Position of REGION48 field. */
+#define BPROT_CONFIG1_REGION48_Msk (0x1UL << BPROT_CONFIG1_REGION48_Pos) /*!< Bit mask of REGION48 field. */
+#define BPROT_CONFIG1_REGION48_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION48_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 15 : Enable protection for region 47. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION47_Pos (15UL) /*!< Position of REGION47 field. */
+#define BPROT_CONFIG1_REGION47_Msk (0x1UL << BPROT_CONFIG1_REGION47_Pos) /*!< Bit mask of REGION47 field. */
+#define BPROT_CONFIG1_REGION47_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION47_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 14 : Enable protection for region 46. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION46_Pos (14UL) /*!< Position of REGION46 field. */
+#define BPROT_CONFIG1_REGION46_Msk (0x1UL << BPROT_CONFIG1_REGION46_Pos) /*!< Bit mask of REGION46 field. */
+#define BPROT_CONFIG1_REGION46_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION46_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 13 : Enable protection for region 45. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION45_Pos (13UL) /*!< Position of REGION45 field. */
+#define BPROT_CONFIG1_REGION45_Msk (0x1UL << BPROT_CONFIG1_REGION45_Pos) /*!< Bit mask of REGION45 field. */
+#define BPROT_CONFIG1_REGION45_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION45_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 12 : Enable protection for region 44. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION44_Pos (12UL) /*!< Position of REGION44 field. */
+#define BPROT_CONFIG1_REGION44_Msk (0x1UL << BPROT_CONFIG1_REGION44_Pos) /*!< Bit mask of REGION44 field. */
+#define BPROT_CONFIG1_REGION44_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION44_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 11 : Enable protection for region 43. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION43_Pos (11UL) /*!< Position of REGION43 field. */
+#define BPROT_CONFIG1_REGION43_Msk (0x1UL << BPROT_CONFIG1_REGION43_Pos) /*!< Bit mask of REGION43 field. */
+#define BPROT_CONFIG1_REGION43_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION43_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 10 : Enable protection for region 42. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION42_Pos (10UL) /*!< Position of REGION42 field. */
+#define BPROT_CONFIG1_REGION42_Msk (0x1UL << BPROT_CONFIG1_REGION42_Pos) /*!< Bit mask of REGION42 field. */
+#define BPROT_CONFIG1_REGION42_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION42_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 9 : Enable protection for region 41. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION41_Pos (9UL) /*!< Position of REGION41 field. */
+#define BPROT_CONFIG1_REGION41_Msk (0x1UL << BPROT_CONFIG1_REGION41_Pos) /*!< Bit mask of REGION41 field. */
+#define BPROT_CONFIG1_REGION41_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION41_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 8 : Enable protection for region 40. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION40_Pos (8UL) /*!< Position of REGION40 field. */
+#define BPROT_CONFIG1_REGION40_Msk (0x1UL << BPROT_CONFIG1_REGION40_Pos) /*!< Bit mask of REGION40 field. */
+#define BPROT_CONFIG1_REGION40_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION40_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 7 : Enable protection for region 39. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION39_Pos (7UL) /*!< Position of REGION39 field. */
+#define BPROT_CONFIG1_REGION39_Msk (0x1UL << BPROT_CONFIG1_REGION39_Pos) /*!< Bit mask of REGION39 field. */
+#define BPROT_CONFIG1_REGION39_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION39_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 6 : Enable protection for region 38. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION38_Pos (6UL) /*!< Position of REGION38 field. */
+#define BPROT_CONFIG1_REGION38_Msk (0x1UL << BPROT_CONFIG1_REGION38_Pos) /*!< Bit mask of REGION38 field. */
+#define BPROT_CONFIG1_REGION38_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION38_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 5 : Enable protection for region 37. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION37_Pos (5UL) /*!< Position of REGION37 field. */
+#define BPROT_CONFIG1_REGION37_Msk (0x1UL << BPROT_CONFIG1_REGION37_Pos) /*!< Bit mask of REGION37 field. */
+#define BPROT_CONFIG1_REGION37_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION37_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 4 : Enable protection for region 36. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION36_Pos (4UL) /*!< Position of REGION36 field. */
+#define BPROT_CONFIG1_REGION36_Msk (0x1UL << BPROT_CONFIG1_REGION36_Pos) /*!< Bit mask of REGION36 field. */
+#define BPROT_CONFIG1_REGION36_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION36_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 3 : Enable protection for region 35. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION35_Pos (3UL) /*!< Position of REGION35 field. */
+#define BPROT_CONFIG1_REGION35_Msk (0x1UL << BPROT_CONFIG1_REGION35_Pos) /*!< Bit mask of REGION35 field. */
+#define BPROT_CONFIG1_REGION35_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION35_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 2 : Enable protection for region 34. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION34_Pos (2UL) /*!< Position of REGION34 field. */
+#define BPROT_CONFIG1_REGION34_Msk (0x1UL << BPROT_CONFIG1_REGION34_Pos) /*!< Bit mask of REGION34 field. */
+#define BPROT_CONFIG1_REGION34_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION34_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 1 : Enable protection for region 33. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION33_Pos (1UL) /*!< Position of REGION33 field. */
+#define BPROT_CONFIG1_REGION33_Msk (0x1UL << BPROT_CONFIG1_REGION33_Pos) /*!< Bit mask of REGION33 field. */
+#define BPROT_CONFIG1_REGION33_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION33_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 0 : Enable protection for region 32. Write '0' has no effect. */
+#define BPROT_CONFIG1_REGION32_Pos (0UL) /*!< Position of REGION32 field. */
+#define BPROT_CONFIG1_REGION32_Msk (0x1UL << BPROT_CONFIG1_REGION32_Pos) /*!< Bit mask of REGION32 field. */
+#define BPROT_CONFIG1_REGION32_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG1_REGION32_Enabled (1UL) /*!< Protection enabled */
+
+/* Register: BPROT_DISABLEINDEBUG */
+/* Description: Disable protection mechanism in debug mode */
+
+/* Bit 0 : Disable the protection mechanism for NVM regions while in debug mode. This register will only disable the protection mechanism if the device is in debug mode. */
+#define BPROT_DISABLEINDEBUG_DISABLEINDEBUG_Pos (0UL) /*!< Position of DISABLEINDEBUG field. */
+#define BPROT_DISABLEINDEBUG_DISABLEINDEBUG_Msk (0x1UL << BPROT_DISABLEINDEBUG_DISABLEINDEBUG_Pos) /*!< Bit mask of DISABLEINDEBUG field. */
+#define BPROT_DISABLEINDEBUG_DISABLEINDEBUG_Enabled (0UL) /*!< Enable in debug */
+#define BPROT_DISABLEINDEBUG_DISABLEINDEBUG_Disabled (1UL) /*!< Disable in debug */
+
+/* Register: BPROT_CONFIG2 */
+/* Description: Block protect configuration register 2 */
+
+/* Bit 31 : Enable protection for region 95. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION95_Pos (31UL) /*!< Position of REGION95 field. */
+#define BPROT_CONFIG2_REGION95_Msk (0x1UL << BPROT_CONFIG2_REGION95_Pos) /*!< Bit mask of REGION95 field. */
+#define BPROT_CONFIG2_REGION95_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION95_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 30 : Enable protection for region 94. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION94_Pos (30UL) /*!< Position of REGION94 field. */
+#define BPROT_CONFIG2_REGION94_Msk (0x1UL << BPROT_CONFIG2_REGION94_Pos) /*!< Bit mask of REGION94 field. */
+#define BPROT_CONFIG2_REGION94_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION94_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 29 : Enable protection for region 93. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION93_Pos (29UL) /*!< Position of REGION93 field. */
+#define BPROT_CONFIG2_REGION93_Msk (0x1UL << BPROT_CONFIG2_REGION93_Pos) /*!< Bit mask of REGION93 field. */
+#define BPROT_CONFIG2_REGION93_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION93_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 28 : Enable protection for region 92. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION92_Pos (28UL) /*!< Position of REGION92 field. */
+#define BPROT_CONFIG2_REGION92_Msk (0x1UL << BPROT_CONFIG2_REGION92_Pos) /*!< Bit mask of REGION92 field. */
+#define BPROT_CONFIG2_REGION92_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION92_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 27 : Enable protection for region 91. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION91_Pos (27UL) /*!< Position of REGION91 field. */
+#define BPROT_CONFIG2_REGION91_Msk (0x1UL << BPROT_CONFIG2_REGION91_Pos) /*!< Bit mask of REGION91 field. */
+#define BPROT_CONFIG2_REGION91_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION91_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 26 : Enable protection for region 90. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION90_Pos (26UL) /*!< Position of REGION90 field. */
+#define BPROT_CONFIG2_REGION90_Msk (0x1UL << BPROT_CONFIG2_REGION90_Pos) /*!< Bit mask of REGION90 field. */
+#define BPROT_CONFIG2_REGION90_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION90_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 25 : Enable protection for region 89. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION89_Pos (25UL) /*!< Position of REGION89 field. */
+#define BPROT_CONFIG2_REGION89_Msk (0x1UL << BPROT_CONFIG2_REGION89_Pos) /*!< Bit mask of REGION89 field. */
+#define BPROT_CONFIG2_REGION89_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION89_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 24 : Enable protection for region 88. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION88_Pos (24UL) /*!< Position of REGION88 field. */
+#define BPROT_CONFIG2_REGION88_Msk (0x1UL << BPROT_CONFIG2_REGION88_Pos) /*!< Bit mask of REGION88 field. */
+#define BPROT_CONFIG2_REGION88_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION88_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 23 : Enable protection for region 87. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION87_Pos (23UL) /*!< Position of REGION87 field. */
+#define BPROT_CONFIG2_REGION87_Msk (0x1UL << BPROT_CONFIG2_REGION87_Pos) /*!< Bit mask of REGION87 field. */
+#define BPROT_CONFIG2_REGION87_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION87_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 22 : Enable protection for region 86. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION86_Pos (22UL) /*!< Position of REGION86 field. */
+#define BPROT_CONFIG2_REGION86_Msk (0x1UL << BPROT_CONFIG2_REGION86_Pos) /*!< Bit mask of REGION86 field. */
+#define BPROT_CONFIG2_REGION86_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION86_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 21 : Enable protection for region 85. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION85_Pos (21UL) /*!< Position of REGION85 field. */
+#define BPROT_CONFIG2_REGION85_Msk (0x1UL << BPROT_CONFIG2_REGION85_Pos) /*!< Bit mask of REGION85 field. */
+#define BPROT_CONFIG2_REGION85_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION85_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 20 : Enable protection for region 84. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION84_Pos (20UL) /*!< Position of REGION84 field. */
+#define BPROT_CONFIG2_REGION84_Msk (0x1UL << BPROT_CONFIG2_REGION84_Pos) /*!< Bit mask of REGION84 field. */
+#define BPROT_CONFIG2_REGION84_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION84_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 19 : Enable protection for region 83. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION83_Pos (19UL) /*!< Position of REGION83 field. */
+#define BPROT_CONFIG2_REGION83_Msk (0x1UL << BPROT_CONFIG2_REGION83_Pos) /*!< Bit mask of REGION83 field. */
+#define BPROT_CONFIG2_REGION83_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION83_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 18 : Enable protection for region 82. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION82_Pos (18UL) /*!< Position of REGION82 field. */
+#define BPROT_CONFIG2_REGION82_Msk (0x1UL << BPROT_CONFIG2_REGION82_Pos) /*!< Bit mask of REGION82 field. */
+#define BPROT_CONFIG2_REGION82_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION82_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 17 : Enable protection for region 81. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION81_Pos (17UL) /*!< Position of REGION81 field. */
+#define BPROT_CONFIG2_REGION81_Msk (0x1UL << BPROT_CONFIG2_REGION81_Pos) /*!< Bit mask of REGION81 field. */
+#define BPROT_CONFIG2_REGION81_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION81_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 16 : Enable protection for region 80. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION80_Pos (16UL) /*!< Position of REGION80 field. */
+#define BPROT_CONFIG2_REGION80_Msk (0x1UL << BPROT_CONFIG2_REGION80_Pos) /*!< Bit mask of REGION80 field. */
+#define BPROT_CONFIG2_REGION80_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION80_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 15 : Enable protection for region 79. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION79_Pos (15UL) /*!< Position of REGION79 field. */
+#define BPROT_CONFIG2_REGION79_Msk (0x1UL << BPROT_CONFIG2_REGION79_Pos) /*!< Bit mask of REGION79 field. */
+#define BPROT_CONFIG2_REGION79_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION79_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 14 : Enable protection for region 78. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION78_Pos (14UL) /*!< Position of REGION78 field. */
+#define BPROT_CONFIG2_REGION78_Msk (0x1UL << BPROT_CONFIG2_REGION78_Pos) /*!< Bit mask of REGION78 field. */
+#define BPROT_CONFIG2_REGION78_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION78_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 13 : Enable protection for region 77. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION77_Pos (13UL) /*!< Position of REGION77 field. */
+#define BPROT_CONFIG2_REGION77_Msk (0x1UL << BPROT_CONFIG2_REGION77_Pos) /*!< Bit mask of REGION77 field. */
+#define BPROT_CONFIG2_REGION77_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION77_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 12 : Enable protection for region 76. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION76_Pos (12UL) /*!< Position of REGION76 field. */
+#define BPROT_CONFIG2_REGION76_Msk (0x1UL << BPROT_CONFIG2_REGION76_Pos) /*!< Bit mask of REGION76 field. */
+#define BPROT_CONFIG2_REGION76_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION76_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 11 : Enable protection for region 75. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION75_Pos (11UL) /*!< Position of REGION75 field. */
+#define BPROT_CONFIG2_REGION75_Msk (0x1UL << BPROT_CONFIG2_REGION75_Pos) /*!< Bit mask of REGION75 field. */
+#define BPROT_CONFIG2_REGION75_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION75_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 10 : Enable protection for region 74. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION74_Pos (10UL) /*!< Position of REGION74 field. */
+#define BPROT_CONFIG2_REGION74_Msk (0x1UL << BPROT_CONFIG2_REGION74_Pos) /*!< Bit mask of REGION74 field. */
+#define BPROT_CONFIG2_REGION74_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION74_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 9 : Enable protection for region 73. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION73_Pos (9UL) /*!< Position of REGION73 field. */
+#define BPROT_CONFIG2_REGION73_Msk (0x1UL << BPROT_CONFIG2_REGION73_Pos) /*!< Bit mask of REGION73 field. */
+#define BPROT_CONFIG2_REGION73_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION73_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 8 : Enable protection for region 72. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION72_Pos (8UL) /*!< Position of REGION72 field. */
+#define BPROT_CONFIG2_REGION72_Msk (0x1UL << BPROT_CONFIG2_REGION72_Pos) /*!< Bit mask of REGION72 field. */
+#define BPROT_CONFIG2_REGION72_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION72_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 7 : Enable protection for region 71. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION71_Pos (7UL) /*!< Position of REGION71 field. */
+#define BPROT_CONFIG2_REGION71_Msk (0x1UL << BPROT_CONFIG2_REGION71_Pos) /*!< Bit mask of REGION71 field. */
+#define BPROT_CONFIG2_REGION71_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION71_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 6 : Enable protection for region 70. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION70_Pos (6UL) /*!< Position of REGION70 field. */
+#define BPROT_CONFIG2_REGION70_Msk (0x1UL << BPROT_CONFIG2_REGION70_Pos) /*!< Bit mask of REGION70 field. */
+#define BPROT_CONFIG2_REGION70_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION70_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 5 : Enable protection for region 69. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION69_Pos (5UL) /*!< Position of REGION69 field. */
+#define BPROT_CONFIG2_REGION69_Msk (0x1UL << BPROT_CONFIG2_REGION69_Pos) /*!< Bit mask of REGION69 field. */
+#define BPROT_CONFIG2_REGION69_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION69_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 4 : Enable protection for region 68. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION68_Pos (4UL) /*!< Position of REGION68 field. */
+#define BPROT_CONFIG2_REGION68_Msk (0x1UL << BPROT_CONFIG2_REGION68_Pos) /*!< Bit mask of REGION68 field. */
+#define BPROT_CONFIG2_REGION68_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION68_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 3 : Enable protection for region 67. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION67_Pos (3UL) /*!< Position of REGION67 field. */
+#define BPROT_CONFIG2_REGION67_Msk (0x1UL << BPROT_CONFIG2_REGION67_Pos) /*!< Bit mask of REGION67 field. */
+#define BPROT_CONFIG2_REGION67_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION67_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 2 : Enable protection for region 66. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION66_Pos (2UL) /*!< Position of REGION66 field. */
+#define BPROT_CONFIG2_REGION66_Msk (0x1UL << BPROT_CONFIG2_REGION66_Pos) /*!< Bit mask of REGION66 field. */
+#define BPROT_CONFIG2_REGION66_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION66_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 1 : Enable protection for region 65. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION65_Pos (1UL) /*!< Position of REGION65 field. */
+#define BPROT_CONFIG2_REGION65_Msk (0x1UL << BPROT_CONFIG2_REGION65_Pos) /*!< Bit mask of REGION65 field. */
+#define BPROT_CONFIG2_REGION65_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION65_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 0 : Enable protection for region 64. Write '0' has no effect. */
+#define BPROT_CONFIG2_REGION64_Pos (0UL) /*!< Position of REGION64 field. */
+#define BPROT_CONFIG2_REGION64_Msk (0x1UL << BPROT_CONFIG2_REGION64_Pos) /*!< Bit mask of REGION64 field. */
+#define BPROT_CONFIG2_REGION64_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG2_REGION64_Enabled (1UL) /*!< Protection enabled */
+
+/* Register: BPROT_CONFIG3 */
+/* Description: Block protect configuration register 3 */
+
+/* Bit 31 : Enable protection for region 127. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION127_Pos (31UL) /*!< Position of REGION127 field. */
+#define BPROT_CONFIG3_REGION127_Msk (0x1UL << BPROT_CONFIG3_REGION127_Pos) /*!< Bit mask of REGION127 field. */
+#define BPROT_CONFIG3_REGION127_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION127_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 30 : Enable protection for region 126. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION126_Pos (30UL) /*!< Position of REGION126 field. */
+#define BPROT_CONFIG3_REGION126_Msk (0x1UL << BPROT_CONFIG3_REGION126_Pos) /*!< Bit mask of REGION126 field. */
+#define BPROT_CONFIG3_REGION126_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION126_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 29 : Enable protection for region 125. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION125_Pos (29UL) /*!< Position of REGION125 field. */
+#define BPROT_CONFIG3_REGION125_Msk (0x1UL << BPROT_CONFIG3_REGION125_Pos) /*!< Bit mask of REGION125 field. */
+#define BPROT_CONFIG3_REGION125_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION125_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 28 : Enable protection for region 124. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION124_Pos (28UL) /*!< Position of REGION124 field. */
+#define BPROT_CONFIG3_REGION124_Msk (0x1UL << BPROT_CONFIG3_REGION124_Pos) /*!< Bit mask of REGION124 field. */
+#define BPROT_CONFIG3_REGION124_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION124_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 27 : Enable protection for region 123. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION123_Pos (27UL) /*!< Position of REGION123 field. */
+#define BPROT_CONFIG3_REGION123_Msk (0x1UL << BPROT_CONFIG3_REGION123_Pos) /*!< Bit mask of REGION123 field. */
+#define BPROT_CONFIG3_REGION123_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION123_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 26 : Enable protection for region 122. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION122_Pos (26UL) /*!< Position of REGION122 field. */
+#define BPROT_CONFIG3_REGION122_Msk (0x1UL << BPROT_CONFIG3_REGION122_Pos) /*!< Bit mask of REGION122 field. */
+#define BPROT_CONFIG3_REGION122_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION122_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 25 : Enable protection for region 121. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION121_Pos (25UL) /*!< Position of REGION121 field. */
+#define BPROT_CONFIG3_REGION121_Msk (0x1UL << BPROT_CONFIG3_REGION121_Pos) /*!< Bit mask of REGION121 field. */
+#define BPROT_CONFIG3_REGION121_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION121_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 24 : Enable protection for region 120. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION120_Pos (24UL) /*!< Position of REGION120 field. */
+#define BPROT_CONFIG3_REGION120_Msk (0x1UL << BPROT_CONFIG3_REGION120_Pos) /*!< Bit mask of REGION120 field. */
+#define BPROT_CONFIG3_REGION120_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION120_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 23 : Enable protection for region 119. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION119_Pos (23UL) /*!< Position of REGION119 field. */
+#define BPROT_CONFIG3_REGION119_Msk (0x1UL << BPROT_CONFIG3_REGION119_Pos) /*!< Bit mask of REGION119 field. */
+#define BPROT_CONFIG3_REGION119_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION119_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 22 : Enable protection for region 118. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION118_Pos (22UL) /*!< Position of REGION118 field. */
+#define BPROT_CONFIG3_REGION118_Msk (0x1UL << BPROT_CONFIG3_REGION118_Pos) /*!< Bit mask of REGION118 field. */
+#define BPROT_CONFIG3_REGION118_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION118_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 21 : Enable protection for region 117. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION117_Pos (21UL) /*!< Position of REGION117 field. */
+#define BPROT_CONFIG3_REGION117_Msk (0x1UL << BPROT_CONFIG3_REGION117_Pos) /*!< Bit mask of REGION117 field. */
+#define BPROT_CONFIG3_REGION117_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION117_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 20 : Enable protection for region 116. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION116_Pos (20UL) /*!< Position of REGION116 field. */
+#define BPROT_CONFIG3_REGION116_Msk (0x1UL << BPROT_CONFIG3_REGION116_Pos) /*!< Bit mask of REGION116 field. */
+#define BPROT_CONFIG3_REGION116_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION116_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 19 : Enable protection for region 115. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION115_Pos (19UL) /*!< Position of REGION115 field. */
+#define BPROT_CONFIG3_REGION115_Msk (0x1UL << BPROT_CONFIG3_REGION115_Pos) /*!< Bit mask of REGION115 field. */
+#define BPROT_CONFIG3_REGION115_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION115_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 18 : Enable protection for region 114. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION114_Pos (18UL) /*!< Position of REGION114 field. */
+#define BPROT_CONFIG3_REGION114_Msk (0x1UL << BPROT_CONFIG3_REGION114_Pos) /*!< Bit mask of REGION114 field. */
+#define BPROT_CONFIG3_REGION114_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION114_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 17 : Enable protection for region 113. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION113_Pos (17UL) /*!< Position of REGION113 field. */
+#define BPROT_CONFIG3_REGION113_Msk (0x1UL << BPROT_CONFIG3_REGION113_Pos) /*!< Bit mask of REGION113 field. */
+#define BPROT_CONFIG3_REGION113_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION113_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 16 : Enable protection for region 112. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION112_Pos (16UL) /*!< Position of REGION112 field. */
+#define BPROT_CONFIG3_REGION112_Msk (0x1UL << BPROT_CONFIG3_REGION112_Pos) /*!< Bit mask of REGION112 field. */
+#define BPROT_CONFIG3_REGION112_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION112_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 15 : Enable protection for region 111. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION111_Pos (15UL) /*!< Position of REGION111 field. */
+#define BPROT_CONFIG3_REGION111_Msk (0x1UL << BPROT_CONFIG3_REGION111_Pos) /*!< Bit mask of REGION111 field. */
+#define BPROT_CONFIG3_REGION111_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION111_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 14 : Enable protection for region 110. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION110_Pos (14UL) /*!< Position of REGION110 field. */
+#define BPROT_CONFIG3_REGION110_Msk (0x1UL << BPROT_CONFIG3_REGION110_Pos) /*!< Bit mask of REGION110 field. */
+#define BPROT_CONFIG3_REGION110_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION110_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 13 : Enable protection for region 109. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION109_Pos (13UL) /*!< Position of REGION109 field. */
+#define BPROT_CONFIG3_REGION109_Msk (0x1UL << BPROT_CONFIG3_REGION109_Pos) /*!< Bit mask of REGION109 field. */
+#define BPROT_CONFIG3_REGION109_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION109_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 12 : Enable protection for region 108. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION108_Pos (12UL) /*!< Position of REGION108 field. */
+#define BPROT_CONFIG3_REGION108_Msk (0x1UL << BPROT_CONFIG3_REGION108_Pos) /*!< Bit mask of REGION108 field. */
+#define BPROT_CONFIG3_REGION108_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION108_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 11 : Enable protection for region 107. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION107_Pos (11UL) /*!< Position of REGION107 field. */
+#define BPROT_CONFIG3_REGION107_Msk (0x1UL << BPROT_CONFIG3_REGION107_Pos) /*!< Bit mask of REGION107 field. */
+#define BPROT_CONFIG3_REGION107_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION107_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 10 : Enable protection for region 106. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION106_Pos (10UL) /*!< Position of REGION106 field. */
+#define BPROT_CONFIG3_REGION106_Msk (0x1UL << BPROT_CONFIG3_REGION106_Pos) /*!< Bit mask of REGION106 field. */
+#define BPROT_CONFIG3_REGION106_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION106_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 9 : Enable protection for region 105. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION105_Pos (9UL) /*!< Position of REGION105 field. */
+#define BPROT_CONFIG3_REGION105_Msk (0x1UL << BPROT_CONFIG3_REGION105_Pos) /*!< Bit mask of REGION105 field. */
+#define BPROT_CONFIG3_REGION105_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION105_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 8 : Enable protection for region 104. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION104_Pos (8UL) /*!< Position of REGION104 field. */
+#define BPROT_CONFIG3_REGION104_Msk (0x1UL << BPROT_CONFIG3_REGION104_Pos) /*!< Bit mask of REGION104 field. */
+#define BPROT_CONFIG3_REGION104_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION104_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 7 : Enable protection for region 103. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION103_Pos (7UL) /*!< Position of REGION103 field. */
+#define BPROT_CONFIG3_REGION103_Msk (0x1UL << BPROT_CONFIG3_REGION103_Pos) /*!< Bit mask of REGION103 field. */
+#define BPROT_CONFIG3_REGION103_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION103_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 6 : Enable protection for region 102. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION102_Pos (6UL) /*!< Position of REGION102 field. */
+#define BPROT_CONFIG3_REGION102_Msk (0x1UL << BPROT_CONFIG3_REGION102_Pos) /*!< Bit mask of REGION102 field. */
+#define BPROT_CONFIG3_REGION102_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION102_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 5 : Enable protection for region 101. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION101_Pos (5UL) /*!< Position of REGION101 field. */
+#define BPROT_CONFIG3_REGION101_Msk (0x1UL << BPROT_CONFIG3_REGION101_Pos) /*!< Bit mask of REGION101 field. */
+#define BPROT_CONFIG3_REGION101_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION101_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 4 : Enable protection for region 100. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION100_Pos (4UL) /*!< Position of REGION100 field. */
+#define BPROT_CONFIG3_REGION100_Msk (0x1UL << BPROT_CONFIG3_REGION100_Pos) /*!< Bit mask of REGION100 field. */
+#define BPROT_CONFIG3_REGION100_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION100_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 3 : Enable protection for region 99. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION99_Pos (3UL) /*!< Position of REGION99 field. */
+#define BPROT_CONFIG3_REGION99_Msk (0x1UL << BPROT_CONFIG3_REGION99_Pos) /*!< Bit mask of REGION99 field. */
+#define BPROT_CONFIG3_REGION99_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION99_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 2 : Enable protection for region 98. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION98_Pos (2UL) /*!< Position of REGION98 field. */
+#define BPROT_CONFIG3_REGION98_Msk (0x1UL << BPROT_CONFIG3_REGION98_Pos) /*!< Bit mask of REGION98 field. */
+#define BPROT_CONFIG3_REGION98_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION98_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 1 : Enable protection for region 97. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION97_Pos (1UL) /*!< Position of REGION97 field. */
+#define BPROT_CONFIG3_REGION97_Msk (0x1UL << BPROT_CONFIG3_REGION97_Pos) /*!< Bit mask of REGION97 field. */
+#define BPROT_CONFIG3_REGION97_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION97_Enabled (1UL) /*!< Protection enabled */
+
+/* Bit 0 : Enable protection for region 96. Write '0' has no effect. */
+#define BPROT_CONFIG3_REGION96_Pos (0UL) /*!< Position of REGION96 field. */
+#define BPROT_CONFIG3_REGION96_Msk (0x1UL << BPROT_CONFIG3_REGION96_Pos) /*!< Bit mask of REGION96 field. */
+#define BPROT_CONFIG3_REGION96_Disabled (0UL) /*!< Protection disabled */
+#define BPROT_CONFIG3_REGION96_Enabled (1UL) /*!< Protection enabled */
+
+
+/* Peripheral: CCM */
+/* Description: AES CCM Mode Encryption */
+
+/* Register: CCM_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 0 : Shortcut between ENDKSGEN event and CRYPT task */
+#define CCM_SHORTS_ENDKSGEN_CRYPT_Pos (0UL) /*!< Position of ENDKSGEN_CRYPT field. */
+#define CCM_SHORTS_ENDKSGEN_CRYPT_Msk (0x1UL << CCM_SHORTS_ENDKSGEN_CRYPT_Pos) /*!< Bit mask of ENDKSGEN_CRYPT field. */
+#define CCM_SHORTS_ENDKSGEN_CRYPT_Disabled (0UL) /*!< Disable shortcut */
+#define CCM_SHORTS_ENDKSGEN_CRYPT_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: CCM_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 2 : Write '1' to Enable interrupt for ERROR event */
+#define CCM_INTENSET_ERROR_Pos (2UL) /*!< Position of ERROR field. */
+#define CCM_INTENSET_ERROR_Msk (0x1UL << CCM_INTENSET_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define CCM_INTENSET_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define CCM_INTENSET_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define CCM_INTENSET_ERROR_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for ENDCRYPT event */
+#define CCM_INTENSET_ENDCRYPT_Pos (1UL) /*!< Position of ENDCRYPT field. */
+#define CCM_INTENSET_ENDCRYPT_Msk (0x1UL << CCM_INTENSET_ENDCRYPT_Pos) /*!< Bit mask of ENDCRYPT field. */
+#define CCM_INTENSET_ENDCRYPT_Disabled (0UL) /*!< Read: Disabled */
+#define CCM_INTENSET_ENDCRYPT_Enabled (1UL) /*!< Read: Enabled */
+#define CCM_INTENSET_ENDCRYPT_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for ENDKSGEN event */
+#define CCM_INTENSET_ENDKSGEN_Pos (0UL) /*!< Position of ENDKSGEN field. */
+#define CCM_INTENSET_ENDKSGEN_Msk (0x1UL << CCM_INTENSET_ENDKSGEN_Pos) /*!< Bit mask of ENDKSGEN field. */
+#define CCM_INTENSET_ENDKSGEN_Disabled (0UL) /*!< Read: Disabled */
+#define CCM_INTENSET_ENDKSGEN_Enabled (1UL) /*!< Read: Enabled */
+#define CCM_INTENSET_ENDKSGEN_Set (1UL) /*!< Enable */
+
+/* Register: CCM_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 2 : Write '1' to Disable interrupt for ERROR event */
+#define CCM_INTENCLR_ERROR_Pos (2UL) /*!< Position of ERROR field. */
+#define CCM_INTENCLR_ERROR_Msk (0x1UL << CCM_INTENCLR_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define CCM_INTENCLR_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define CCM_INTENCLR_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define CCM_INTENCLR_ERROR_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for ENDCRYPT event */
+#define CCM_INTENCLR_ENDCRYPT_Pos (1UL) /*!< Position of ENDCRYPT field. */
+#define CCM_INTENCLR_ENDCRYPT_Msk (0x1UL << CCM_INTENCLR_ENDCRYPT_Pos) /*!< Bit mask of ENDCRYPT field. */
+#define CCM_INTENCLR_ENDCRYPT_Disabled (0UL) /*!< Read: Disabled */
+#define CCM_INTENCLR_ENDCRYPT_Enabled (1UL) /*!< Read: Enabled */
+#define CCM_INTENCLR_ENDCRYPT_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for ENDKSGEN event */
+#define CCM_INTENCLR_ENDKSGEN_Pos (0UL) /*!< Position of ENDKSGEN field. */
+#define CCM_INTENCLR_ENDKSGEN_Msk (0x1UL << CCM_INTENCLR_ENDKSGEN_Pos) /*!< Bit mask of ENDKSGEN field. */
+#define CCM_INTENCLR_ENDKSGEN_Disabled (0UL) /*!< Read: Disabled */
+#define CCM_INTENCLR_ENDKSGEN_Enabled (1UL) /*!< Read: Enabled */
+#define CCM_INTENCLR_ENDKSGEN_Clear (1UL) /*!< Disable */
+
+/* Register: CCM_MICSTATUS */
+/* Description: MIC check result */
+
+/* Bit 0 : The result of the MIC check performed during the previous decryption operation */
+#define CCM_MICSTATUS_MICSTATUS_Pos (0UL) /*!< Position of MICSTATUS field. */
+#define CCM_MICSTATUS_MICSTATUS_Msk (0x1UL << CCM_MICSTATUS_MICSTATUS_Pos) /*!< Bit mask of MICSTATUS field. */
+#define CCM_MICSTATUS_MICSTATUS_CheckFailed (0UL) /*!< MIC check failed */
+#define CCM_MICSTATUS_MICSTATUS_CheckPassed (1UL) /*!< MIC check passed */
+
+/* Register: CCM_ENABLE */
+/* Description: Enable */
+
+/* Bits 1..0 : Enable or disable CCM */
+#define CCM_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define CCM_ENABLE_ENABLE_Msk (0x3UL << CCM_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define CCM_ENABLE_ENABLE_Disabled (0UL) /*!< Disable */
+#define CCM_ENABLE_ENABLE_Enabled (2UL) /*!< Enable */
+
+/* Register: CCM_MODE */
+/* Description: Operation mode */
+
+/* Bit 24 : Packet length configuration */
+#define CCM_MODE_LENGTH_Pos (24UL) /*!< Position of LENGTH field. */
+#define CCM_MODE_LENGTH_Msk (0x1UL << CCM_MODE_LENGTH_Pos) /*!< Bit mask of LENGTH field. */
+#define CCM_MODE_LENGTH_Default (0UL) /*!< Default length. Effective length of LENGTH field is 5-bit */
+#define CCM_MODE_LENGTH_Extended (1UL) /*!< Extended length. Effective length of LENGTH field is 8-bit */
+
+/* Bit 16 : Data rate that the CCM shall run in synch with */
+#define CCM_MODE_DATARATE_Pos (16UL) /*!< Position of DATARATE field. */
+#define CCM_MODE_DATARATE_Msk (0x1UL << CCM_MODE_DATARATE_Pos) /*!< Bit mask of DATARATE field. */
+#define CCM_MODE_DATARATE_1Mbit (0UL) /*!< In synch with 1 Mbit data rate */
+#define CCM_MODE_DATARATE_2Mbit (1UL) /*!< In synch with 2 Mbit data rate */
+
+/* Bit 0 : The mode of operation to be used */
+#define CCM_MODE_MODE_Pos (0UL) /*!< Position of MODE field. */
+#define CCM_MODE_MODE_Msk (0x1UL << CCM_MODE_MODE_Pos) /*!< Bit mask of MODE field. */
+#define CCM_MODE_MODE_Encryption (0UL) /*!< AES CCM packet encryption mode */
+#define CCM_MODE_MODE_Decryption (1UL) /*!< AES CCM packet decryption mode */
+
+/* Register: CCM_CNFPTR */
+/* Description: Pointer to data structure holding AES key and NONCE vector */
+
+/* Bits 31..0 : Pointer to the data structure holding the AES key and the CCM NONCE vector (see Table 1 CCM data structure overview) */
+#define CCM_CNFPTR_CNFPTR_Pos (0UL) /*!< Position of CNFPTR field. */
+#define CCM_CNFPTR_CNFPTR_Msk (0xFFFFFFFFUL << CCM_CNFPTR_CNFPTR_Pos) /*!< Bit mask of CNFPTR field. */
+
+/* Register: CCM_INPTR */
+/* Description: Input pointer */
+
+/* Bits 31..0 : Input pointer */
+#define CCM_INPTR_INPTR_Pos (0UL) /*!< Position of INPTR field. */
+#define CCM_INPTR_INPTR_Msk (0xFFFFFFFFUL << CCM_INPTR_INPTR_Pos) /*!< Bit mask of INPTR field. */
+
+/* Register: CCM_OUTPTR */
+/* Description: Output pointer */
+
+/* Bits 31..0 : Output pointer */
+#define CCM_OUTPTR_OUTPTR_Pos (0UL) /*!< Position of OUTPTR field. */
+#define CCM_OUTPTR_OUTPTR_Msk (0xFFFFFFFFUL << CCM_OUTPTR_OUTPTR_Pos) /*!< Bit mask of OUTPTR field. */
+
+/* Register: CCM_SCRATCHPTR */
+/* Description: Pointer to data area used for temporary storage */
+
+/* Bits 31..0 : Pointer to a "scratch" data area used for temporary storage during key-stream generation, MIC generation and encryption/decryption. */
+#define CCM_SCRATCHPTR_SCRATCHPTR_Pos (0UL) /*!< Position of SCRATCHPTR field. */
+#define CCM_SCRATCHPTR_SCRATCHPTR_Msk (0xFFFFFFFFUL << CCM_SCRATCHPTR_SCRATCHPTR_Pos) /*!< Bit mask of SCRATCHPTR field. */
+
+
+/* Peripheral: CLOCK */
+/* Description: Clock control */
+
+/* Register: CLOCK_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 4 : Write '1' to Enable interrupt for CTTO event */
+#define CLOCK_INTENSET_CTTO_Pos (4UL) /*!< Position of CTTO field. */
+#define CLOCK_INTENSET_CTTO_Msk (0x1UL << CLOCK_INTENSET_CTTO_Pos) /*!< Bit mask of CTTO field. */
+#define CLOCK_INTENSET_CTTO_Disabled (0UL) /*!< Read: Disabled */
+#define CLOCK_INTENSET_CTTO_Enabled (1UL) /*!< Read: Enabled */
+#define CLOCK_INTENSET_CTTO_Set (1UL) /*!< Enable */
+
+/* Bit 3 : Write '1' to Enable interrupt for DONE event */
+#define CLOCK_INTENSET_DONE_Pos (3UL) /*!< Position of DONE field. */
+#define CLOCK_INTENSET_DONE_Msk (0x1UL << CLOCK_INTENSET_DONE_Pos) /*!< Bit mask of DONE field. */
+#define CLOCK_INTENSET_DONE_Disabled (0UL) /*!< Read: Disabled */
+#define CLOCK_INTENSET_DONE_Enabled (1UL) /*!< Read: Enabled */
+#define CLOCK_INTENSET_DONE_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for LFCLKSTARTED event */
+#define CLOCK_INTENSET_LFCLKSTARTED_Pos (1UL) /*!< Position of LFCLKSTARTED field. */
+#define CLOCK_INTENSET_LFCLKSTARTED_Msk (0x1UL << CLOCK_INTENSET_LFCLKSTARTED_Pos) /*!< Bit mask of LFCLKSTARTED field. */
+#define CLOCK_INTENSET_LFCLKSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define CLOCK_INTENSET_LFCLKSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define CLOCK_INTENSET_LFCLKSTARTED_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for HFCLKSTARTED event */
+#define CLOCK_INTENSET_HFCLKSTARTED_Pos (0UL) /*!< Position of HFCLKSTARTED field. */
+#define CLOCK_INTENSET_HFCLKSTARTED_Msk (0x1UL << CLOCK_INTENSET_HFCLKSTARTED_Pos) /*!< Bit mask of HFCLKSTARTED field. */
+#define CLOCK_INTENSET_HFCLKSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define CLOCK_INTENSET_HFCLKSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define CLOCK_INTENSET_HFCLKSTARTED_Set (1UL) /*!< Enable */
+
+/* Register: CLOCK_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 4 : Write '1' to Disable interrupt for CTTO event */
+#define CLOCK_INTENCLR_CTTO_Pos (4UL) /*!< Position of CTTO field. */
+#define CLOCK_INTENCLR_CTTO_Msk (0x1UL << CLOCK_INTENCLR_CTTO_Pos) /*!< Bit mask of CTTO field. */
+#define CLOCK_INTENCLR_CTTO_Disabled (0UL) /*!< Read: Disabled */
+#define CLOCK_INTENCLR_CTTO_Enabled (1UL) /*!< Read: Enabled */
+#define CLOCK_INTENCLR_CTTO_Clear (1UL) /*!< Disable */
+
+/* Bit 3 : Write '1' to Disable interrupt for DONE event */
+#define CLOCK_INTENCLR_DONE_Pos (3UL) /*!< Position of DONE field. */
+#define CLOCK_INTENCLR_DONE_Msk (0x1UL << CLOCK_INTENCLR_DONE_Pos) /*!< Bit mask of DONE field. */
+#define CLOCK_INTENCLR_DONE_Disabled (0UL) /*!< Read: Disabled */
+#define CLOCK_INTENCLR_DONE_Enabled (1UL) /*!< Read: Enabled */
+#define CLOCK_INTENCLR_DONE_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for LFCLKSTARTED event */
+#define CLOCK_INTENCLR_LFCLKSTARTED_Pos (1UL) /*!< Position of LFCLKSTARTED field. */
+#define CLOCK_INTENCLR_LFCLKSTARTED_Msk (0x1UL << CLOCK_INTENCLR_LFCLKSTARTED_Pos) /*!< Bit mask of LFCLKSTARTED field. */
+#define CLOCK_INTENCLR_LFCLKSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define CLOCK_INTENCLR_LFCLKSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define CLOCK_INTENCLR_LFCLKSTARTED_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for HFCLKSTARTED event */
+#define CLOCK_INTENCLR_HFCLKSTARTED_Pos (0UL) /*!< Position of HFCLKSTARTED field. */
+#define CLOCK_INTENCLR_HFCLKSTARTED_Msk (0x1UL << CLOCK_INTENCLR_HFCLKSTARTED_Pos) /*!< Bit mask of HFCLKSTARTED field. */
+#define CLOCK_INTENCLR_HFCLKSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define CLOCK_INTENCLR_HFCLKSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define CLOCK_INTENCLR_HFCLKSTARTED_Clear (1UL) /*!< Disable */
+
+/* Register: CLOCK_HFCLKRUN */
+/* Description: Status indicating that HFCLKSTART task has been triggered */
+
+/* Bit 0 : HFCLKSTART task triggered or not */
+#define CLOCK_HFCLKRUN_STATUS_Pos (0UL) /*!< Position of STATUS field. */
+#define CLOCK_HFCLKRUN_STATUS_Msk (0x1UL << CLOCK_HFCLKRUN_STATUS_Pos) /*!< Bit mask of STATUS field. */
+#define CLOCK_HFCLKRUN_STATUS_NotTriggered (0UL) /*!< Task not triggered */
+#define CLOCK_HFCLKRUN_STATUS_Triggered (1UL) /*!< Task triggered */
+
+/* Register: CLOCK_HFCLKSTAT */
+/* Description: HFCLK status */
+
+/* Bit 16 : HFCLK state */
+#define CLOCK_HFCLKSTAT_STATE_Pos (16UL) /*!< Position of STATE field. */
+#define CLOCK_HFCLKSTAT_STATE_Msk (0x1UL << CLOCK_HFCLKSTAT_STATE_Pos) /*!< Bit mask of STATE field. */
+#define CLOCK_HFCLKSTAT_STATE_NotRunning (0UL) /*!< HFCLK not running */
+#define CLOCK_HFCLKSTAT_STATE_Running (1UL) /*!< HFCLK running */
+
+/* Bit 0 : Source of HFCLK */
+#define CLOCK_HFCLKSTAT_SRC_Pos (0UL) /*!< Position of SRC field. */
+#define CLOCK_HFCLKSTAT_SRC_Msk (0x1UL << CLOCK_HFCLKSTAT_SRC_Pos) /*!< Bit mask of SRC field. */
+#define CLOCK_HFCLKSTAT_SRC_RC (0UL) /*!< 64 MHz internal oscillator (HFINT) */
+#define CLOCK_HFCLKSTAT_SRC_Xtal (1UL) /*!< 64 MHz crystal oscillator (HFXO) */
+
+/* Register: CLOCK_LFCLKRUN */
+/* Description: Status indicating that LFCLKSTART task has been triggered */
+
+/* Bit 0 : LFCLKSTART task triggered or not */
+#define CLOCK_LFCLKRUN_STATUS_Pos (0UL) /*!< Position of STATUS field. */
+#define CLOCK_LFCLKRUN_STATUS_Msk (0x1UL << CLOCK_LFCLKRUN_STATUS_Pos) /*!< Bit mask of STATUS field. */
+#define CLOCK_LFCLKRUN_STATUS_NotTriggered (0UL) /*!< Task not triggered */
+#define CLOCK_LFCLKRUN_STATUS_Triggered (1UL) /*!< Task triggered */
+
+/* Register: CLOCK_LFCLKSTAT */
+/* Description: LFCLK status */
+
+/* Bit 16 : LFCLK state */
+#define CLOCK_LFCLKSTAT_STATE_Pos (16UL) /*!< Position of STATE field. */
+#define CLOCK_LFCLKSTAT_STATE_Msk (0x1UL << CLOCK_LFCLKSTAT_STATE_Pos) /*!< Bit mask of STATE field. */
+#define CLOCK_LFCLKSTAT_STATE_NotRunning (0UL) /*!< LFCLK not running */
+#define CLOCK_LFCLKSTAT_STATE_Running (1UL) /*!< LFCLK running */
+
+/* Bits 1..0 : Source of LFCLK */
+#define CLOCK_LFCLKSTAT_SRC_Pos (0UL) /*!< Position of SRC field. */
+#define CLOCK_LFCLKSTAT_SRC_Msk (0x3UL << CLOCK_LFCLKSTAT_SRC_Pos) /*!< Bit mask of SRC field. */
+#define CLOCK_LFCLKSTAT_SRC_RC (0UL) /*!< 32.768 kHz RC oscillator */
+#define CLOCK_LFCLKSTAT_SRC_Xtal (1UL) /*!< 32.768 kHz crystal oscillator */
+#define CLOCK_LFCLKSTAT_SRC_Synth (2UL) /*!< 32.768 kHz synthesized from HFCLK */
+
+/* Register: CLOCK_LFCLKSRCCOPY */
+/* Description: Copy of LFCLKSRC register, set when LFCLKSTART task was triggered */
+
+/* Bits 1..0 : Clock source */
+#define CLOCK_LFCLKSRCCOPY_SRC_Pos (0UL) /*!< Position of SRC field. */
+#define CLOCK_LFCLKSRCCOPY_SRC_Msk (0x3UL << CLOCK_LFCLKSRCCOPY_SRC_Pos) /*!< Bit mask of SRC field. */
+#define CLOCK_LFCLKSRCCOPY_SRC_RC (0UL) /*!< 32.768 kHz RC oscillator */
+#define CLOCK_LFCLKSRCCOPY_SRC_Xtal (1UL) /*!< 32.768 kHz crystal oscillator */
+#define CLOCK_LFCLKSRCCOPY_SRC_Synth (2UL) /*!< 32.768 kHz synthesized from HFCLK */
+
+/* Register: CLOCK_LFCLKSRC */
+/* Description: Clock source for the LFCLK */
+
+/* Bits 1..0 : Clock source */
+#define CLOCK_LFCLKSRC_SRC_Pos (0UL) /*!< Position of SRC field. */
+#define CLOCK_LFCLKSRC_SRC_Msk (0x3UL << CLOCK_LFCLKSRC_SRC_Pos) /*!< Bit mask of SRC field. */
+#define CLOCK_LFCLKSRC_SRC_RC (0UL) /*!< 32.768 kHz RC oscillator */
+#define CLOCK_LFCLKSRC_SRC_Xtal (1UL) /*!< 32.768 kHz crystal oscillator */
+#define CLOCK_LFCLKSRC_SRC_Synth (2UL) /*!< 32.768 kHz synthesized from HFCLK */
+
+/* Register: CLOCK_CTIV */
+/* Description: Calibration timer interval (retained register, same reset behaviour as RESETREAS) */
+
+/* Bits 6..0 : Calibration timer interval in multiple of 0.25 seconds. Range: 0.25 seconds to 31.75 seconds. */
+#define CLOCK_CTIV_CTIV_Pos (0UL) /*!< Position of CTIV field. */
+#define CLOCK_CTIV_CTIV_Msk (0x7FUL << CLOCK_CTIV_CTIV_Pos) /*!< Bit mask of CTIV field. */
+
+/* Register: CLOCK_TRACECONFIG */
+/* Description: Clocking options for the Trace Port debug interface */
+
+/* Bits 17..16 : Pin multiplexing of trace signals. */
+#define CLOCK_TRACECONFIG_TRACEMUX_Pos (16UL) /*!< Position of TRACEMUX field. */
+#define CLOCK_TRACECONFIG_TRACEMUX_Msk (0x3UL << CLOCK_TRACECONFIG_TRACEMUX_Pos) /*!< Bit mask of TRACEMUX field. */
+#define CLOCK_TRACECONFIG_TRACEMUX_GPIO (0UL) /*!< GPIOs multiplexed onto all trace-pins */
+#define CLOCK_TRACECONFIG_TRACEMUX_Serial (1UL) /*!< SWO multiplexed onto P0.18, GPIO multiplexed onto other trace pins */
+#define CLOCK_TRACECONFIG_TRACEMUX_Parallel (2UL) /*!< TRACECLK and TRACEDATA multiplexed onto P0.20, P0.18, P0.16, P0.15 and P0.14. */
+
+/* Bits 1..0 : Speed of Trace Port clock. Note that the TRACECLK pin will output this clock divided by two. */
+#define CLOCK_TRACECONFIG_TRACEPORTSPEED_Pos (0UL) /*!< Position of TRACEPORTSPEED field. */
+#define CLOCK_TRACECONFIG_TRACEPORTSPEED_Msk (0x3UL << CLOCK_TRACECONFIG_TRACEPORTSPEED_Pos) /*!< Bit mask of TRACEPORTSPEED field. */
+#define CLOCK_TRACECONFIG_TRACEPORTSPEED_32MHz (0UL) /*!< 32 MHz Trace Port clock (TRACECLK = 16 MHz) */
+#define CLOCK_TRACECONFIG_TRACEPORTSPEED_16MHz (1UL) /*!< 16 MHz Trace Port clock (TRACECLK = 8 MHz) */
+#define CLOCK_TRACECONFIG_TRACEPORTSPEED_8MHz (2UL) /*!< 8 MHz Trace Port clock (TRACECLK = 4 MHz) */
+#define CLOCK_TRACECONFIG_TRACEPORTSPEED_4MHz (3UL) /*!< 4 MHz Trace Port clock (TRACECLK = 2 MHz) */
+
+
+/* Peripheral: COMP */
+/* Description: Comparator */
+
+/* Register: COMP_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 4 : Shortcut between CROSS event and STOP task */
+#define COMP_SHORTS_CROSS_STOP_Pos (4UL) /*!< Position of CROSS_STOP field. */
+#define COMP_SHORTS_CROSS_STOP_Msk (0x1UL << COMP_SHORTS_CROSS_STOP_Pos) /*!< Bit mask of CROSS_STOP field. */
+#define COMP_SHORTS_CROSS_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define COMP_SHORTS_CROSS_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 3 : Shortcut between UP event and STOP task */
+#define COMP_SHORTS_UP_STOP_Pos (3UL) /*!< Position of UP_STOP field. */
+#define COMP_SHORTS_UP_STOP_Msk (0x1UL << COMP_SHORTS_UP_STOP_Pos) /*!< Bit mask of UP_STOP field. */
+#define COMP_SHORTS_UP_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define COMP_SHORTS_UP_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 2 : Shortcut between DOWN event and STOP task */
+#define COMP_SHORTS_DOWN_STOP_Pos (2UL) /*!< Position of DOWN_STOP field. */
+#define COMP_SHORTS_DOWN_STOP_Msk (0x1UL << COMP_SHORTS_DOWN_STOP_Pos) /*!< Bit mask of DOWN_STOP field. */
+#define COMP_SHORTS_DOWN_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define COMP_SHORTS_DOWN_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 1 : Shortcut between READY event and STOP task */
+#define COMP_SHORTS_READY_STOP_Pos (1UL) /*!< Position of READY_STOP field. */
+#define COMP_SHORTS_READY_STOP_Msk (0x1UL << COMP_SHORTS_READY_STOP_Pos) /*!< Bit mask of READY_STOP field. */
+#define COMP_SHORTS_READY_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define COMP_SHORTS_READY_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 0 : Shortcut between READY event and SAMPLE task */
+#define COMP_SHORTS_READY_SAMPLE_Pos (0UL) /*!< Position of READY_SAMPLE field. */
+#define COMP_SHORTS_READY_SAMPLE_Msk (0x1UL << COMP_SHORTS_READY_SAMPLE_Pos) /*!< Bit mask of READY_SAMPLE field. */
+#define COMP_SHORTS_READY_SAMPLE_Disabled (0UL) /*!< Disable shortcut */
+#define COMP_SHORTS_READY_SAMPLE_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: COMP_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 3 : Enable or disable interrupt for CROSS event */
+#define COMP_INTEN_CROSS_Pos (3UL) /*!< Position of CROSS field. */
+#define COMP_INTEN_CROSS_Msk (0x1UL << COMP_INTEN_CROSS_Pos) /*!< Bit mask of CROSS field. */
+#define COMP_INTEN_CROSS_Disabled (0UL) /*!< Disable */
+#define COMP_INTEN_CROSS_Enabled (1UL) /*!< Enable */
+
+/* Bit 2 : Enable or disable interrupt for UP event */
+#define COMP_INTEN_UP_Pos (2UL) /*!< Position of UP field. */
+#define COMP_INTEN_UP_Msk (0x1UL << COMP_INTEN_UP_Pos) /*!< Bit mask of UP field. */
+#define COMP_INTEN_UP_Disabled (0UL) /*!< Disable */
+#define COMP_INTEN_UP_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for DOWN event */
+#define COMP_INTEN_DOWN_Pos (1UL) /*!< Position of DOWN field. */
+#define COMP_INTEN_DOWN_Msk (0x1UL << COMP_INTEN_DOWN_Pos) /*!< Bit mask of DOWN field. */
+#define COMP_INTEN_DOWN_Disabled (0UL) /*!< Disable */
+#define COMP_INTEN_DOWN_Enabled (1UL) /*!< Enable */
+
+/* Bit 0 : Enable or disable interrupt for READY event */
+#define COMP_INTEN_READY_Pos (0UL) /*!< Position of READY field. */
+#define COMP_INTEN_READY_Msk (0x1UL << COMP_INTEN_READY_Pos) /*!< Bit mask of READY field. */
+#define COMP_INTEN_READY_Disabled (0UL) /*!< Disable */
+#define COMP_INTEN_READY_Enabled (1UL) /*!< Enable */
+
+/* Register: COMP_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 3 : Write '1' to Enable interrupt for CROSS event */
+#define COMP_INTENSET_CROSS_Pos (3UL) /*!< Position of CROSS field. */
+#define COMP_INTENSET_CROSS_Msk (0x1UL << COMP_INTENSET_CROSS_Pos) /*!< Bit mask of CROSS field. */
+#define COMP_INTENSET_CROSS_Disabled (0UL) /*!< Read: Disabled */
+#define COMP_INTENSET_CROSS_Enabled (1UL) /*!< Read: Enabled */
+#define COMP_INTENSET_CROSS_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for UP event */
+#define COMP_INTENSET_UP_Pos (2UL) /*!< Position of UP field. */
+#define COMP_INTENSET_UP_Msk (0x1UL << COMP_INTENSET_UP_Pos) /*!< Bit mask of UP field. */
+#define COMP_INTENSET_UP_Disabled (0UL) /*!< Read: Disabled */
+#define COMP_INTENSET_UP_Enabled (1UL) /*!< Read: Enabled */
+#define COMP_INTENSET_UP_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for DOWN event */
+#define COMP_INTENSET_DOWN_Pos (1UL) /*!< Position of DOWN field. */
+#define COMP_INTENSET_DOWN_Msk (0x1UL << COMP_INTENSET_DOWN_Pos) /*!< Bit mask of DOWN field. */
+#define COMP_INTENSET_DOWN_Disabled (0UL) /*!< Read: Disabled */
+#define COMP_INTENSET_DOWN_Enabled (1UL) /*!< Read: Enabled */
+#define COMP_INTENSET_DOWN_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for READY event */
+#define COMP_INTENSET_READY_Pos (0UL) /*!< Position of READY field. */
+#define COMP_INTENSET_READY_Msk (0x1UL << COMP_INTENSET_READY_Pos) /*!< Bit mask of READY field. */
+#define COMP_INTENSET_READY_Disabled (0UL) /*!< Read: Disabled */
+#define COMP_INTENSET_READY_Enabled (1UL) /*!< Read: Enabled */
+#define COMP_INTENSET_READY_Set (1UL) /*!< Enable */
+
+/* Register: COMP_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 3 : Write '1' to Disable interrupt for CROSS event */
+#define COMP_INTENCLR_CROSS_Pos (3UL) /*!< Position of CROSS field. */
+#define COMP_INTENCLR_CROSS_Msk (0x1UL << COMP_INTENCLR_CROSS_Pos) /*!< Bit mask of CROSS field. */
+#define COMP_INTENCLR_CROSS_Disabled (0UL) /*!< Read: Disabled */
+#define COMP_INTENCLR_CROSS_Enabled (1UL) /*!< Read: Enabled */
+#define COMP_INTENCLR_CROSS_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for UP event */
+#define COMP_INTENCLR_UP_Pos (2UL) /*!< Position of UP field. */
+#define COMP_INTENCLR_UP_Msk (0x1UL << COMP_INTENCLR_UP_Pos) /*!< Bit mask of UP field. */
+#define COMP_INTENCLR_UP_Disabled (0UL) /*!< Read: Disabled */
+#define COMP_INTENCLR_UP_Enabled (1UL) /*!< Read: Enabled */
+#define COMP_INTENCLR_UP_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for DOWN event */
+#define COMP_INTENCLR_DOWN_Pos (1UL) /*!< Position of DOWN field. */
+#define COMP_INTENCLR_DOWN_Msk (0x1UL << COMP_INTENCLR_DOWN_Pos) /*!< Bit mask of DOWN field. */
+#define COMP_INTENCLR_DOWN_Disabled (0UL) /*!< Read: Disabled */
+#define COMP_INTENCLR_DOWN_Enabled (1UL) /*!< Read: Enabled */
+#define COMP_INTENCLR_DOWN_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for READY event */
+#define COMP_INTENCLR_READY_Pos (0UL) /*!< Position of READY field. */
+#define COMP_INTENCLR_READY_Msk (0x1UL << COMP_INTENCLR_READY_Pos) /*!< Bit mask of READY field. */
+#define COMP_INTENCLR_READY_Disabled (0UL) /*!< Read: Disabled */
+#define COMP_INTENCLR_READY_Enabled (1UL) /*!< Read: Enabled */
+#define COMP_INTENCLR_READY_Clear (1UL) /*!< Disable */
+
+/* Register: COMP_RESULT */
+/* Description: Compare result */
+
+/* Bit 0 : Result of last compare. Decision point SAMPLE task. */
+#define COMP_RESULT_RESULT_Pos (0UL) /*!< Position of RESULT field. */
+#define COMP_RESULT_RESULT_Msk (0x1UL << COMP_RESULT_RESULT_Pos) /*!< Bit mask of RESULT field. */
+#define COMP_RESULT_RESULT_Below (0UL) /*!< Input voltage is below the threshold (VIN+ &lt; VIN-) */
+#define COMP_RESULT_RESULT_Above (1UL) /*!< Input voltage is above the threshold (VIN+ &gt; VIN-) */
+
+/* Register: COMP_ENABLE */
+/* Description: COMP enable */
+
+/* Bits 1..0 : Enable or disable COMP */
+#define COMP_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define COMP_ENABLE_ENABLE_Msk (0x3UL << COMP_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define COMP_ENABLE_ENABLE_Disabled (0UL) /*!< Disable */
+#define COMP_ENABLE_ENABLE_Enabled (2UL) /*!< Enable */
+
+/* Register: COMP_PSEL */
+/* Description: Pin select */
+
+/* Bits 2..0 : Analog pin select */
+#define COMP_PSEL_PSEL_Pos (0UL) /*!< Position of PSEL field. */
+#define COMP_PSEL_PSEL_Msk (0x7UL << COMP_PSEL_PSEL_Pos) /*!< Bit mask of PSEL field. */
+#define COMP_PSEL_PSEL_AnalogInput0 (0UL) /*!< AIN0 selected as analog input */
+#define COMP_PSEL_PSEL_AnalogInput1 (1UL) /*!< AIN1 selected as analog input */
+#define COMP_PSEL_PSEL_AnalogInput2 (2UL) /*!< AIN2 selected as analog input */
+#define COMP_PSEL_PSEL_AnalogInput3 (3UL) /*!< AIN3 selected as analog input */
+#define COMP_PSEL_PSEL_AnalogInput4 (4UL) /*!< AIN4 selected as analog input */
+#define COMP_PSEL_PSEL_AnalogInput5 (5UL) /*!< AIN5 selected as analog input */
+#define COMP_PSEL_PSEL_AnalogInput6 (6UL) /*!< AIN6 selected as analog input */
+#define COMP_PSEL_PSEL_AnalogInput7 (7UL) /*!< AIN7 selected as analog input */
+
+/* Register: COMP_REFSEL */
+/* Description: Reference source select */
+
+/* Bits 2..0 : Reference select */
+#define COMP_REFSEL_REFSEL_Pos (0UL) /*!< Position of REFSEL field. */
+#define COMP_REFSEL_REFSEL_Msk (0x7UL << COMP_REFSEL_REFSEL_Pos) /*!< Bit mask of REFSEL field. */
+#define COMP_REFSEL_REFSEL_Int1V2 (0UL) /*!< VREF = internal 1.2 V reference (VDD &gt;= 1.7 V) */
+#define COMP_REFSEL_REFSEL_Int1V8 (1UL) /*!< VREF = internal 1.8 V reference (VDD &gt;= VREF + 0.2 V) */
+#define COMP_REFSEL_REFSEL_Int2V4 (2UL) /*!< VREF = internal 2.4 V reference (VDD &gt;= VREF + 0.2 V) */
+#define COMP_REFSEL_REFSEL_VDD (4UL) /*!< VREF = VDD */
+#define COMP_REFSEL_REFSEL_ARef (5UL) /*!< VREF = AREF (VDD &gt;= VREF &gt;= AREFMIN) */
+
+/* Register: COMP_EXTREFSEL */
+/* Description: External reference select */
+
+/* Bit 0 : External analog reference select */
+#define COMP_EXTREFSEL_EXTREFSEL_Pos (0UL) /*!< Position of EXTREFSEL field. */
+#define COMP_EXTREFSEL_EXTREFSEL_Msk (0x1UL << COMP_EXTREFSEL_EXTREFSEL_Pos) /*!< Bit mask of EXTREFSEL field. */
+#define COMP_EXTREFSEL_EXTREFSEL_AnalogReference0 (0UL) /*!< Use AIN0 as external analog reference */
+#define COMP_EXTREFSEL_EXTREFSEL_AnalogReference1 (1UL) /*!< Use AIN1 as external analog reference */
+
+/* Register: COMP_TH */
+/* Description: Threshold configuration for hysteresis unit */
+
+/* Bits 13..8 : VDOWN = (THDOWN+1)/64*VREF */
+#define COMP_TH_THDOWN_Pos (8UL) /*!< Position of THDOWN field. */
+#define COMP_TH_THDOWN_Msk (0x3FUL << COMP_TH_THDOWN_Pos) /*!< Bit mask of THDOWN field. */
+
+/* Bits 5..0 : VUP = (THUP+1)/64*VREF */
+#define COMP_TH_THUP_Pos (0UL) /*!< Position of THUP field. */
+#define COMP_TH_THUP_Msk (0x3FUL << COMP_TH_THUP_Pos) /*!< Bit mask of THUP field. */
+
+/* Register: COMP_MODE */
+/* Description: Mode configuration */
+
+/* Bit 8 : Main operation mode */
+#define COMP_MODE_MAIN_Pos (8UL) /*!< Position of MAIN field. */
+#define COMP_MODE_MAIN_Msk (0x1UL << COMP_MODE_MAIN_Pos) /*!< Bit mask of MAIN field. */
+#define COMP_MODE_MAIN_SE (0UL) /*!< Single ended mode */
+#define COMP_MODE_MAIN_Diff (1UL) /*!< Differential mode */
+
+/* Bits 1..0 : Speed and power mode */
+#define COMP_MODE_SP_Pos (0UL) /*!< Position of SP field. */
+#define COMP_MODE_SP_Msk (0x3UL << COMP_MODE_SP_Pos) /*!< Bit mask of SP field. */
+#define COMP_MODE_SP_Low (0UL) /*!< Low power mode */
+#define COMP_MODE_SP_Normal (1UL) /*!< Normal mode */
+#define COMP_MODE_SP_High (2UL) /*!< High speed mode */
+
+/* Register: COMP_HYST */
+/* Description: Comparator hysteresis enable */
+
+/* Bit 0 : Comparator hysteresis */
+#define COMP_HYST_HYST_Pos (0UL) /*!< Position of HYST field. */
+#define COMP_HYST_HYST_Msk (0x1UL << COMP_HYST_HYST_Pos) /*!< Bit mask of HYST field. */
+#define COMP_HYST_HYST_NoHyst (0UL) /*!< Comparator hysteresis disabled */
+#define COMP_HYST_HYST_Hyst50mV (1UL) /*!< Comparator hysteresis enabled */
+
+/* Register: COMP_ISOURCE */
+/* Description: Current source select on analog input */
+
+/* Bits 1..0 : Comparator hysteresis */
+#define COMP_ISOURCE_ISOURCE_Pos (0UL) /*!< Position of ISOURCE field. */
+#define COMP_ISOURCE_ISOURCE_Msk (0x3UL << COMP_ISOURCE_ISOURCE_Pos) /*!< Bit mask of ISOURCE field. */
+#define COMP_ISOURCE_ISOURCE_Off (0UL) /*!< Current source disabled */
+#define COMP_ISOURCE_ISOURCE_Ien2mA5 (1UL) /*!< Current source enabled (+/- 2.5 uA) */
+#define COMP_ISOURCE_ISOURCE_Ien5mA (2UL) /*!< Current source enabled (+/- 5 uA) */
+#define COMP_ISOURCE_ISOURCE_Ien10mA (3UL) /*!< Current source enabled (+/- 10 uA) */
+
+
+/* Peripheral: ECB */
+/* Description: AES ECB Mode Encryption */
+
+/* Register: ECB_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 1 : Write '1' to Enable interrupt for ERRORECB event */
+#define ECB_INTENSET_ERRORECB_Pos (1UL) /*!< Position of ERRORECB field. */
+#define ECB_INTENSET_ERRORECB_Msk (0x1UL << ECB_INTENSET_ERRORECB_Pos) /*!< Bit mask of ERRORECB field. */
+#define ECB_INTENSET_ERRORECB_Disabled (0UL) /*!< Read: Disabled */
+#define ECB_INTENSET_ERRORECB_Enabled (1UL) /*!< Read: Enabled */
+#define ECB_INTENSET_ERRORECB_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for ENDECB event */
+#define ECB_INTENSET_ENDECB_Pos (0UL) /*!< Position of ENDECB field. */
+#define ECB_INTENSET_ENDECB_Msk (0x1UL << ECB_INTENSET_ENDECB_Pos) /*!< Bit mask of ENDECB field. */
+#define ECB_INTENSET_ENDECB_Disabled (0UL) /*!< Read: Disabled */
+#define ECB_INTENSET_ENDECB_Enabled (1UL) /*!< Read: Enabled */
+#define ECB_INTENSET_ENDECB_Set (1UL) /*!< Enable */
+
+/* Register: ECB_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 1 : Write '1' to Disable interrupt for ERRORECB event */
+#define ECB_INTENCLR_ERRORECB_Pos (1UL) /*!< Position of ERRORECB field. */
+#define ECB_INTENCLR_ERRORECB_Msk (0x1UL << ECB_INTENCLR_ERRORECB_Pos) /*!< Bit mask of ERRORECB field. */
+#define ECB_INTENCLR_ERRORECB_Disabled (0UL) /*!< Read: Disabled */
+#define ECB_INTENCLR_ERRORECB_Enabled (1UL) /*!< Read: Enabled */
+#define ECB_INTENCLR_ERRORECB_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for ENDECB event */
+#define ECB_INTENCLR_ENDECB_Pos (0UL) /*!< Position of ENDECB field. */
+#define ECB_INTENCLR_ENDECB_Msk (0x1UL << ECB_INTENCLR_ENDECB_Pos) /*!< Bit mask of ENDECB field. */
+#define ECB_INTENCLR_ENDECB_Disabled (0UL) /*!< Read: Disabled */
+#define ECB_INTENCLR_ENDECB_Enabled (1UL) /*!< Read: Enabled */
+#define ECB_INTENCLR_ENDECB_Clear (1UL) /*!< Disable */
+
+/* Register: ECB_ECBDATAPTR */
+/* Description: ECB block encrypt memory pointers */
+
+/* Bits 31..0 : Pointer to the ECB data structure (see Table 1 ECB data structure overview) */
+#define ECB_ECBDATAPTR_ECBDATAPTR_Pos (0UL) /*!< Position of ECBDATAPTR field. */
+#define ECB_ECBDATAPTR_ECBDATAPTR_Msk (0xFFFFFFFFUL << ECB_ECBDATAPTR_ECBDATAPTR_Pos) /*!< Bit mask of ECBDATAPTR field. */
+
+
+/* Peripheral: EGU */
+/* Description: Event Generator Unit 0 */
+
+/* Register: EGU_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 15 : Enable or disable interrupt for TRIGGERED[15] event */
+#define EGU_INTEN_TRIGGERED15_Pos (15UL) /*!< Position of TRIGGERED15 field. */
+#define EGU_INTEN_TRIGGERED15_Msk (0x1UL << EGU_INTEN_TRIGGERED15_Pos) /*!< Bit mask of TRIGGERED15 field. */
+#define EGU_INTEN_TRIGGERED15_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED15_Enabled (1UL) /*!< Enable */
+
+/* Bit 14 : Enable or disable interrupt for TRIGGERED[14] event */
+#define EGU_INTEN_TRIGGERED14_Pos (14UL) /*!< Position of TRIGGERED14 field. */
+#define EGU_INTEN_TRIGGERED14_Msk (0x1UL << EGU_INTEN_TRIGGERED14_Pos) /*!< Bit mask of TRIGGERED14 field. */
+#define EGU_INTEN_TRIGGERED14_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED14_Enabled (1UL) /*!< Enable */
+
+/* Bit 13 : Enable or disable interrupt for TRIGGERED[13] event */
+#define EGU_INTEN_TRIGGERED13_Pos (13UL) /*!< Position of TRIGGERED13 field. */
+#define EGU_INTEN_TRIGGERED13_Msk (0x1UL << EGU_INTEN_TRIGGERED13_Pos) /*!< Bit mask of TRIGGERED13 field. */
+#define EGU_INTEN_TRIGGERED13_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED13_Enabled (1UL) /*!< Enable */
+
+/* Bit 12 : Enable or disable interrupt for TRIGGERED[12] event */
+#define EGU_INTEN_TRIGGERED12_Pos (12UL) /*!< Position of TRIGGERED12 field. */
+#define EGU_INTEN_TRIGGERED12_Msk (0x1UL << EGU_INTEN_TRIGGERED12_Pos) /*!< Bit mask of TRIGGERED12 field. */
+#define EGU_INTEN_TRIGGERED12_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED12_Enabled (1UL) /*!< Enable */
+
+/* Bit 11 : Enable or disable interrupt for TRIGGERED[11] event */
+#define EGU_INTEN_TRIGGERED11_Pos (11UL) /*!< Position of TRIGGERED11 field. */
+#define EGU_INTEN_TRIGGERED11_Msk (0x1UL << EGU_INTEN_TRIGGERED11_Pos) /*!< Bit mask of TRIGGERED11 field. */
+#define EGU_INTEN_TRIGGERED11_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED11_Enabled (1UL) /*!< Enable */
+
+/* Bit 10 : Enable or disable interrupt for TRIGGERED[10] event */
+#define EGU_INTEN_TRIGGERED10_Pos (10UL) /*!< Position of TRIGGERED10 field. */
+#define EGU_INTEN_TRIGGERED10_Msk (0x1UL << EGU_INTEN_TRIGGERED10_Pos) /*!< Bit mask of TRIGGERED10 field. */
+#define EGU_INTEN_TRIGGERED10_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED10_Enabled (1UL) /*!< Enable */
+
+/* Bit 9 : Enable or disable interrupt for TRIGGERED[9] event */
+#define EGU_INTEN_TRIGGERED9_Pos (9UL) /*!< Position of TRIGGERED9 field. */
+#define EGU_INTEN_TRIGGERED9_Msk (0x1UL << EGU_INTEN_TRIGGERED9_Pos) /*!< Bit mask of TRIGGERED9 field. */
+#define EGU_INTEN_TRIGGERED9_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED9_Enabled (1UL) /*!< Enable */
+
+/* Bit 8 : Enable or disable interrupt for TRIGGERED[8] event */
+#define EGU_INTEN_TRIGGERED8_Pos (8UL) /*!< Position of TRIGGERED8 field. */
+#define EGU_INTEN_TRIGGERED8_Msk (0x1UL << EGU_INTEN_TRIGGERED8_Pos) /*!< Bit mask of TRIGGERED8 field. */
+#define EGU_INTEN_TRIGGERED8_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED8_Enabled (1UL) /*!< Enable */
+
+/* Bit 7 : Enable or disable interrupt for TRIGGERED[7] event */
+#define EGU_INTEN_TRIGGERED7_Pos (7UL) /*!< Position of TRIGGERED7 field. */
+#define EGU_INTEN_TRIGGERED7_Msk (0x1UL << EGU_INTEN_TRIGGERED7_Pos) /*!< Bit mask of TRIGGERED7 field. */
+#define EGU_INTEN_TRIGGERED7_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED7_Enabled (1UL) /*!< Enable */
+
+/* Bit 6 : Enable or disable interrupt for TRIGGERED[6] event */
+#define EGU_INTEN_TRIGGERED6_Pos (6UL) /*!< Position of TRIGGERED6 field. */
+#define EGU_INTEN_TRIGGERED6_Msk (0x1UL << EGU_INTEN_TRIGGERED6_Pos) /*!< Bit mask of TRIGGERED6 field. */
+#define EGU_INTEN_TRIGGERED6_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED6_Enabled (1UL) /*!< Enable */
+
+/* Bit 5 : Enable or disable interrupt for TRIGGERED[5] event */
+#define EGU_INTEN_TRIGGERED5_Pos (5UL) /*!< Position of TRIGGERED5 field. */
+#define EGU_INTEN_TRIGGERED5_Msk (0x1UL << EGU_INTEN_TRIGGERED5_Pos) /*!< Bit mask of TRIGGERED5 field. */
+#define EGU_INTEN_TRIGGERED5_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED5_Enabled (1UL) /*!< Enable */
+
+/* Bit 4 : Enable or disable interrupt for TRIGGERED[4] event */
+#define EGU_INTEN_TRIGGERED4_Pos (4UL) /*!< Position of TRIGGERED4 field. */
+#define EGU_INTEN_TRIGGERED4_Msk (0x1UL << EGU_INTEN_TRIGGERED4_Pos) /*!< Bit mask of TRIGGERED4 field. */
+#define EGU_INTEN_TRIGGERED4_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED4_Enabled (1UL) /*!< Enable */
+
+/* Bit 3 : Enable or disable interrupt for TRIGGERED[3] event */
+#define EGU_INTEN_TRIGGERED3_Pos (3UL) /*!< Position of TRIGGERED3 field. */
+#define EGU_INTEN_TRIGGERED3_Msk (0x1UL << EGU_INTEN_TRIGGERED3_Pos) /*!< Bit mask of TRIGGERED3 field. */
+#define EGU_INTEN_TRIGGERED3_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED3_Enabled (1UL) /*!< Enable */
+
+/* Bit 2 : Enable or disable interrupt for TRIGGERED[2] event */
+#define EGU_INTEN_TRIGGERED2_Pos (2UL) /*!< Position of TRIGGERED2 field. */
+#define EGU_INTEN_TRIGGERED2_Msk (0x1UL << EGU_INTEN_TRIGGERED2_Pos) /*!< Bit mask of TRIGGERED2 field. */
+#define EGU_INTEN_TRIGGERED2_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED2_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for TRIGGERED[1] event */
+#define EGU_INTEN_TRIGGERED1_Pos (1UL) /*!< Position of TRIGGERED1 field. */
+#define EGU_INTEN_TRIGGERED1_Msk (0x1UL << EGU_INTEN_TRIGGERED1_Pos) /*!< Bit mask of TRIGGERED1 field. */
+#define EGU_INTEN_TRIGGERED1_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED1_Enabled (1UL) /*!< Enable */
+
+/* Bit 0 : Enable or disable interrupt for TRIGGERED[0] event */
+#define EGU_INTEN_TRIGGERED0_Pos (0UL) /*!< Position of TRIGGERED0 field. */
+#define EGU_INTEN_TRIGGERED0_Msk (0x1UL << EGU_INTEN_TRIGGERED0_Pos) /*!< Bit mask of TRIGGERED0 field. */
+#define EGU_INTEN_TRIGGERED0_Disabled (0UL) /*!< Disable */
+#define EGU_INTEN_TRIGGERED0_Enabled (1UL) /*!< Enable */
+
+/* Register: EGU_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 15 : Write '1' to Enable interrupt for TRIGGERED[15] event */
+#define EGU_INTENSET_TRIGGERED15_Pos (15UL) /*!< Position of TRIGGERED15 field. */
+#define EGU_INTENSET_TRIGGERED15_Msk (0x1UL << EGU_INTENSET_TRIGGERED15_Pos) /*!< Bit mask of TRIGGERED15 field. */
+#define EGU_INTENSET_TRIGGERED15_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED15_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED15_Set (1UL) /*!< Enable */
+
+/* Bit 14 : Write '1' to Enable interrupt for TRIGGERED[14] event */
+#define EGU_INTENSET_TRIGGERED14_Pos (14UL) /*!< Position of TRIGGERED14 field. */
+#define EGU_INTENSET_TRIGGERED14_Msk (0x1UL << EGU_INTENSET_TRIGGERED14_Pos) /*!< Bit mask of TRIGGERED14 field. */
+#define EGU_INTENSET_TRIGGERED14_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED14_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED14_Set (1UL) /*!< Enable */
+
+/* Bit 13 : Write '1' to Enable interrupt for TRIGGERED[13] event */
+#define EGU_INTENSET_TRIGGERED13_Pos (13UL) /*!< Position of TRIGGERED13 field. */
+#define EGU_INTENSET_TRIGGERED13_Msk (0x1UL << EGU_INTENSET_TRIGGERED13_Pos) /*!< Bit mask of TRIGGERED13 field. */
+#define EGU_INTENSET_TRIGGERED13_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED13_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED13_Set (1UL) /*!< Enable */
+
+/* Bit 12 : Write '1' to Enable interrupt for TRIGGERED[12] event */
+#define EGU_INTENSET_TRIGGERED12_Pos (12UL) /*!< Position of TRIGGERED12 field. */
+#define EGU_INTENSET_TRIGGERED12_Msk (0x1UL << EGU_INTENSET_TRIGGERED12_Pos) /*!< Bit mask of TRIGGERED12 field. */
+#define EGU_INTENSET_TRIGGERED12_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED12_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED12_Set (1UL) /*!< Enable */
+
+/* Bit 11 : Write '1' to Enable interrupt for TRIGGERED[11] event */
+#define EGU_INTENSET_TRIGGERED11_Pos (11UL) /*!< Position of TRIGGERED11 field. */
+#define EGU_INTENSET_TRIGGERED11_Msk (0x1UL << EGU_INTENSET_TRIGGERED11_Pos) /*!< Bit mask of TRIGGERED11 field. */
+#define EGU_INTENSET_TRIGGERED11_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED11_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED11_Set (1UL) /*!< Enable */
+
+/* Bit 10 : Write '1' to Enable interrupt for TRIGGERED[10] event */
+#define EGU_INTENSET_TRIGGERED10_Pos (10UL) /*!< Position of TRIGGERED10 field. */
+#define EGU_INTENSET_TRIGGERED10_Msk (0x1UL << EGU_INTENSET_TRIGGERED10_Pos) /*!< Bit mask of TRIGGERED10 field. */
+#define EGU_INTENSET_TRIGGERED10_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED10_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED10_Set (1UL) /*!< Enable */
+
+/* Bit 9 : Write '1' to Enable interrupt for TRIGGERED[9] event */
+#define EGU_INTENSET_TRIGGERED9_Pos (9UL) /*!< Position of TRIGGERED9 field. */
+#define EGU_INTENSET_TRIGGERED9_Msk (0x1UL << EGU_INTENSET_TRIGGERED9_Pos) /*!< Bit mask of TRIGGERED9 field. */
+#define EGU_INTENSET_TRIGGERED9_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED9_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED9_Set (1UL) /*!< Enable */
+
+/* Bit 8 : Write '1' to Enable interrupt for TRIGGERED[8] event */
+#define EGU_INTENSET_TRIGGERED8_Pos (8UL) /*!< Position of TRIGGERED8 field. */
+#define EGU_INTENSET_TRIGGERED8_Msk (0x1UL << EGU_INTENSET_TRIGGERED8_Pos) /*!< Bit mask of TRIGGERED8 field. */
+#define EGU_INTENSET_TRIGGERED8_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED8_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED8_Set (1UL) /*!< Enable */
+
+/* Bit 7 : Write '1' to Enable interrupt for TRIGGERED[7] event */
+#define EGU_INTENSET_TRIGGERED7_Pos (7UL) /*!< Position of TRIGGERED7 field. */
+#define EGU_INTENSET_TRIGGERED7_Msk (0x1UL << EGU_INTENSET_TRIGGERED7_Pos) /*!< Bit mask of TRIGGERED7 field. */
+#define EGU_INTENSET_TRIGGERED7_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED7_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED7_Set (1UL) /*!< Enable */
+
+/* Bit 6 : Write '1' to Enable interrupt for TRIGGERED[6] event */
+#define EGU_INTENSET_TRIGGERED6_Pos (6UL) /*!< Position of TRIGGERED6 field. */
+#define EGU_INTENSET_TRIGGERED6_Msk (0x1UL << EGU_INTENSET_TRIGGERED6_Pos) /*!< Bit mask of TRIGGERED6 field. */
+#define EGU_INTENSET_TRIGGERED6_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED6_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED6_Set (1UL) /*!< Enable */
+
+/* Bit 5 : Write '1' to Enable interrupt for TRIGGERED[5] event */
+#define EGU_INTENSET_TRIGGERED5_Pos (5UL) /*!< Position of TRIGGERED5 field. */
+#define EGU_INTENSET_TRIGGERED5_Msk (0x1UL << EGU_INTENSET_TRIGGERED5_Pos) /*!< Bit mask of TRIGGERED5 field. */
+#define EGU_INTENSET_TRIGGERED5_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED5_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED5_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable interrupt for TRIGGERED[4] event */
+#define EGU_INTENSET_TRIGGERED4_Pos (4UL) /*!< Position of TRIGGERED4 field. */
+#define EGU_INTENSET_TRIGGERED4_Msk (0x1UL << EGU_INTENSET_TRIGGERED4_Pos) /*!< Bit mask of TRIGGERED4 field. */
+#define EGU_INTENSET_TRIGGERED4_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED4_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED4_Set (1UL) /*!< Enable */
+
+/* Bit 3 : Write '1' to Enable interrupt for TRIGGERED[3] event */
+#define EGU_INTENSET_TRIGGERED3_Pos (3UL) /*!< Position of TRIGGERED3 field. */
+#define EGU_INTENSET_TRIGGERED3_Msk (0x1UL << EGU_INTENSET_TRIGGERED3_Pos) /*!< Bit mask of TRIGGERED3 field. */
+#define EGU_INTENSET_TRIGGERED3_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED3_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED3_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for TRIGGERED[2] event */
+#define EGU_INTENSET_TRIGGERED2_Pos (2UL) /*!< Position of TRIGGERED2 field. */
+#define EGU_INTENSET_TRIGGERED2_Msk (0x1UL << EGU_INTENSET_TRIGGERED2_Pos) /*!< Bit mask of TRIGGERED2 field. */
+#define EGU_INTENSET_TRIGGERED2_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED2_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED2_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for TRIGGERED[1] event */
+#define EGU_INTENSET_TRIGGERED1_Pos (1UL) /*!< Position of TRIGGERED1 field. */
+#define EGU_INTENSET_TRIGGERED1_Msk (0x1UL << EGU_INTENSET_TRIGGERED1_Pos) /*!< Bit mask of TRIGGERED1 field. */
+#define EGU_INTENSET_TRIGGERED1_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED1_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED1_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for TRIGGERED[0] event */
+#define EGU_INTENSET_TRIGGERED0_Pos (0UL) /*!< Position of TRIGGERED0 field. */
+#define EGU_INTENSET_TRIGGERED0_Msk (0x1UL << EGU_INTENSET_TRIGGERED0_Pos) /*!< Bit mask of TRIGGERED0 field. */
+#define EGU_INTENSET_TRIGGERED0_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENSET_TRIGGERED0_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENSET_TRIGGERED0_Set (1UL) /*!< Enable */
+
+/* Register: EGU_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 15 : Write '1' to Disable interrupt for TRIGGERED[15] event */
+#define EGU_INTENCLR_TRIGGERED15_Pos (15UL) /*!< Position of TRIGGERED15 field. */
+#define EGU_INTENCLR_TRIGGERED15_Msk (0x1UL << EGU_INTENCLR_TRIGGERED15_Pos) /*!< Bit mask of TRIGGERED15 field. */
+#define EGU_INTENCLR_TRIGGERED15_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED15_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED15_Clear (1UL) /*!< Disable */
+
+/* Bit 14 : Write '1' to Disable interrupt for TRIGGERED[14] event */
+#define EGU_INTENCLR_TRIGGERED14_Pos (14UL) /*!< Position of TRIGGERED14 field. */
+#define EGU_INTENCLR_TRIGGERED14_Msk (0x1UL << EGU_INTENCLR_TRIGGERED14_Pos) /*!< Bit mask of TRIGGERED14 field. */
+#define EGU_INTENCLR_TRIGGERED14_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED14_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED14_Clear (1UL) /*!< Disable */
+
+/* Bit 13 : Write '1' to Disable interrupt for TRIGGERED[13] event */
+#define EGU_INTENCLR_TRIGGERED13_Pos (13UL) /*!< Position of TRIGGERED13 field. */
+#define EGU_INTENCLR_TRIGGERED13_Msk (0x1UL << EGU_INTENCLR_TRIGGERED13_Pos) /*!< Bit mask of TRIGGERED13 field. */
+#define EGU_INTENCLR_TRIGGERED13_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED13_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED13_Clear (1UL) /*!< Disable */
+
+/* Bit 12 : Write '1' to Disable interrupt for TRIGGERED[12] event */
+#define EGU_INTENCLR_TRIGGERED12_Pos (12UL) /*!< Position of TRIGGERED12 field. */
+#define EGU_INTENCLR_TRIGGERED12_Msk (0x1UL << EGU_INTENCLR_TRIGGERED12_Pos) /*!< Bit mask of TRIGGERED12 field. */
+#define EGU_INTENCLR_TRIGGERED12_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED12_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED12_Clear (1UL) /*!< Disable */
+
+/* Bit 11 : Write '1' to Disable interrupt for TRIGGERED[11] event */
+#define EGU_INTENCLR_TRIGGERED11_Pos (11UL) /*!< Position of TRIGGERED11 field. */
+#define EGU_INTENCLR_TRIGGERED11_Msk (0x1UL << EGU_INTENCLR_TRIGGERED11_Pos) /*!< Bit mask of TRIGGERED11 field. */
+#define EGU_INTENCLR_TRIGGERED11_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED11_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED11_Clear (1UL) /*!< Disable */
+
+/* Bit 10 : Write '1' to Disable interrupt for TRIGGERED[10] event */
+#define EGU_INTENCLR_TRIGGERED10_Pos (10UL) /*!< Position of TRIGGERED10 field. */
+#define EGU_INTENCLR_TRIGGERED10_Msk (0x1UL << EGU_INTENCLR_TRIGGERED10_Pos) /*!< Bit mask of TRIGGERED10 field. */
+#define EGU_INTENCLR_TRIGGERED10_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED10_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED10_Clear (1UL) /*!< Disable */
+
+/* Bit 9 : Write '1' to Disable interrupt for TRIGGERED[9] event */
+#define EGU_INTENCLR_TRIGGERED9_Pos (9UL) /*!< Position of TRIGGERED9 field. */
+#define EGU_INTENCLR_TRIGGERED9_Msk (0x1UL << EGU_INTENCLR_TRIGGERED9_Pos) /*!< Bit mask of TRIGGERED9 field. */
+#define EGU_INTENCLR_TRIGGERED9_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED9_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED9_Clear (1UL) /*!< Disable */
+
+/* Bit 8 : Write '1' to Disable interrupt for TRIGGERED[8] event */
+#define EGU_INTENCLR_TRIGGERED8_Pos (8UL) /*!< Position of TRIGGERED8 field. */
+#define EGU_INTENCLR_TRIGGERED8_Msk (0x1UL << EGU_INTENCLR_TRIGGERED8_Pos) /*!< Bit mask of TRIGGERED8 field. */
+#define EGU_INTENCLR_TRIGGERED8_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED8_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED8_Clear (1UL) /*!< Disable */
+
+/* Bit 7 : Write '1' to Disable interrupt for TRIGGERED[7] event */
+#define EGU_INTENCLR_TRIGGERED7_Pos (7UL) /*!< Position of TRIGGERED7 field. */
+#define EGU_INTENCLR_TRIGGERED7_Msk (0x1UL << EGU_INTENCLR_TRIGGERED7_Pos) /*!< Bit mask of TRIGGERED7 field. */
+#define EGU_INTENCLR_TRIGGERED7_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED7_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED7_Clear (1UL) /*!< Disable */
+
+/* Bit 6 : Write '1' to Disable interrupt for TRIGGERED[6] event */
+#define EGU_INTENCLR_TRIGGERED6_Pos (6UL) /*!< Position of TRIGGERED6 field. */
+#define EGU_INTENCLR_TRIGGERED6_Msk (0x1UL << EGU_INTENCLR_TRIGGERED6_Pos) /*!< Bit mask of TRIGGERED6 field. */
+#define EGU_INTENCLR_TRIGGERED6_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED6_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED6_Clear (1UL) /*!< Disable */
+
+/* Bit 5 : Write '1' to Disable interrupt for TRIGGERED[5] event */
+#define EGU_INTENCLR_TRIGGERED5_Pos (5UL) /*!< Position of TRIGGERED5 field. */
+#define EGU_INTENCLR_TRIGGERED5_Msk (0x1UL << EGU_INTENCLR_TRIGGERED5_Pos) /*!< Bit mask of TRIGGERED5 field. */
+#define EGU_INTENCLR_TRIGGERED5_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED5_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED5_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable interrupt for TRIGGERED[4] event */
+#define EGU_INTENCLR_TRIGGERED4_Pos (4UL) /*!< Position of TRIGGERED4 field. */
+#define EGU_INTENCLR_TRIGGERED4_Msk (0x1UL << EGU_INTENCLR_TRIGGERED4_Pos) /*!< Bit mask of TRIGGERED4 field. */
+#define EGU_INTENCLR_TRIGGERED4_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED4_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED4_Clear (1UL) /*!< Disable */
+
+/* Bit 3 : Write '1' to Disable interrupt for TRIGGERED[3] event */
+#define EGU_INTENCLR_TRIGGERED3_Pos (3UL) /*!< Position of TRIGGERED3 field. */
+#define EGU_INTENCLR_TRIGGERED3_Msk (0x1UL << EGU_INTENCLR_TRIGGERED3_Pos) /*!< Bit mask of TRIGGERED3 field. */
+#define EGU_INTENCLR_TRIGGERED3_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED3_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED3_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for TRIGGERED[2] event */
+#define EGU_INTENCLR_TRIGGERED2_Pos (2UL) /*!< Position of TRIGGERED2 field. */
+#define EGU_INTENCLR_TRIGGERED2_Msk (0x1UL << EGU_INTENCLR_TRIGGERED2_Pos) /*!< Bit mask of TRIGGERED2 field. */
+#define EGU_INTENCLR_TRIGGERED2_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED2_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED2_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for TRIGGERED[1] event */
+#define EGU_INTENCLR_TRIGGERED1_Pos (1UL) /*!< Position of TRIGGERED1 field. */
+#define EGU_INTENCLR_TRIGGERED1_Msk (0x1UL << EGU_INTENCLR_TRIGGERED1_Pos) /*!< Bit mask of TRIGGERED1 field. */
+#define EGU_INTENCLR_TRIGGERED1_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED1_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED1_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for TRIGGERED[0] event */
+#define EGU_INTENCLR_TRIGGERED0_Pos (0UL) /*!< Position of TRIGGERED0 field. */
+#define EGU_INTENCLR_TRIGGERED0_Msk (0x1UL << EGU_INTENCLR_TRIGGERED0_Pos) /*!< Bit mask of TRIGGERED0 field. */
+#define EGU_INTENCLR_TRIGGERED0_Disabled (0UL) /*!< Read: Disabled */
+#define EGU_INTENCLR_TRIGGERED0_Enabled (1UL) /*!< Read: Enabled */
+#define EGU_INTENCLR_TRIGGERED0_Clear (1UL) /*!< Disable */
+
+
+/* Peripheral: FICR */
+/* Description: Factory Information Configuration Registers */
+
+/* Register: FICR_CODEPAGESIZE */
+/* Description: Code memory page size */
+
+/* Bits 31..0 : Code memory page size */
+#define FICR_CODEPAGESIZE_CODEPAGESIZE_Pos (0UL) /*!< Position of CODEPAGESIZE field. */
+#define FICR_CODEPAGESIZE_CODEPAGESIZE_Msk (0xFFFFFFFFUL << FICR_CODEPAGESIZE_CODEPAGESIZE_Pos) /*!< Bit mask of CODEPAGESIZE field. */
+
+/* Register: FICR_CODESIZE */
+/* Description: Code memory size */
+
+/* Bits 31..0 : Code memory size in number of pages */
+#define FICR_CODESIZE_CODESIZE_Pos (0UL) /*!< Position of CODESIZE field. */
+#define FICR_CODESIZE_CODESIZE_Msk (0xFFFFFFFFUL << FICR_CODESIZE_CODESIZE_Pos) /*!< Bit mask of CODESIZE field. */
+
+/* Register: FICR_CONFIGID */
+/* Description: Configuration identifier */
+
+/* Bits 31..16 : Deprecated field -  Identification number for the FW that is pre-loaded into the chip */
+#define FICR_CONFIGID_FWID_Pos (16UL) /*!< Position of FWID field. */
+#define FICR_CONFIGID_FWID_Msk (0xFFFFUL << FICR_CONFIGID_FWID_Pos) /*!< Bit mask of FWID field. */
+
+/* Bits 15..0 : Identification number for the HW */
+#define FICR_CONFIGID_HWID_Pos (0UL) /*!< Position of HWID field. */
+#define FICR_CONFIGID_HWID_Msk (0xFFFFUL << FICR_CONFIGID_HWID_Pos) /*!< Bit mask of HWID field. */
+
+/* Register: FICR_DEVICEID */
+/* Description: Description collection[0]:  Device identifier */
+
+/* Bits 31..0 : 64 bit unique device identifier */
+#define FICR_DEVICEID_DEVICEID_Pos (0UL) /*!< Position of DEVICEID field. */
+#define FICR_DEVICEID_DEVICEID_Msk (0xFFFFFFFFUL << FICR_DEVICEID_DEVICEID_Pos) /*!< Bit mask of DEVICEID field. */
+
+/* Register: FICR_ER */
+/* Description: Description collection[0]:  Encryption Root, word 0 */
+
+/* Bits 31..0 : Encryption Root, word n */
+#define FICR_ER_ER_Pos (0UL) /*!< Position of ER field. */
+#define FICR_ER_ER_Msk (0xFFFFFFFFUL << FICR_ER_ER_Pos) /*!< Bit mask of ER field. */
+
+/* Register: FICR_IR */
+/* Description: Description collection[0]:  Identity Root, word 0 */
+
+/* Bits 31..0 : Identity Root, word n */
+#define FICR_IR_IR_Pos (0UL) /*!< Position of IR field. */
+#define FICR_IR_IR_Msk (0xFFFFFFFFUL << FICR_IR_IR_Pos) /*!< Bit mask of IR field. */
+
+/* Register: FICR_DEVICEADDRTYPE */
+/* Description: Device address type */
+
+/* Bit 0 : Device address type */
+#define FICR_DEVICEADDRTYPE_DEVICEADDRTYPE_Pos (0UL) /*!< Position of DEVICEADDRTYPE field. */
+#define FICR_DEVICEADDRTYPE_DEVICEADDRTYPE_Msk (0x1UL << FICR_DEVICEADDRTYPE_DEVICEADDRTYPE_Pos) /*!< Bit mask of DEVICEADDRTYPE field. */
+#define FICR_DEVICEADDRTYPE_DEVICEADDRTYPE_Public (0UL) /*!< Public address */
+#define FICR_DEVICEADDRTYPE_DEVICEADDRTYPE_Random (1UL) /*!< Random address */
+
+/* Register: FICR_DEVICEADDR */
+/* Description: Description collection[0]:  Device address 0 */
+
+/* Bits 31..0 : 48 bit device address */
+#define FICR_DEVICEADDR_DEVICEADDR_Pos (0UL) /*!< Position of DEVICEADDR field. */
+#define FICR_DEVICEADDR_DEVICEADDR_Msk (0xFFFFFFFFUL << FICR_DEVICEADDR_DEVICEADDR_Pos) /*!< Bit mask of DEVICEADDR field. */
+
+/* Register: FICR_INFO_PART */
+/* Description: Part code */
+
+/* Bits 31..0 : Part code */
+#define FICR_INFO_PART_PART_Pos (0UL) /*!< Position of PART field. */
+#define FICR_INFO_PART_PART_Msk (0xFFFFFFFFUL << FICR_INFO_PART_PART_Pos) /*!< Bit mask of PART field. */
+#define FICR_INFO_PART_PART_N52832 (0x52832UL) /*!< nRF52832 */
+#define FICR_INFO_PART_PART_Unspecified (0xFFFFFFFFUL) /*!< Unspecified */
+
+/* Register: FICR_INFO_VARIANT */
+/* Description: Part variant */
+
+/* Bits 31..0 : Part variant */
+#define FICR_INFO_VARIANT_VARIANT_Pos (0UL) /*!< Position of VARIANT field. */
+#define FICR_INFO_VARIANT_VARIANT_Msk (0xFFFFFFFFUL << FICR_INFO_VARIANT_VARIANT_Pos) /*!< Bit mask of VARIANT field. */
+#define FICR_INFO_VARIANT_VARIANT_nRF52AA (0x2000UL) /*!< nRF52832-AA (Engineering sample) */
+#define FICR_INFO_VARIANT_VARIANT_nRF52A0 (0x2001UL) /*!< nRF52832-A0 */
+#define FICR_INFO_VARIANT_VARIANT_Unspecified (0xFFFFFFFFUL) /*!< Unspecified */
+
+/* Register: FICR_INFO_PACKAGE */
+/* Description: Package option */
+
+/* Bits 31..0 : Package option */
+#define FICR_INFO_PACKAGE_PACKAGE_Pos (0UL) /*!< Position of PACKAGE field. */
+#define FICR_INFO_PACKAGE_PACKAGE_Msk (0xFFFFFFFFUL << FICR_INFO_PACKAGE_PACKAGE_Pos) /*!< Bit mask of PACKAGE field. */
+#define FICR_INFO_PACKAGE_PACKAGE_QFN48 (0x0000UL) /*!< 48-pin QFN with 31 GPIO */
+#define FICR_INFO_PACKAGE_PACKAGE_nRF52832QF (0x2000UL) /*!< nRF52832 QFxx - 48-pin QFN */
+#define FICR_INFO_PACKAGE_PACKAGE_nRF52832CH (0x2001UL) /*!< nRF52832 CHxx - 7x8 WLCSP 56 balls */
+#define FICR_INFO_PACKAGE_PACKAGE_Unspecified (0xFFFFFFFFUL) /*!< Unspecified */
+
+/* Register: FICR_INFO_RAM */
+/* Description: RAM variant */
+
+/* Bits 31..0 : RAM variant */
+#define FICR_INFO_RAM_RAM_Pos (0UL) /*!< Position of RAM field. */
+#define FICR_INFO_RAM_RAM_Msk (0xFFFFFFFFUL << FICR_INFO_RAM_RAM_Pos) /*!< Bit mask of RAM field. */
+#define FICR_INFO_RAM_RAM_K16 (16UL) /*!< 16 kByte RAM */
+#define FICR_INFO_RAM_RAM_K32 (32UL) /*!< 32 kByte RAM */
+#define FICR_INFO_RAM_RAM_K64 (64UL) /*!< 64 kByte RAM */
+#define FICR_INFO_RAM_RAM_Unspecified (0xFFFFFFFFUL) /*!< Unspecified */
+
+/* Register: FICR_INFO_FLASH */
+/* Description: Flash variant */
+
+/* Bits 31..0 : Flash variant */
+#define FICR_INFO_FLASH_FLASH_Pos (0UL) /*!< Position of FLASH field. */
+#define FICR_INFO_FLASH_FLASH_Msk (0xFFFFFFFFUL << FICR_INFO_FLASH_FLASH_Pos) /*!< Bit mask of FLASH field. */
+#define FICR_INFO_FLASH_FLASH_K128 (128UL) /*!< 128 kByte FLASH */
+#define FICR_INFO_FLASH_FLASH_K256 (256UL) /*!< 256 kByte FLASH */
+#define FICR_INFO_FLASH_FLASH_K512 (512UL) /*!< 512 kByte FLASH */
+#define FICR_INFO_FLASH_FLASH_Unspecified (0xFFFFFFFFUL) /*!< Unspecified */
+
+/* Register: FICR_TEMP_A0 */
+/* Description: Slope definition A0. */
+
+/* Bits 11..0 : A (slope definition) register. */
+#define FICR_TEMP_A0_A_Pos (0UL) /*!< Position of A field. */
+#define FICR_TEMP_A0_A_Msk (0xFFFUL << FICR_TEMP_A0_A_Pos) /*!< Bit mask of A field. */
+
+/* Register: FICR_TEMP_A1 */
+/* Description: Slope definition A1. */
+
+/* Bits 11..0 : A (slope definition) register. */
+#define FICR_TEMP_A1_A_Pos (0UL) /*!< Position of A field. */
+#define FICR_TEMP_A1_A_Msk (0xFFFUL << FICR_TEMP_A1_A_Pos) /*!< Bit mask of A field. */
+
+/* Register: FICR_TEMP_A2 */
+/* Description: Slope definition A2. */
+
+/* Bits 11..0 : A (slope definition) register. */
+#define FICR_TEMP_A2_A_Pos (0UL) /*!< Position of A field. */
+#define FICR_TEMP_A2_A_Msk (0xFFFUL << FICR_TEMP_A2_A_Pos) /*!< Bit mask of A field. */
+
+/* Register: FICR_TEMP_A3 */
+/* Description: Slope definition A3. */
+
+/* Bits 11..0 : A (slope definition) register. */
+#define FICR_TEMP_A3_A_Pos (0UL) /*!< Position of A field. */
+#define FICR_TEMP_A3_A_Msk (0xFFFUL << FICR_TEMP_A3_A_Pos) /*!< Bit mask of A field. */
+
+/* Register: FICR_TEMP_A4 */
+/* Description: Slope definition A4. */
+
+/* Bits 11..0 : A (slope definition) register. */
+#define FICR_TEMP_A4_A_Pos (0UL) /*!< Position of A field. */
+#define FICR_TEMP_A4_A_Msk (0xFFFUL << FICR_TEMP_A4_A_Pos) /*!< Bit mask of A field. */
+
+/* Register: FICR_TEMP_A5 */
+/* Description: Slope definition A5. */
+
+/* Bits 11..0 : A (slope definition) register. */
+#define FICR_TEMP_A5_A_Pos (0UL) /*!< Position of A field. */
+#define FICR_TEMP_A5_A_Msk (0xFFFUL << FICR_TEMP_A5_A_Pos) /*!< Bit mask of A field. */
+
+/* Register: FICR_TEMP_B0 */
+/* Description: y-intercept B0. */
+
+/* Bits 13..0 : B (y-intercept) */
+#define FICR_TEMP_B0_B_Pos (0UL) /*!< Position of B field. */
+#define FICR_TEMP_B0_B_Msk (0x3FFFUL << FICR_TEMP_B0_B_Pos) /*!< Bit mask of B field. */
+
+/* Register: FICR_TEMP_B1 */
+/* Description: y-intercept B1. */
+
+/* Bits 13..0 : B (y-intercept) */
+#define FICR_TEMP_B1_B_Pos (0UL) /*!< Position of B field. */
+#define FICR_TEMP_B1_B_Msk (0x3FFFUL << FICR_TEMP_B1_B_Pos) /*!< Bit mask of B field. */
+
+/* Register: FICR_TEMP_B2 */
+/* Description: y-intercept B2. */
+
+/* Bits 13..0 : B (y-intercept) */
+#define FICR_TEMP_B2_B_Pos (0UL) /*!< Position of B field. */
+#define FICR_TEMP_B2_B_Msk (0x3FFFUL << FICR_TEMP_B2_B_Pos) /*!< Bit mask of B field. */
+
+/* Register: FICR_TEMP_B3 */
+/* Description: y-intercept B3. */
+
+/* Bits 13..0 : B (y-intercept) */
+#define FICR_TEMP_B3_B_Pos (0UL) /*!< Position of B field. */
+#define FICR_TEMP_B3_B_Msk (0x3FFFUL << FICR_TEMP_B3_B_Pos) /*!< Bit mask of B field. */
+
+/* Register: FICR_TEMP_B4 */
+/* Description: y-intercept B4. */
+
+/* Bits 13..0 : B (y-intercept) */
+#define FICR_TEMP_B4_B_Pos (0UL) /*!< Position of B field. */
+#define FICR_TEMP_B4_B_Msk (0x3FFFUL << FICR_TEMP_B4_B_Pos) /*!< Bit mask of B field. */
+
+/* Register: FICR_TEMP_B5 */
+/* Description: y-intercept B5. */
+
+/* Bits 13..0 : B (y-intercept) */
+#define FICR_TEMP_B5_B_Pos (0UL) /*!< Position of B field. */
+#define FICR_TEMP_B5_B_Msk (0x3FFFUL << FICR_TEMP_B5_B_Pos) /*!< Bit mask of B field. */
+
+/* Register: FICR_TEMP_T0 */
+/* Description: Segment end T0. */
+
+/* Bits 7..0 : T (segment end)register. */
+#define FICR_TEMP_T0_T_Pos (0UL) /*!< Position of T field. */
+#define FICR_TEMP_T0_T_Msk (0xFFUL << FICR_TEMP_T0_T_Pos) /*!< Bit mask of T field. */
+
+/* Register: FICR_TEMP_T1 */
+/* Description: Segment end T1. */
+
+/* Bits 7..0 : T (segment end)register. */
+#define FICR_TEMP_T1_T_Pos (0UL) /*!< Position of T field. */
+#define FICR_TEMP_T1_T_Msk (0xFFUL << FICR_TEMP_T1_T_Pos) /*!< Bit mask of T field. */
+
+/* Register: FICR_TEMP_T2 */
+/* Description: Segment end T2. */
+
+/* Bits 7..0 : T (segment end)register. */
+#define FICR_TEMP_T2_T_Pos (0UL) /*!< Position of T field. */
+#define FICR_TEMP_T2_T_Msk (0xFFUL << FICR_TEMP_T2_T_Pos) /*!< Bit mask of T field. */
+
+/* Register: FICR_TEMP_T3 */
+/* Description: Segment end T3. */
+
+/* Bits 7..0 : T (segment end)register. */
+#define FICR_TEMP_T3_T_Pos (0UL) /*!< Position of T field. */
+#define FICR_TEMP_T3_T_Msk (0xFFUL << FICR_TEMP_T3_T_Pos) /*!< Bit mask of T field. */
+
+/* Register: FICR_TEMP_T4 */
+/* Description: Segment end T4. */
+
+/* Bits 7..0 : T (segment end)register. */
+#define FICR_TEMP_T4_T_Pos (0UL) /*!< Position of T field. */
+#define FICR_TEMP_T4_T_Msk (0xFFUL << FICR_TEMP_T4_T_Pos) /*!< Bit mask of T field. */
+
+/* Register: FICR_NFC_TAGHEADER0 */
+/* Description: Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST. */
+
+/* Bits 31..24 : Unique identifier byte 3 */
+#define FICR_NFC_TAGHEADER0_UD3_Pos (24UL) /*!< Position of UD3 field. */
+#define FICR_NFC_TAGHEADER0_UD3_Msk (0xFFUL << FICR_NFC_TAGHEADER0_UD3_Pos) /*!< Bit mask of UD3 field. */
+
+/* Bits 23..16 : Unique identifier byte 2 */
+#define FICR_NFC_TAGHEADER0_UD2_Pos (16UL) /*!< Position of UD2 field. */
+#define FICR_NFC_TAGHEADER0_UD2_Msk (0xFFUL << FICR_NFC_TAGHEADER0_UD2_Pos) /*!< Bit mask of UD2 field. */
+
+/* Bits 15..8 : Unique identifier byte 1 */
+#define FICR_NFC_TAGHEADER0_UD1_Pos (8UL) /*!< Position of UD1 field. */
+#define FICR_NFC_TAGHEADER0_UD1_Msk (0xFFUL << FICR_NFC_TAGHEADER0_UD1_Pos) /*!< Bit mask of UD1 field. */
+
+/* Bits 7..0 : Default Manufacturer ID: Nordic Semiconductor ASA has ICM 0x5F */
+#define FICR_NFC_TAGHEADER0_MFGID_Pos (0UL) /*!< Position of MFGID field. */
+#define FICR_NFC_TAGHEADER0_MFGID_Msk (0xFFUL << FICR_NFC_TAGHEADER0_MFGID_Pos) /*!< Bit mask of MFGID field. */
+
+/* Register: FICR_NFC_TAGHEADER1 */
+/* Description: Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST. */
+
+/* Bits 31..24 : Unique identifier byte 7 */
+#define FICR_NFC_TAGHEADER1_UD7_Pos (24UL) /*!< Position of UD7 field. */
+#define FICR_NFC_TAGHEADER1_UD7_Msk (0xFFUL << FICR_NFC_TAGHEADER1_UD7_Pos) /*!< Bit mask of UD7 field. */
+
+/* Bits 23..16 : Unique identifier byte 6 */
+#define FICR_NFC_TAGHEADER1_UD6_Pos (16UL) /*!< Position of UD6 field. */
+#define FICR_NFC_TAGHEADER1_UD6_Msk (0xFFUL << FICR_NFC_TAGHEADER1_UD6_Pos) /*!< Bit mask of UD6 field. */
+
+/* Bits 15..8 : Unique identifier byte 5 */
+#define FICR_NFC_TAGHEADER1_UD5_Pos (8UL) /*!< Position of UD5 field. */
+#define FICR_NFC_TAGHEADER1_UD5_Msk (0xFFUL << FICR_NFC_TAGHEADER1_UD5_Pos) /*!< Bit mask of UD5 field. */
+
+/* Bits 7..0 : Unique identifier byte 4 */
+#define FICR_NFC_TAGHEADER1_UD4_Pos (0UL) /*!< Position of UD4 field. */
+#define FICR_NFC_TAGHEADER1_UD4_Msk (0xFFUL << FICR_NFC_TAGHEADER1_UD4_Pos) /*!< Bit mask of UD4 field. */
+
+/* Register: FICR_NFC_TAGHEADER2 */
+/* Description: Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST. */
+
+/* Bits 31..24 : Unique identifier byte 11 */
+#define FICR_NFC_TAGHEADER2_UD11_Pos (24UL) /*!< Position of UD11 field. */
+#define FICR_NFC_TAGHEADER2_UD11_Msk (0xFFUL << FICR_NFC_TAGHEADER2_UD11_Pos) /*!< Bit mask of UD11 field. */
+
+/* Bits 23..16 : Unique identifier byte 10 */
+#define FICR_NFC_TAGHEADER2_UD10_Pos (16UL) /*!< Position of UD10 field. */
+#define FICR_NFC_TAGHEADER2_UD10_Msk (0xFFUL << FICR_NFC_TAGHEADER2_UD10_Pos) /*!< Bit mask of UD10 field. */
+
+/* Bits 15..8 : Unique identifier byte 9 */
+#define FICR_NFC_TAGHEADER2_UD9_Pos (8UL) /*!< Position of UD9 field. */
+#define FICR_NFC_TAGHEADER2_UD9_Msk (0xFFUL << FICR_NFC_TAGHEADER2_UD9_Pos) /*!< Bit mask of UD9 field. */
+
+/* Bits 7..0 : Unique identifier byte 8 */
+#define FICR_NFC_TAGHEADER2_UD8_Pos (0UL) /*!< Position of UD8 field. */
+#define FICR_NFC_TAGHEADER2_UD8_Msk (0xFFUL << FICR_NFC_TAGHEADER2_UD8_Pos) /*!< Bit mask of UD8 field. */
+
+/* Register: FICR_NFC_TAGHEADER3 */
+/* Description: Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST. */
+
+/* Bits 31..24 : Unique identifier byte 15 */
+#define FICR_NFC_TAGHEADER3_UD15_Pos (24UL) /*!< Position of UD15 field. */
+#define FICR_NFC_TAGHEADER3_UD15_Msk (0xFFUL << FICR_NFC_TAGHEADER3_UD15_Pos) /*!< Bit mask of UD15 field. */
+
+/* Bits 23..16 : Unique identifier byte 14 */
+#define FICR_NFC_TAGHEADER3_UD14_Pos (16UL) /*!< Position of UD14 field. */
+#define FICR_NFC_TAGHEADER3_UD14_Msk (0xFFUL << FICR_NFC_TAGHEADER3_UD14_Pos) /*!< Bit mask of UD14 field. */
+
+/* Bits 15..8 : Unique identifier byte 13 */
+#define FICR_NFC_TAGHEADER3_UD13_Pos (8UL) /*!< Position of UD13 field. */
+#define FICR_NFC_TAGHEADER3_UD13_Msk (0xFFUL << FICR_NFC_TAGHEADER3_UD13_Pos) /*!< Bit mask of UD13 field. */
+
+/* Bits 7..0 : Unique identifier byte 12 */
+#define FICR_NFC_TAGHEADER3_UD12_Pos (0UL) /*!< Position of UD12 field. */
+#define FICR_NFC_TAGHEADER3_UD12_Msk (0xFFUL << FICR_NFC_TAGHEADER3_UD12_Pos) /*!< Bit mask of UD12 field. */
+
+
+/* Peripheral: GPIOTE */
+/* Description: GPIO Tasks and Events */
+
+/* Register: GPIOTE_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 31 : Write '1' to Enable interrupt for PORT event */
+#define GPIOTE_INTENSET_PORT_Pos (31UL) /*!< Position of PORT field. */
+#define GPIOTE_INTENSET_PORT_Msk (0x1UL << GPIOTE_INTENSET_PORT_Pos) /*!< Bit mask of PORT field. */
+#define GPIOTE_INTENSET_PORT_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENSET_PORT_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENSET_PORT_Set (1UL) /*!< Enable */
+
+/* Bit 7 : Write '1' to Enable interrupt for IN[7] event */
+#define GPIOTE_INTENSET_IN7_Pos (7UL) /*!< Position of IN7 field. */
+#define GPIOTE_INTENSET_IN7_Msk (0x1UL << GPIOTE_INTENSET_IN7_Pos) /*!< Bit mask of IN7 field. */
+#define GPIOTE_INTENSET_IN7_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENSET_IN7_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENSET_IN7_Set (1UL) /*!< Enable */
+
+/* Bit 6 : Write '1' to Enable interrupt for IN[6] event */
+#define GPIOTE_INTENSET_IN6_Pos (6UL) /*!< Position of IN6 field. */
+#define GPIOTE_INTENSET_IN6_Msk (0x1UL << GPIOTE_INTENSET_IN6_Pos) /*!< Bit mask of IN6 field. */
+#define GPIOTE_INTENSET_IN6_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENSET_IN6_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENSET_IN6_Set (1UL) /*!< Enable */
+
+/* Bit 5 : Write '1' to Enable interrupt for IN[5] event */
+#define GPIOTE_INTENSET_IN5_Pos (5UL) /*!< Position of IN5 field. */
+#define GPIOTE_INTENSET_IN5_Msk (0x1UL << GPIOTE_INTENSET_IN5_Pos) /*!< Bit mask of IN5 field. */
+#define GPIOTE_INTENSET_IN5_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENSET_IN5_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENSET_IN5_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable interrupt for IN[4] event */
+#define GPIOTE_INTENSET_IN4_Pos (4UL) /*!< Position of IN4 field. */
+#define GPIOTE_INTENSET_IN4_Msk (0x1UL << GPIOTE_INTENSET_IN4_Pos) /*!< Bit mask of IN4 field. */
+#define GPIOTE_INTENSET_IN4_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENSET_IN4_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENSET_IN4_Set (1UL) /*!< Enable */
+
+/* Bit 3 : Write '1' to Enable interrupt for IN[3] event */
+#define GPIOTE_INTENSET_IN3_Pos (3UL) /*!< Position of IN3 field. */
+#define GPIOTE_INTENSET_IN3_Msk (0x1UL << GPIOTE_INTENSET_IN3_Pos) /*!< Bit mask of IN3 field. */
+#define GPIOTE_INTENSET_IN3_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENSET_IN3_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENSET_IN3_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for IN[2] event */
+#define GPIOTE_INTENSET_IN2_Pos (2UL) /*!< Position of IN2 field. */
+#define GPIOTE_INTENSET_IN2_Msk (0x1UL << GPIOTE_INTENSET_IN2_Pos) /*!< Bit mask of IN2 field. */
+#define GPIOTE_INTENSET_IN2_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENSET_IN2_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENSET_IN2_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for IN[1] event */
+#define GPIOTE_INTENSET_IN1_Pos (1UL) /*!< Position of IN1 field. */
+#define GPIOTE_INTENSET_IN1_Msk (0x1UL << GPIOTE_INTENSET_IN1_Pos) /*!< Bit mask of IN1 field. */
+#define GPIOTE_INTENSET_IN1_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENSET_IN1_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENSET_IN1_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for IN[0] event */
+#define GPIOTE_INTENSET_IN0_Pos (0UL) /*!< Position of IN0 field. */
+#define GPIOTE_INTENSET_IN0_Msk (0x1UL << GPIOTE_INTENSET_IN0_Pos) /*!< Bit mask of IN0 field. */
+#define GPIOTE_INTENSET_IN0_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENSET_IN0_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENSET_IN0_Set (1UL) /*!< Enable */
+
+/* Register: GPIOTE_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 31 : Write '1' to Disable interrupt for PORT event */
+#define GPIOTE_INTENCLR_PORT_Pos (31UL) /*!< Position of PORT field. */
+#define GPIOTE_INTENCLR_PORT_Msk (0x1UL << GPIOTE_INTENCLR_PORT_Pos) /*!< Bit mask of PORT field. */
+#define GPIOTE_INTENCLR_PORT_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENCLR_PORT_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENCLR_PORT_Clear (1UL) /*!< Disable */
+
+/* Bit 7 : Write '1' to Disable interrupt for IN[7] event */
+#define GPIOTE_INTENCLR_IN7_Pos (7UL) /*!< Position of IN7 field. */
+#define GPIOTE_INTENCLR_IN7_Msk (0x1UL << GPIOTE_INTENCLR_IN7_Pos) /*!< Bit mask of IN7 field. */
+#define GPIOTE_INTENCLR_IN7_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENCLR_IN7_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENCLR_IN7_Clear (1UL) /*!< Disable */
+
+/* Bit 6 : Write '1' to Disable interrupt for IN[6] event */
+#define GPIOTE_INTENCLR_IN6_Pos (6UL) /*!< Position of IN6 field. */
+#define GPIOTE_INTENCLR_IN6_Msk (0x1UL << GPIOTE_INTENCLR_IN6_Pos) /*!< Bit mask of IN6 field. */
+#define GPIOTE_INTENCLR_IN6_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENCLR_IN6_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENCLR_IN6_Clear (1UL) /*!< Disable */
+
+/* Bit 5 : Write '1' to Disable interrupt for IN[5] event */
+#define GPIOTE_INTENCLR_IN5_Pos (5UL) /*!< Position of IN5 field. */
+#define GPIOTE_INTENCLR_IN5_Msk (0x1UL << GPIOTE_INTENCLR_IN5_Pos) /*!< Bit mask of IN5 field. */
+#define GPIOTE_INTENCLR_IN5_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENCLR_IN5_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENCLR_IN5_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable interrupt for IN[4] event */
+#define GPIOTE_INTENCLR_IN4_Pos (4UL) /*!< Position of IN4 field. */
+#define GPIOTE_INTENCLR_IN4_Msk (0x1UL << GPIOTE_INTENCLR_IN4_Pos) /*!< Bit mask of IN4 field. */
+#define GPIOTE_INTENCLR_IN4_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENCLR_IN4_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENCLR_IN4_Clear (1UL) /*!< Disable */
+
+/* Bit 3 : Write '1' to Disable interrupt for IN[3] event */
+#define GPIOTE_INTENCLR_IN3_Pos (3UL) /*!< Position of IN3 field. */
+#define GPIOTE_INTENCLR_IN3_Msk (0x1UL << GPIOTE_INTENCLR_IN3_Pos) /*!< Bit mask of IN3 field. */
+#define GPIOTE_INTENCLR_IN3_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENCLR_IN3_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENCLR_IN3_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for IN[2] event */
+#define GPIOTE_INTENCLR_IN2_Pos (2UL) /*!< Position of IN2 field. */
+#define GPIOTE_INTENCLR_IN2_Msk (0x1UL << GPIOTE_INTENCLR_IN2_Pos) /*!< Bit mask of IN2 field. */
+#define GPIOTE_INTENCLR_IN2_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENCLR_IN2_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENCLR_IN2_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for IN[1] event */
+#define GPIOTE_INTENCLR_IN1_Pos (1UL) /*!< Position of IN1 field. */
+#define GPIOTE_INTENCLR_IN1_Msk (0x1UL << GPIOTE_INTENCLR_IN1_Pos) /*!< Bit mask of IN1 field. */
+#define GPIOTE_INTENCLR_IN1_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENCLR_IN1_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENCLR_IN1_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for IN[0] event */
+#define GPIOTE_INTENCLR_IN0_Pos (0UL) /*!< Position of IN0 field. */
+#define GPIOTE_INTENCLR_IN0_Msk (0x1UL << GPIOTE_INTENCLR_IN0_Pos) /*!< Bit mask of IN0 field. */
+#define GPIOTE_INTENCLR_IN0_Disabled (0UL) /*!< Read: Disabled */
+#define GPIOTE_INTENCLR_IN0_Enabled (1UL) /*!< Read: Enabled */
+#define GPIOTE_INTENCLR_IN0_Clear (1UL) /*!< Disable */
+
+/* Register: GPIOTE_CONFIG */
+/* Description: Description collection[0]:  Configuration for OUT[n], SET[n] and CLR[n] tasks and IN[n] event */
+
+/* Bit 20 : When in task mode: Initial value of the output when the GPIOTE channel is configured. When in event mode: No effect. */
+#define GPIOTE_CONFIG_OUTINIT_Pos (20UL) /*!< Position of OUTINIT field. */
+#define GPIOTE_CONFIG_OUTINIT_Msk (0x1UL << GPIOTE_CONFIG_OUTINIT_Pos) /*!< Bit mask of OUTINIT field. */
+#define GPIOTE_CONFIG_OUTINIT_Low (0UL) /*!< Task mode: Initial value of pin before task triggering is low */
+#define GPIOTE_CONFIG_OUTINIT_High (1UL) /*!< Task mode: Initial value of pin before task triggering is high */
+
+/* Bits 17..16 : When In task mode: Operation to be performed on output when OUT[n] task is triggered. When In event mode: Operation on input that shall trigger IN[n] event. */
+#define GPIOTE_CONFIG_POLARITY_Pos (16UL) /*!< Position of POLARITY field. */
+#define GPIOTE_CONFIG_POLARITY_Msk (0x3UL << GPIOTE_CONFIG_POLARITY_Pos) /*!< Bit mask of POLARITY field. */
+#define GPIOTE_CONFIG_POLARITY_None (0UL) /*!< Task mode: No effect on pin from OUT[n] task. Event mode: no IN[n] event generated on pin activity. */
+#define GPIOTE_CONFIG_POLARITY_LoToHi (1UL) /*!< Task mode: Set pin from OUT[n] task. Event mode: Generate IN[n] event when rising edge on pin. */
+#define GPIOTE_CONFIG_POLARITY_HiToLo (2UL) /*!< Task mode: Clear pin from OUT[n] task. Event mode: Generate IN[n] event when falling edge on pin. */
+#define GPIOTE_CONFIG_POLARITY_Toggle (3UL) /*!< Task mode: Toggle pin from OUT[n]. Event mode: Generate IN[n] when any change on pin. */
+
+/* Bits 12..8 : GPIO number associated with SET[n], CLR[n] and OUT[n] tasks and IN[n] event */
+#define GPIOTE_CONFIG_PSEL_Pos (8UL) /*!< Position of PSEL field. */
+#define GPIOTE_CONFIG_PSEL_Msk (0x1FUL << GPIOTE_CONFIG_PSEL_Pos) /*!< Bit mask of PSEL field. */
+
+/* Bits 1..0 : Mode */
+#define GPIOTE_CONFIG_MODE_Pos (0UL) /*!< Position of MODE field. */
+#define GPIOTE_CONFIG_MODE_Msk (0x3UL << GPIOTE_CONFIG_MODE_Pos) /*!< Bit mask of MODE field. */
+#define GPIOTE_CONFIG_MODE_Disabled (0UL) /*!< Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module. */
+#define GPIOTE_CONFIG_MODE_Event (1UL) /*!< Event mode */
+#define GPIOTE_CONFIG_MODE_Task (3UL) /*!< Task mode */
+
+
+/* Peripheral: I2S */
+/* Description: Inter-IC Sound */
+
+/* Register: I2S_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 5 : Enable or disable interrupt for TXPTRUPD event */
+#define I2S_INTEN_TXPTRUPD_Pos (5UL) /*!< Position of TXPTRUPD field. */
+#define I2S_INTEN_TXPTRUPD_Msk (0x1UL << I2S_INTEN_TXPTRUPD_Pos) /*!< Bit mask of TXPTRUPD field. */
+#define I2S_INTEN_TXPTRUPD_Disabled (0UL) /*!< Disable */
+#define I2S_INTEN_TXPTRUPD_Enabled (1UL) /*!< Enable */
+
+/* Bit 2 : Enable or disable interrupt for STOPPED event */
+#define I2S_INTEN_STOPPED_Pos (2UL) /*!< Position of STOPPED field. */
+#define I2S_INTEN_STOPPED_Msk (0x1UL << I2S_INTEN_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define I2S_INTEN_STOPPED_Disabled (0UL) /*!< Disable */
+#define I2S_INTEN_STOPPED_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for RXPTRUPD event */
+#define I2S_INTEN_RXPTRUPD_Pos (1UL) /*!< Position of RXPTRUPD field. */
+#define I2S_INTEN_RXPTRUPD_Msk (0x1UL << I2S_INTEN_RXPTRUPD_Pos) /*!< Bit mask of RXPTRUPD field. */
+#define I2S_INTEN_RXPTRUPD_Disabled (0UL) /*!< Disable */
+#define I2S_INTEN_RXPTRUPD_Enabled (1UL) /*!< Enable */
+
+/* Register: I2S_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 5 : Write '1' to Enable interrupt for TXPTRUPD event */
+#define I2S_INTENSET_TXPTRUPD_Pos (5UL) /*!< Position of TXPTRUPD field. */
+#define I2S_INTENSET_TXPTRUPD_Msk (0x1UL << I2S_INTENSET_TXPTRUPD_Pos) /*!< Bit mask of TXPTRUPD field. */
+#define I2S_INTENSET_TXPTRUPD_Disabled (0UL) /*!< Read: Disabled */
+#define I2S_INTENSET_TXPTRUPD_Enabled (1UL) /*!< Read: Enabled */
+#define I2S_INTENSET_TXPTRUPD_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for STOPPED event */
+#define I2S_INTENSET_STOPPED_Pos (2UL) /*!< Position of STOPPED field. */
+#define I2S_INTENSET_STOPPED_Msk (0x1UL << I2S_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define I2S_INTENSET_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define I2S_INTENSET_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define I2S_INTENSET_STOPPED_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for RXPTRUPD event */
+#define I2S_INTENSET_RXPTRUPD_Pos (1UL) /*!< Position of RXPTRUPD field. */
+#define I2S_INTENSET_RXPTRUPD_Msk (0x1UL << I2S_INTENSET_RXPTRUPD_Pos) /*!< Bit mask of RXPTRUPD field. */
+#define I2S_INTENSET_RXPTRUPD_Disabled (0UL) /*!< Read: Disabled */
+#define I2S_INTENSET_RXPTRUPD_Enabled (1UL) /*!< Read: Enabled */
+#define I2S_INTENSET_RXPTRUPD_Set (1UL) /*!< Enable */
+
+/* Register: I2S_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 5 : Write '1' to Disable interrupt for TXPTRUPD event */
+#define I2S_INTENCLR_TXPTRUPD_Pos (5UL) /*!< Position of TXPTRUPD field. */
+#define I2S_INTENCLR_TXPTRUPD_Msk (0x1UL << I2S_INTENCLR_TXPTRUPD_Pos) /*!< Bit mask of TXPTRUPD field. */
+#define I2S_INTENCLR_TXPTRUPD_Disabled (0UL) /*!< Read: Disabled */
+#define I2S_INTENCLR_TXPTRUPD_Enabled (1UL) /*!< Read: Enabled */
+#define I2S_INTENCLR_TXPTRUPD_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for STOPPED event */
+#define I2S_INTENCLR_STOPPED_Pos (2UL) /*!< Position of STOPPED field. */
+#define I2S_INTENCLR_STOPPED_Msk (0x1UL << I2S_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define I2S_INTENCLR_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define I2S_INTENCLR_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define I2S_INTENCLR_STOPPED_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for RXPTRUPD event */
+#define I2S_INTENCLR_RXPTRUPD_Pos (1UL) /*!< Position of RXPTRUPD field. */
+#define I2S_INTENCLR_RXPTRUPD_Msk (0x1UL << I2S_INTENCLR_RXPTRUPD_Pos) /*!< Bit mask of RXPTRUPD field. */
+#define I2S_INTENCLR_RXPTRUPD_Disabled (0UL) /*!< Read: Disabled */
+#define I2S_INTENCLR_RXPTRUPD_Enabled (1UL) /*!< Read: Enabled */
+#define I2S_INTENCLR_RXPTRUPD_Clear (1UL) /*!< Disable */
+
+/* Register: I2S_ENABLE */
+/* Description: Enable I2S module. */
+
+/* Bit 0 : Enable I2S module. */
+#define I2S_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define I2S_ENABLE_ENABLE_Msk (0x1UL << I2S_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define I2S_ENABLE_ENABLE_DISABLE (0UL) /*!< Disabl */
+#define I2S_ENABLE_ENABLE_ENABLE (1UL) /*!< Enable */
+
+/* Register: I2S_CONFIG_MODE */
+/* Description: I2S mode. */
+
+/* Bit 0 : I2S mode. */
+#define I2S_CONFIG_MODE_MODE_Pos (0UL) /*!< Position of MODE field. */
+#define I2S_CONFIG_MODE_MODE_Msk (0x1UL << I2S_CONFIG_MODE_MODE_Pos) /*!< Bit mask of MODE field. */
+#define I2S_CONFIG_MODE_MODE_MASTER (0UL) /*!< Master mode. SCK and LRCK generated from internal master clcok (MCK) and output on pins defined by PSEL.xxx. */
+#define I2S_CONFIG_MODE_MODE_SLAVE (1UL) /*!< Slave mode. SCK and LRCK generated by external master and received on pins defined by PSEL.xxx */
+
+/* Register: I2S_CONFIG_RXEN */
+/* Description: Reception (RX) enable. */
+
+/* Bit 0 : Reception (RX) enable. */
+#define I2S_CONFIG_RXEN_RXEN_Pos (0UL) /*!< Position of RXEN field. */
+#define I2S_CONFIG_RXEN_RXEN_Msk (0x1UL << I2S_CONFIG_RXEN_RXEN_Pos) /*!< Bit mask of RXEN field. */
+#define I2S_CONFIG_RXEN_RXEN_DISABLE (0UL) /*!< Reception disabled and now data will be written to the RXD.PTR address. */
+#define I2S_CONFIG_RXEN_RXEN_ENABLE (1UL) /*!< Reception enabled. */
+
+/* Register: I2S_CONFIG_TXEN */
+/* Description: Transmission (TX) enable. */
+
+/* Bit 0 : Transmission (TX) enable. */
+#define I2S_CONFIG_TXEN_TXEN_Pos (0UL) /*!< Position of TXEN field. */
+#define I2S_CONFIG_TXEN_TXEN_Msk (0x1UL << I2S_CONFIG_TXEN_TXEN_Pos) /*!< Bit mask of TXEN field. */
+#define I2S_CONFIG_TXEN_TXEN_DISABLE (0UL) /*!< Transmission disabled and now data will be read from the RXD.TXD address. */
+#define I2S_CONFIG_TXEN_TXEN_ENABLE (1UL) /*!< Transmission enabled. */
+
+/* Register: I2S_CONFIG_MCKEN */
+/* Description: Master clock generator enable. */
+
+/* Bit 0 : Master clock generator enable. */
+#define I2S_CONFIG_MCKEN_MCKEN_Pos (0UL) /*!< Position of MCKEN field. */
+#define I2S_CONFIG_MCKEN_MCKEN_Msk (0x1UL << I2S_CONFIG_MCKEN_MCKEN_Pos) /*!< Bit mask of MCKEN field. */
+#define I2S_CONFIG_MCKEN_MCKEN_DISABLE (0UL) /*!< Master clock generator disabled and PSEL.MCK not connected(available as GPIO). */
+#define I2S_CONFIG_MCKEN_MCKEN_ENABLE (1UL) /*!< Master clock generator running and MCK output on PSEL.MCK. */
+
+/* Register: I2S_CONFIG_MCKFREQ */
+/* Description: Master clock generator frequency. */
+
+/* Bits 31..0 : Master clock generator frequency. */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_Pos (0UL) /*!< Position of MCKFREQ field. */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_Msk (0xFFFFFFFFUL << I2S_CONFIG_MCKFREQ_MCKFREQ_Pos) /*!< Bit mask of MCKFREQ field. */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV125 (0x020C0000UL) /*!< 32 MHz / 125 = 0.256 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV63 (0x04100000UL) /*!< 32 MHz / 63 = 0.5079365 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV42 (0x06000000UL) /*!< 32 MHz / 42 = 0.7619048 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV32 (0x08000000UL) /*!< 32 MHz / 32 = 1.0 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV31 (0x08400000UL) /*!< 32 MHz / 31 = 1.0322581 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV30 (0x08800000UL) /*!< 32 MHz / 30 = 1.0666667 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV23 (0x0B000000UL) /*!< 32 MHz / 23 = 1.3913043 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV21 (0x0C000000UL) /*!< 32 MHz / 21 = 1.5238095 */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV16 (0x10000000UL) /*!< 32 MHz / 16 = 2.0 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV15 (0x11000000UL) /*!< 32 MHz / 15 = 2.1333333 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV11 (0x16000000UL) /*!< 32 MHz / 11 = 2.9090909 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV10 (0x18000000UL) /*!< 32 MHz / 10 = 3.2 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV8 (0x20000000UL) /*!< 32 MHz / 8 = 4.0 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV6 (0x28000000UL) /*!< 32 MHz / 6 = 5.3333333 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV5 (0x30000000UL) /*!< 32 MHz / 5 = 6.4 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV4 (0x40000000UL) /*!< 32 MHz / 4 = 8.0 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV3 (0x50000000UL) /*!< 32 MHz / 3 = 10.6666667 MHz */
+#define I2S_CONFIG_MCKFREQ_MCKFREQ_32MDIV2 (0x80000000UL) /*!< 32 MHz / 2 = 16.0 MHz */
+
+/* Register: I2S_CONFIG_RATIO */
+/* Description: MCK / LRCK ratio. */
+
+/* Bits 3..0 : MCK / LRCK ratio. */
+#define I2S_CONFIG_RATIO_RATIO_Pos (0UL) /*!< Position of RATIO field. */
+#define I2S_CONFIG_RATIO_RATIO_Msk (0xFUL << I2S_CONFIG_RATIO_RATIO_Pos) /*!< Bit mask of RATIO field. */
+#define I2S_CONFIG_RATIO_RATIO_32X (0UL) /*!< LRCK = MCK / 32 */
+#define I2S_CONFIG_RATIO_RATIO_48X (1UL) /*!< LRCK = MCK / 48 */
+#define I2S_CONFIG_RATIO_RATIO_64X (2UL) /*!< LRCK = MCK / 64 */
+#define I2S_CONFIG_RATIO_RATIO_96X (3UL) /*!< LRCK = MCK / 96 */
+#define I2S_CONFIG_RATIO_RATIO_128X (4UL) /*!< LRCK = MCK / 128 */
+#define I2S_CONFIG_RATIO_RATIO_192X (5UL) /*!< LRCK = MCK / 192 */
+#define I2S_CONFIG_RATIO_RATIO_256X (6UL) /*!< LRCK = MCK / 256 */
+#define I2S_CONFIG_RATIO_RATIO_384X (7UL) /*!< LRCK = MCK / 384 */
+#define I2S_CONFIG_RATIO_RATIO_512X (8UL) /*!< LRCK = MCK / 512 */
+
+/* Register: I2S_CONFIG_SWIDTH */
+/* Description: Sample width. */
+
+/* Bits 1..0 : Sample width. */
+#define I2S_CONFIG_SWIDTH_SWIDTH_Pos (0UL) /*!< Position of SWIDTH field. */
+#define I2S_CONFIG_SWIDTH_SWIDTH_Msk (0x3UL << I2S_CONFIG_SWIDTH_SWIDTH_Pos) /*!< Bit mask of SWIDTH field. */
+#define I2S_CONFIG_SWIDTH_SWIDTH_8BIT (0UL) /*!< 8 bit. */
+#define I2S_CONFIG_SWIDTH_SWIDTH_16BIT (1UL) /*!< 16 bit. */
+#define I2S_CONFIG_SWIDTH_SWIDTH_24BIT (2UL) /*!< 24 bit. */
+
+/* Register: I2S_CONFIG_ALIGN */
+/* Description: Alignment of sample within a frame. */
+
+/* Bit 0 : Alignment of sample within a frame. */
+#define I2S_CONFIG_ALIGN_ALIGN_Pos (0UL) /*!< Position of ALIGN field. */
+#define I2S_CONFIG_ALIGN_ALIGN_Msk (0x1UL << I2S_CONFIG_ALIGN_ALIGN_Pos) /*!< Bit mask of ALIGN field. */
+#define I2S_CONFIG_ALIGN_ALIGN_LEFT (0UL) /*!< Left-aligned. */
+#define I2S_CONFIG_ALIGN_ALIGN_RIGHT (1UL) /*!< Right-aligned. */
+
+/* Register: I2S_CONFIG_FORMAT */
+/* Description: Frame format. */
+
+/* Bit 0 : Frame format. */
+#define I2S_CONFIG_FORMAT_FORMAT_Pos (0UL) /*!< Position of FORMAT field. */
+#define I2S_CONFIG_FORMAT_FORMAT_Msk (0x1UL << I2S_CONFIG_FORMAT_FORMAT_Pos) /*!< Bit mask of FORMAT field. */
+#define I2S_CONFIG_FORMAT_FORMAT_I2S (0UL) /*!< Original I2S format. */
+#define I2S_CONFIG_FORMAT_FORMAT_ALIGNED (1UL) /*!< Alternate (left- or right-aligned) format. */
+
+/* Register: I2S_CONFIG_CHANNELS */
+/* Description: Enable channels. */
+
+/* Bits 1..0 : Enable channels. */
+#define I2S_CONFIG_CHANNELS_CHANNELS_Pos (0UL) /*!< Position of CHANNELS field. */
+#define I2S_CONFIG_CHANNELS_CHANNELS_Msk (0x3UL << I2S_CONFIG_CHANNELS_CHANNELS_Pos) /*!< Bit mask of CHANNELS field. */
+#define I2S_CONFIG_CHANNELS_CHANNELS_STEREO (0UL) /*!< Stereo. */
+#define I2S_CONFIG_CHANNELS_CHANNELS_LEFT (1UL) /*!< Left only. */
+#define I2S_CONFIG_CHANNELS_CHANNELS_RIGHT (2UL) /*!< Right only. */
+
+/* Register: I2S_RXD_PTR */
+/* Description: Receive buffer RAM start address. */
+
+/* Bits 31..0 : Receive buffer Data RAM start address. When receiving, words containing samples will be written to this address. This address is a word aligned Data RAM address. */
+#define I2S_RXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define I2S_RXD_PTR_PTR_Msk (0xFFFFFFFFUL << I2S_RXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: I2S_TXD_PTR */
+/* Description: Transmit buffer RAM start address. */
+
+/* Bits 31..0 : Transmit buffer Data RAM start address. When transmitting, words containing samples will be fetched from this address. This address is a word aligned Data RAM address. */
+#define I2S_TXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define I2S_TXD_PTR_PTR_Msk (0xFFFFFFFFUL << I2S_TXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: I2S_RXTXD_MAXCNT */
+/* Description: Size of RXD and TXD buffers. */
+
+/* Bits 13..0 : Size of RXD and TXD buffers in number of 32 bit words. */
+#define I2S_RXTXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define I2S_RXTXD_MAXCNT_MAXCNT_Msk (0x3FFFUL << I2S_RXTXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: I2S_PSEL_MCK */
+/* Description: Pin select for MCK signal. */
+
+/* Bit 31 : Connection */
+#define I2S_PSEL_MCK_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define I2S_PSEL_MCK_CONNECT_Msk (0x1UL << I2S_PSEL_MCK_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define I2S_PSEL_MCK_CONNECT_Connected (0UL) /*!< Connect */
+#define I2S_PSEL_MCK_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define I2S_PSEL_MCK_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define I2S_PSEL_MCK_PIN_Msk (0x1FUL << I2S_PSEL_MCK_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: I2S_PSEL_SCK */
+/* Description: Pin select for SCK signal. */
+
+/* Bit 31 : Connection */
+#define I2S_PSEL_SCK_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define I2S_PSEL_SCK_CONNECT_Msk (0x1UL << I2S_PSEL_SCK_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define I2S_PSEL_SCK_CONNECT_Connected (0UL) /*!< Connect */
+#define I2S_PSEL_SCK_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define I2S_PSEL_SCK_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define I2S_PSEL_SCK_PIN_Msk (0x1FUL << I2S_PSEL_SCK_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: I2S_PSEL_LRCK */
+/* Description: Pin select for LRCK signal. */
+
+/* Bit 31 : Connection */
+#define I2S_PSEL_LRCK_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define I2S_PSEL_LRCK_CONNECT_Msk (0x1UL << I2S_PSEL_LRCK_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define I2S_PSEL_LRCK_CONNECT_Connected (0UL) /*!< Connect */
+#define I2S_PSEL_LRCK_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define I2S_PSEL_LRCK_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define I2S_PSEL_LRCK_PIN_Msk (0x1FUL << I2S_PSEL_LRCK_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: I2S_PSEL_SDIN */
+/* Description: Pin select for SDIN signal. */
+
+/* Bit 31 : Connection */
+#define I2S_PSEL_SDIN_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define I2S_PSEL_SDIN_CONNECT_Msk (0x1UL << I2S_PSEL_SDIN_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define I2S_PSEL_SDIN_CONNECT_Connected (0UL) /*!< Connect */
+#define I2S_PSEL_SDIN_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define I2S_PSEL_SDIN_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define I2S_PSEL_SDIN_PIN_Msk (0x1FUL << I2S_PSEL_SDIN_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: I2S_PSEL_SDOUT */
+/* Description: Pin select for SDOUT signal. */
+
+/* Bit 31 : Connection */
+#define I2S_PSEL_SDOUT_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define I2S_PSEL_SDOUT_CONNECT_Msk (0x1UL << I2S_PSEL_SDOUT_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define I2S_PSEL_SDOUT_CONNECT_Connected (0UL) /*!< Connect */
+#define I2S_PSEL_SDOUT_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define I2S_PSEL_SDOUT_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define I2S_PSEL_SDOUT_PIN_Msk (0x1FUL << I2S_PSEL_SDOUT_PIN_Pos) /*!< Bit mask of PIN field. */
+
+
+/* Peripheral: LPCOMP */
+/* Description: Low Power Comparator */
+
+/* Register: LPCOMP_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 4 : Shortcut between CROSS event and STOP task */
+#define LPCOMP_SHORTS_CROSS_STOP_Pos (4UL) /*!< Position of CROSS_STOP field. */
+#define LPCOMP_SHORTS_CROSS_STOP_Msk (0x1UL << LPCOMP_SHORTS_CROSS_STOP_Pos) /*!< Bit mask of CROSS_STOP field. */
+#define LPCOMP_SHORTS_CROSS_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define LPCOMP_SHORTS_CROSS_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 3 : Shortcut between UP event and STOP task */
+#define LPCOMP_SHORTS_UP_STOP_Pos (3UL) /*!< Position of UP_STOP field. */
+#define LPCOMP_SHORTS_UP_STOP_Msk (0x1UL << LPCOMP_SHORTS_UP_STOP_Pos) /*!< Bit mask of UP_STOP field. */
+#define LPCOMP_SHORTS_UP_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define LPCOMP_SHORTS_UP_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 2 : Shortcut between DOWN event and STOP task */
+#define LPCOMP_SHORTS_DOWN_STOP_Pos (2UL) /*!< Position of DOWN_STOP field. */
+#define LPCOMP_SHORTS_DOWN_STOP_Msk (0x1UL << LPCOMP_SHORTS_DOWN_STOP_Pos) /*!< Bit mask of DOWN_STOP field. */
+#define LPCOMP_SHORTS_DOWN_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define LPCOMP_SHORTS_DOWN_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 1 : Shortcut between READY event and STOP task */
+#define LPCOMP_SHORTS_READY_STOP_Pos (1UL) /*!< Position of READY_STOP field. */
+#define LPCOMP_SHORTS_READY_STOP_Msk (0x1UL << LPCOMP_SHORTS_READY_STOP_Pos) /*!< Bit mask of READY_STOP field. */
+#define LPCOMP_SHORTS_READY_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define LPCOMP_SHORTS_READY_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 0 : Shortcut between READY event and SAMPLE task */
+#define LPCOMP_SHORTS_READY_SAMPLE_Pos (0UL) /*!< Position of READY_SAMPLE field. */
+#define LPCOMP_SHORTS_READY_SAMPLE_Msk (0x1UL << LPCOMP_SHORTS_READY_SAMPLE_Pos) /*!< Bit mask of READY_SAMPLE field. */
+#define LPCOMP_SHORTS_READY_SAMPLE_Disabled (0UL) /*!< Disable shortcut */
+#define LPCOMP_SHORTS_READY_SAMPLE_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: LPCOMP_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 3 : Write '1' to Enable interrupt for CROSS event */
+#define LPCOMP_INTENSET_CROSS_Pos (3UL) /*!< Position of CROSS field. */
+#define LPCOMP_INTENSET_CROSS_Msk (0x1UL << LPCOMP_INTENSET_CROSS_Pos) /*!< Bit mask of CROSS field. */
+#define LPCOMP_INTENSET_CROSS_Disabled (0UL) /*!< Read: Disabled */
+#define LPCOMP_INTENSET_CROSS_Enabled (1UL) /*!< Read: Enabled */
+#define LPCOMP_INTENSET_CROSS_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for UP event */
+#define LPCOMP_INTENSET_UP_Pos (2UL) /*!< Position of UP field. */
+#define LPCOMP_INTENSET_UP_Msk (0x1UL << LPCOMP_INTENSET_UP_Pos) /*!< Bit mask of UP field. */
+#define LPCOMP_INTENSET_UP_Disabled (0UL) /*!< Read: Disabled */
+#define LPCOMP_INTENSET_UP_Enabled (1UL) /*!< Read: Enabled */
+#define LPCOMP_INTENSET_UP_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for DOWN event */
+#define LPCOMP_INTENSET_DOWN_Pos (1UL) /*!< Position of DOWN field. */
+#define LPCOMP_INTENSET_DOWN_Msk (0x1UL << LPCOMP_INTENSET_DOWN_Pos) /*!< Bit mask of DOWN field. */
+#define LPCOMP_INTENSET_DOWN_Disabled (0UL) /*!< Read: Disabled */
+#define LPCOMP_INTENSET_DOWN_Enabled (1UL) /*!< Read: Enabled */
+#define LPCOMP_INTENSET_DOWN_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for READY event */
+#define LPCOMP_INTENSET_READY_Pos (0UL) /*!< Position of READY field. */
+#define LPCOMP_INTENSET_READY_Msk (0x1UL << LPCOMP_INTENSET_READY_Pos) /*!< Bit mask of READY field. */
+#define LPCOMP_INTENSET_READY_Disabled (0UL) /*!< Read: Disabled */
+#define LPCOMP_INTENSET_READY_Enabled (1UL) /*!< Read: Enabled */
+#define LPCOMP_INTENSET_READY_Set (1UL) /*!< Enable */
+
+/* Register: LPCOMP_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 3 : Write '1' to Disable interrupt for CROSS event */
+#define LPCOMP_INTENCLR_CROSS_Pos (3UL) /*!< Position of CROSS field. */
+#define LPCOMP_INTENCLR_CROSS_Msk (0x1UL << LPCOMP_INTENCLR_CROSS_Pos) /*!< Bit mask of CROSS field. */
+#define LPCOMP_INTENCLR_CROSS_Disabled (0UL) /*!< Read: Disabled */
+#define LPCOMP_INTENCLR_CROSS_Enabled (1UL) /*!< Read: Enabled */
+#define LPCOMP_INTENCLR_CROSS_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for UP event */
+#define LPCOMP_INTENCLR_UP_Pos (2UL) /*!< Position of UP field. */
+#define LPCOMP_INTENCLR_UP_Msk (0x1UL << LPCOMP_INTENCLR_UP_Pos) /*!< Bit mask of UP field. */
+#define LPCOMP_INTENCLR_UP_Disabled (0UL) /*!< Read: Disabled */
+#define LPCOMP_INTENCLR_UP_Enabled (1UL) /*!< Read: Enabled */
+#define LPCOMP_INTENCLR_UP_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for DOWN event */
+#define LPCOMP_INTENCLR_DOWN_Pos (1UL) /*!< Position of DOWN field. */
+#define LPCOMP_INTENCLR_DOWN_Msk (0x1UL << LPCOMP_INTENCLR_DOWN_Pos) /*!< Bit mask of DOWN field. */
+#define LPCOMP_INTENCLR_DOWN_Disabled (0UL) /*!< Read: Disabled */
+#define LPCOMP_INTENCLR_DOWN_Enabled (1UL) /*!< Read: Enabled */
+#define LPCOMP_INTENCLR_DOWN_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for READY event */
+#define LPCOMP_INTENCLR_READY_Pos (0UL) /*!< Position of READY field. */
+#define LPCOMP_INTENCLR_READY_Msk (0x1UL << LPCOMP_INTENCLR_READY_Pos) /*!< Bit mask of READY field. */
+#define LPCOMP_INTENCLR_READY_Disabled (0UL) /*!< Read: Disabled */
+#define LPCOMP_INTENCLR_READY_Enabled (1UL) /*!< Read: Enabled */
+#define LPCOMP_INTENCLR_READY_Clear (1UL) /*!< Disable */
+
+/* Register: LPCOMP_RESULT */
+/* Description: Compare result */
+
+/* Bit 0 : Result of last compare. Decision point SAMPLE task. */
+#define LPCOMP_RESULT_RESULT_Pos (0UL) /*!< Position of RESULT field. */
+#define LPCOMP_RESULT_RESULT_Msk (0x1UL << LPCOMP_RESULT_RESULT_Pos) /*!< Bit mask of RESULT field. */
+#define LPCOMP_RESULT_RESULT_Bellow (0UL) /*!< Input voltage is below the reference threshold (VIN+ &lt; VIN-). */
+#define LPCOMP_RESULT_RESULT_Above (1UL) /*!< Input voltage is above the reference threshold (VIN+ &gt; VIN-). */
+
+/* Register: LPCOMP_ENABLE */
+/* Description: Enable LPCOMP */
+
+/* Bits 1..0 : Enable or disable LPCOMP */
+#define LPCOMP_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define LPCOMP_ENABLE_ENABLE_Msk (0x3UL << LPCOMP_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define LPCOMP_ENABLE_ENABLE_Disabled (0UL) /*!< Disable */
+#define LPCOMP_ENABLE_ENABLE_Enabled (1UL) /*!< Enable */
+
+/* Register: LPCOMP_PSEL */
+/* Description: Input pin select */
+
+/* Bits 2..0 : Analog pin select */
+#define LPCOMP_PSEL_PSEL_Pos (0UL) /*!< Position of PSEL field. */
+#define LPCOMP_PSEL_PSEL_Msk (0x7UL << LPCOMP_PSEL_PSEL_Pos) /*!< Bit mask of PSEL field. */
+#define LPCOMP_PSEL_PSEL_AnalogInput0 (0UL) /*!< AIN0 selected as analog input */
+#define LPCOMP_PSEL_PSEL_AnalogInput1 (1UL) /*!< AIN1 selected as analog input */
+#define LPCOMP_PSEL_PSEL_AnalogInput2 (2UL) /*!< AIN2 selected as analog input */
+#define LPCOMP_PSEL_PSEL_AnalogInput3 (3UL) /*!< AIN3 selected as analog input */
+#define LPCOMP_PSEL_PSEL_AnalogInput4 (4UL) /*!< AIN4 selected as analog input */
+#define LPCOMP_PSEL_PSEL_AnalogInput5 (5UL) /*!< AIN5 selected as analog input */
+#define LPCOMP_PSEL_PSEL_AnalogInput6 (6UL) /*!< AIN6 selected as analog input */
+#define LPCOMP_PSEL_PSEL_AnalogInput7 (7UL) /*!< AIN7 selected as analog input */
+
+/* Register: LPCOMP_REFSEL */
+/* Description: Reference select */
+
+/* Bits 3..0 : Reference select */
+#define LPCOMP_REFSEL_REFSEL_Pos (0UL) /*!< Position of REFSEL field. */
+#define LPCOMP_REFSEL_REFSEL_Msk (0xFUL << LPCOMP_REFSEL_REFSEL_Pos) /*!< Bit mask of REFSEL field. */
+#define LPCOMP_REFSEL_REFSEL_Ref1_8Vdd (0UL) /*!< VDD * 1/8 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref2_8Vdd (1UL) /*!< VDD * 2/8 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref3_8Vdd (2UL) /*!< VDD * 3/8 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref4_8Vdd (3UL) /*!< VDD * 4/8 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref5_8Vdd (4UL) /*!< VDD * 5/8 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref6_8Vdd (5UL) /*!< VDD * 6/8 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref7_8Vdd (6UL) /*!< VDD * 7/8 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_ARef (7UL) /*!< External analog reference selected */
+#define LPCOMP_REFSEL_REFSEL_Ref1_16Vdd (8UL) /*!< VDD * 1/16 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref3_16Vdd (9UL) /*!< VDD * 3/16 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref5_16Vdd (10UL) /*!< VDD * 5/16 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref7_16Vdd (11UL) /*!< VDD * 7/16 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref9_16Vdd (12UL) /*!< VDD * 9/16 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref11_16Vdd (13UL) /*!< VDD * 11/16 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref13_16Vdd (14UL) /*!< VDD * 13/16 selected as reference */
+#define LPCOMP_REFSEL_REFSEL_Ref15_16Vdd (15UL) /*!< VDD * 15/16 selected as reference */
+
+/* Register: LPCOMP_EXTREFSEL */
+/* Description: External reference select */
+
+/* Bit 0 : External analog reference select */
+#define LPCOMP_EXTREFSEL_EXTREFSEL_Pos (0UL) /*!< Position of EXTREFSEL field. */
+#define LPCOMP_EXTREFSEL_EXTREFSEL_Msk (0x1UL << LPCOMP_EXTREFSEL_EXTREFSEL_Pos) /*!< Bit mask of EXTREFSEL field. */
+#define LPCOMP_EXTREFSEL_EXTREFSEL_AnalogReference0 (0UL) /*!< Use AIN0 as external analog reference */
+#define LPCOMP_EXTREFSEL_EXTREFSEL_AnalogReference1 (1UL) /*!< Use AIN1 as external analog reference */
+
+/* Register: LPCOMP_ANADETECT */
+/* Description: Analog detect configuration */
+
+/* Bits 1..0 : Analog detect configuration */
+#define LPCOMP_ANADETECT_ANADETECT_Pos (0UL) /*!< Position of ANADETECT field. */
+#define LPCOMP_ANADETECT_ANADETECT_Msk (0x3UL << LPCOMP_ANADETECT_ANADETECT_Pos) /*!< Bit mask of ANADETECT field. */
+#define LPCOMP_ANADETECT_ANADETECT_Cross (0UL) /*!< Generate ANADETECT on crossing, both upward crossing and downward crossing */
+#define LPCOMP_ANADETECT_ANADETECT_Up (1UL) /*!< Generate ANADETECT on upward crossing only */
+#define LPCOMP_ANADETECT_ANADETECT_Down (2UL) /*!< Generate ANADETECT on downward crossing only */
+
+/* Register: LPCOMP_HYST */
+/* Description: Comparator hysteresis enable */
+
+/* Bit 0 : Comparator hysteresis enable */
+#define LPCOMP_HYST_HYST_Pos (0UL) /*!< Position of HYST field. */
+#define LPCOMP_HYST_HYST_Msk (0x1UL << LPCOMP_HYST_HYST_Pos) /*!< Bit mask of HYST field. */
+#define LPCOMP_HYST_HYST_NoHyst (0UL) /*!< Comparator hysteresis disabled */
+#define LPCOMP_HYST_HYST_Hyst50mV (1UL) /*!< Comparator hysteresis disabled (typ. 50 mV) */
+
+
+/* Peripheral: MWU */
+/* Description: Memory Watch Unit */
+
+/* Register: MWU_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 27 : Enable or disable interrupt for PREGION[1].RA event */
+#define MWU_INTEN_PREGION1RA_Pos (27UL) /*!< Position of PREGION1RA field. */
+#define MWU_INTEN_PREGION1RA_Msk (0x1UL << MWU_INTEN_PREGION1RA_Pos) /*!< Bit mask of PREGION1RA field. */
+#define MWU_INTEN_PREGION1RA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_PREGION1RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 26 : Enable or disable interrupt for PREGION[1].WA event */
+#define MWU_INTEN_PREGION1WA_Pos (26UL) /*!< Position of PREGION1WA field. */
+#define MWU_INTEN_PREGION1WA_Msk (0x1UL << MWU_INTEN_PREGION1WA_Pos) /*!< Bit mask of PREGION1WA field. */
+#define MWU_INTEN_PREGION1WA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_PREGION1WA_Enabled (1UL) /*!< Enable */
+
+/* Bit 25 : Enable or disable interrupt for PREGION[0].RA event */
+#define MWU_INTEN_PREGION0RA_Pos (25UL) /*!< Position of PREGION0RA field. */
+#define MWU_INTEN_PREGION0RA_Msk (0x1UL << MWU_INTEN_PREGION0RA_Pos) /*!< Bit mask of PREGION0RA field. */
+#define MWU_INTEN_PREGION0RA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_PREGION0RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 24 : Enable or disable interrupt for PREGION[0].WA event */
+#define MWU_INTEN_PREGION0WA_Pos (24UL) /*!< Position of PREGION0WA field. */
+#define MWU_INTEN_PREGION0WA_Msk (0x1UL << MWU_INTEN_PREGION0WA_Pos) /*!< Bit mask of PREGION0WA field. */
+#define MWU_INTEN_PREGION0WA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_PREGION0WA_Enabled (1UL) /*!< Enable */
+
+/* Bit 7 : Enable or disable interrupt for REGION[3].RA event */
+#define MWU_INTEN_REGION3RA_Pos (7UL) /*!< Position of REGION3RA field. */
+#define MWU_INTEN_REGION3RA_Msk (0x1UL << MWU_INTEN_REGION3RA_Pos) /*!< Bit mask of REGION3RA field. */
+#define MWU_INTEN_REGION3RA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_REGION3RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 6 : Enable or disable interrupt for REGION[3].WA event */
+#define MWU_INTEN_REGION3WA_Pos (6UL) /*!< Position of REGION3WA field. */
+#define MWU_INTEN_REGION3WA_Msk (0x1UL << MWU_INTEN_REGION3WA_Pos) /*!< Bit mask of REGION3WA field. */
+#define MWU_INTEN_REGION3WA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_REGION3WA_Enabled (1UL) /*!< Enable */
+
+/* Bit 5 : Enable or disable interrupt for REGION[2].RA event */
+#define MWU_INTEN_REGION2RA_Pos (5UL) /*!< Position of REGION2RA field. */
+#define MWU_INTEN_REGION2RA_Msk (0x1UL << MWU_INTEN_REGION2RA_Pos) /*!< Bit mask of REGION2RA field. */
+#define MWU_INTEN_REGION2RA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_REGION2RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 4 : Enable or disable interrupt for REGION[2].WA event */
+#define MWU_INTEN_REGION2WA_Pos (4UL) /*!< Position of REGION2WA field. */
+#define MWU_INTEN_REGION2WA_Msk (0x1UL << MWU_INTEN_REGION2WA_Pos) /*!< Bit mask of REGION2WA field. */
+#define MWU_INTEN_REGION2WA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_REGION2WA_Enabled (1UL) /*!< Enable */
+
+/* Bit 3 : Enable or disable interrupt for REGION[1].RA event */
+#define MWU_INTEN_REGION1RA_Pos (3UL) /*!< Position of REGION1RA field. */
+#define MWU_INTEN_REGION1RA_Msk (0x1UL << MWU_INTEN_REGION1RA_Pos) /*!< Bit mask of REGION1RA field. */
+#define MWU_INTEN_REGION1RA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_REGION1RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 2 : Enable or disable interrupt for REGION[1].WA event */
+#define MWU_INTEN_REGION1WA_Pos (2UL) /*!< Position of REGION1WA field. */
+#define MWU_INTEN_REGION1WA_Msk (0x1UL << MWU_INTEN_REGION1WA_Pos) /*!< Bit mask of REGION1WA field. */
+#define MWU_INTEN_REGION1WA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_REGION1WA_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for REGION[0].RA event */
+#define MWU_INTEN_REGION0RA_Pos (1UL) /*!< Position of REGION0RA field. */
+#define MWU_INTEN_REGION0RA_Msk (0x1UL << MWU_INTEN_REGION0RA_Pos) /*!< Bit mask of REGION0RA field. */
+#define MWU_INTEN_REGION0RA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_REGION0RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 0 : Enable or disable interrupt for REGION[0].WA event */
+#define MWU_INTEN_REGION0WA_Pos (0UL) /*!< Position of REGION0WA field. */
+#define MWU_INTEN_REGION0WA_Msk (0x1UL << MWU_INTEN_REGION0WA_Pos) /*!< Bit mask of REGION0WA field. */
+#define MWU_INTEN_REGION0WA_Disabled (0UL) /*!< Disable */
+#define MWU_INTEN_REGION0WA_Enabled (1UL) /*!< Enable */
+
+/* Register: MWU_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 27 : Write '1' to Enable interrupt for PREGION[1].RA event */
+#define MWU_INTENSET_PREGION1RA_Pos (27UL) /*!< Position of PREGION1RA field. */
+#define MWU_INTENSET_PREGION1RA_Msk (0x1UL << MWU_INTENSET_PREGION1RA_Pos) /*!< Bit mask of PREGION1RA field. */
+#define MWU_INTENSET_PREGION1RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_PREGION1RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_PREGION1RA_Set (1UL) /*!< Enable */
+
+/* Bit 26 : Write '1' to Enable interrupt for PREGION[1].WA event */
+#define MWU_INTENSET_PREGION1WA_Pos (26UL) /*!< Position of PREGION1WA field. */
+#define MWU_INTENSET_PREGION1WA_Msk (0x1UL << MWU_INTENSET_PREGION1WA_Pos) /*!< Bit mask of PREGION1WA field. */
+#define MWU_INTENSET_PREGION1WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_PREGION1WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_PREGION1WA_Set (1UL) /*!< Enable */
+
+/* Bit 25 : Write '1' to Enable interrupt for PREGION[0].RA event */
+#define MWU_INTENSET_PREGION0RA_Pos (25UL) /*!< Position of PREGION0RA field. */
+#define MWU_INTENSET_PREGION0RA_Msk (0x1UL << MWU_INTENSET_PREGION0RA_Pos) /*!< Bit mask of PREGION0RA field. */
+#define MWU_INTENSET_PREGION0RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_PREGION0RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_PREGION0RA_Set (1UL) /*!< Enable */
+
+/* Bit 24 : Write '1' to Enable interrupt for PREGION[0].WA event */
+#define MWU_INTENSET_PREGION0WA_Pos (24UL) /*!< Position of PREGION0WA field. */
+#define MWU_INTENSET_PREGION0WA_Msk (0x1UL << MWU_INTENSET_PREGION0WA_Pos) /*!< Bit mask of PREGION0WA field. */
+#define MWU_INTENSET_PREGION0WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_PREGION0WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_PREGION0WA_Set (1UL) /*!< Enable */
+
+/* Bit 7 : Write '1' to Enable interrupt for REGION[3].RA event */
+#define MWU_INTENSET_REGION3RA_Pos (7UL) /*!< Position of REGION3RA field. */
+#define MWU_INTENSET_REGION3RA_Msk (0x1UL << MWU_INTENSET_REGION3RA_Pos) /*!< Bit mask of REGION3RA field. */
+#define MWU_INTENSET_REGION3RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_REGION3RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_REGION3RA_Set (1UL) /*!< Enable */
+
+/* Bit 6 : Write '1' to Enable interrupt for REGION[3].WA event */
+#define MWU_INTENSET_REGION3WA_Pos (6UL) /*!< Position of REGION3WA field. */
+#define MWU_INTENSET_REGION3WA_Msk (0x1UL << MWU_INTENSET_REGION3WA_Pos) /*!< Bit mask of REGION3WA field. */
+#define MWU_INTENSET_REGION3WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_REGION3WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_REGION3WA_Set (1UL) /*!< Enable */
+
+/* Bit 5 : Write '1' to Enable interrupt for REGION[2].RA event */
+#define MWU_INTENSET_REGION2RA_Pos (5UL) /*!< Position of REGION2RA field. */
+#define MWU_INTENSET_REGION2RA_Msk (0x1UL << MWU_INTENSET_REGION2RA_Pos) /*!< Bit mask of REGION2RA field. */
+#define MWU_INTENSET_REGION2RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_REGION2RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_REGION2RA_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable interrupt for REGION[2].WA event */
+#define MWU_INTENSET_REGION2WA_Pos (4UL) /*!< Position of REGION2WA field. */
+#define MWU_INTENSET_REGION2WA_Msk (0x1UL << MWU_INTENSET_REGION2WA_Pos) /*!< Bit mask of REGION2WA field. */
+#define MWU_INTENSET_REGION2WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_REGION2WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_REGION2WA_Set (1UL) /*!< Enable */
+
+/* Bit 3 : Write '1' to Enable interrupt for REGION[1].RA event */
+#define MWU_INTENSET_REGION1RA_Pos (3UL) /*!< Position of REGION1RA field. */
+#define MWU_INTENSET_REGION1RA_Msk (0x1UL << MWU_INTENSET_REGION1RA_Pos) /*!< Bit mask of REGION1RA field. */
+#define MWU_INTENSET_REGION1RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_REGION1RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_REGION1RA_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for REGION[1].WA event */
+#define MWU_INTENSET_REGION1WA_Pos (2UL) /*!< Position of REGION1WA field. */
+#define MWU_INTENSET_REGION1WA_Msk (0x1UL << MWU_INTENSET_REGION1WA_Pos) /*!< Bit mask of REGION1WA field. */
+#define MWU_INTENSET_REGION1WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_REGION1WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_REGION1WA_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for REGION[0].RA event */
+#define MWU_INTENSET_REGION0RA_Pos (1UL) /*!< Position of REGION0RA field. */
+#define MWU_INTENSET_REGION0RA_Msk (0x1UL << MWU_INTENSET_REGION0RA_Pos) /*!< Bit mask of REGION0RA field. */
+#define MWU_INTENSET_REGION0RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_REGION0RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_REGION0RA_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for REGION[0].WA event */
+#define MWU_INTENSET_REGION0WA_Pos (0UL) /*!< Position of REGION0WA field. */
+#define MWU_INTENSET_REGION0WA_Msk (0x1UL << MWU_INTENSET_REGION0WA_Pos) /*!< Bit mask of REGION0WA field. */
+#define MWU_INTENSET_REGION0WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENSET_REGION0WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENSET_REGION0WA_Set (1UL) /*!< Enable */
+
+/* Register: MWU_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 27 : Write '1' to Disable interrupt for PREGION[1].RA event */
+#define MWU_INTENCLR_PREGION1RA_Pos (27UL) /*!< Position of PREGION1RA field. */
+#define MWU_INTENCLR_PREGION1RA_Msk (0x1UL << MWU_INTENCLR_PREGION1RA_Pos) /*!< Bit mask of PREGION1RA field. */
+#define MWU_INTENCLR_PREGION1RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_PREGION1RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_PREGION1RA_Clear (1UL) /*!< Disable */
+
+/* Bit 26 : Write '1' to Disable interrupt for PREGION[1].WA event */
+#define MWU_INTENCLR_PREGION1WA_Pos (26UL) /*!< Position of PREGION1WA field. */
+#define MWU_INTENCLR_PREGION1WA_Msk (0x1UL << MWU_INTENCLR_PREGION1WA_Pos) /*!< Bit mask of PREGION1WA field. */
+#define MWU_INTENCLR_PREGION1WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_PREGION1WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_PREGION1WA_Clear (1UL) /*!< Disable */
+
+/* Bit 25 : Write '1' to Disable interrupt for PREGION[0].RA event */
+#define MWU_INTENCLR_PREGION0RA_Pos (25UL) /*!< Position of PREGION0RA field. */
+#define MWU_INTENCLR_PREGION0RA_Msk (0x1UL << MWU_INTENCLR_PREGION0RA_Pos) /*!< Bit mask of PREGION0RA field. */
+#define MWU_INTENCLR_PREGION0RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_PREGION0RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_PREGION0RA_Clear (1UL) /*!< Disable */
+
+/* Bit 24 : Write '1' to Disable interrupt for PREGION[0].WA event */
+#define MWU_INTENCLR_PREGION0WA_Pos (24UL) /*!< Position of PREGION0WA field. */
+#define MWU_INTENCLR_PREGION0WA_Msk (0x1UL << MWU_INTENCLR_PREGION0WA_Pos) /*!< Bit mask of PREGION0WA field. */
+#define MWU_INTENCLR_PREGION0WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_PREGION0WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_PREGION0WA_Clear (1UL) /*!< Disable */
+
+/* Bit 7 : Write '1' to Disable interrupt for REGION[3].RA event */
+#define MWU_INTENCLR_REGION3RA_Pos (7UL) /*!< Position of REGION3RA field. */
+#define MWU_INTENCLR_REGION3RA_Msk (0x1UL << MWU_INTENCLR_REGION3RA_Pos) /*!< Bit mask of REGION3RA field. */
+#define MWU_INTENCLR_REGION3RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_REGION3RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_REGION3RA_Clear (1UL) /*!< Disable */
+
+/* Bit 6 : Write '1' to Disable interrupt for REGION[3].WA event */
+#define MWU_INTENCLR_REGION3WA_Pos (6UL) /*!< Position of REGION3WA field. */
+#define MWU_INTENCLR_REGION3WA_Msk (0x1UL << MWU_INTENCLR_REGION3WA_Pos) /*!< Bit mask of REGION3WA field. */
+#define MWU_INTENCLR_REGION3WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_REGION3WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_REGION3WA_Clear (1UL) /*!< Disable */
+
+/* Bit 5 : Write '1' to Disable interrupt for REGION[2].RA event */
+#define MWU_INTENCLR_REGION2RA_Pos (5UL) /*!< Position of REGION2RA field. */
+#define MWU_INTENCLR_REGION2RA_Msk (0x1UL << MWU_INTENCLR_REGION2RA_Pos) /*!< Bit mask of REGION2RA field. */
+#define MWU_INTENCLR_REGION2RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_REGION2RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_REGION2RA_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable interrupt for REGION[2].WA event */
+#define MWU_INTENCLR_REGION2WA_Pos (4UL) /*!< Position of REGION2WA field. */
+#define MWU_INTENCLR_REGION2WA_Msk (0x1UL << MWU_INTENCLR_REGION2WA_Pos) /*!< Bit mask of REGION2WA field. */
+#define MWU_INTENCLR_REGION2WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_REGION2WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_REGION2WA_Clear (1UL) /*!< Disable */
+
+/* Bit 3 : Write '1' to Disable interrupt for REGION[1].RA event */
+#define MWU_INTENCLR_REGION1RA_Pos (3UL) /*!< Position of REGION1RA field. */
+#define MWU_INTENCLR_REGION1RA_Msk (0x1UL << MWU_INTENCLR_REGION1RA_Pos) /*!< Bit mask of REGION1RA field. */
+#define MWU_INTENCLR_REGION1RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_REGION1RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_REGION1RA_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for REGION[1].WA event */
+#define MWU_INTENCLR_REGION1WA_Pos (2UL) /*!< Position of REGION1WA field. */
+#define MWU_INTENCLR_REGION1WA_Msk (0x1UL << MWU_INTENCLR_REGION1WA_Pos) /*!< Bit mask of REGION1WA field. */
+#define MWU_INTENCLR_REGION1WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_REGION1WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_REGION1WA_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for REGION[0].RA event */
+#define MWU_INTENCLR_REGION0RA_Pos (1UL) /*!< Position of REGION0RA field. */
+#define MWU_INTENCLR_REGION0RA_Msk (0x1UL << MWU_INTENCLR_REGION0RA_Pos) /*!< Bit mask of REGION0RA field. */
+#define MWU_INTENCLR_REGION0RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_REGION0RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_REGION0RA_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for REGION[0].WA event */
+#define MWU_INTENCLR_REGION0WA_Pos (0UL) /*!< Position of REGION0WA field. */
+#define MWU_INTENCLR_REGION0WA_Msk (0x1UL << MWU_INTENCLR_REGION0WA_Pos) /*!< Bit mask of REGION0WA field. */
+#define MWU_INTENCLR_REGION0WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_INTENCLR_REGION0WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_INTENCLR_REGION0WA_Clear (1UL) /*!< Disable */
+
+/* Register: MWU_NMIEN */
+/* Description: Enable or disable non-maskable interrupt */
+
+/* Bit 27 : Enable or disable non-maskable interrupt for PREGION[1].RA event */
+#define MWU_NMIEN_PREGION1RA_Pos (27UL) /*!< Position of PREGION1RA field. */
+#define MWU_NMIEN_PREGION1RA_Msk (0x1UL << MWU_NMIEN_PREGION1RA_Pos) /*!< Bit mask of PREGION1RA field. */
+#define MWU_NMIEN_PREGION1RA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_PREGION1RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 26 : Enable or disable non-maskable interrupt for PREGION[1].WA event */
+#define MWU_NMIEN_PREGION1WA_Pos (26UL) /*!< Position of PREGION1WA field. */
+#define MWU_NMIEN_PREGION1WA_Msk (0x1UL << MWU_NMIEN_PREGION1WA_Pos) /*!< Bit mask of PREGION1WA field. */
+#define MWU_NMIEN_PREGION1WA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_PREGION1WA_Enabled (1UL) /*!< Enable */
+
+/* Bit 25 : Enable or disable non-maskable interrupt for PREGION[0].RA event */
+#define MWU_NMIEN_PREGION0RA_Pos (25UL) /*!< Position of PREGION0RA field. */
+#define MWU_NMIEN_PREGION0RA_Msk (0x1UL << MWU_NMIEN_PREGION0RA_Pos) /*!< Bit mask of PREGION0RA field. */
+#define MWU_NMIEN_PREGION0RA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_PREGION0RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 24 : Enable or disable non-maskable interrupt for PREGION[0].WA event */
+#define MWU_NMIEN_PREGION0WA_Pos (24UL) /*!< Position of PREGION0WA field. */
+#define MWU_NMIEN_PREGION0WA_Msk (0x1UL << MWU_NMIEN_PREGION0WA_Pos) /*!< Bit mask of PREGION0WA field. */
+#define MWU_NMIEN_PREGION0WA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_PREGION0WA_Enabled (1UL) /*!< Enable */
+
+/* Bit 7 : Enable or disable non-maskable interrupt for REGION[3].RA event */
+#define MWU_NMIEN_REGION3RA_Pos (7UL) /*!< Position of REGION3RA field. */
+#define MWU_NMIEN_REGION3RA_Msk (0x1UL << MWU_NMIEN_REGION3RA_Pos) /*!< Bit mask of REGION3RA field. */
+#define MWU_NMIEN_REGION3RA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_REGION3RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 6 : Enable or disable non-maskable interrupt for REGION[3].WA event */
+#define MWU_NMIEN_REGION3WA_Pos (6UL) /*!< Position of REGION3WA field. */
+#define MWU_NMIEN_REGION3WA_Msk (0x1UL << MWU_NMIEN_REGION3WA_Pos) /*!< Bit mask of REGION3WA field. */
+#define MWU_NMIEN_REGION3WA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_REGION3WA_Enabled (1UL) /*!< Enable */
+
+/* Bit 5 : Enable or disable non-maskable interrupt for REGION[2].RA event */
+#define MWU_NMIEN_REGION2RA_Pos (5UL) /*!< Position of REGION2RA field. */
+#define MWU_NMIEN_REGION2RA_Msk (0x1UL << MWU_NMIEN_REGION2RA_Pos) /*!< Bit mask of REGION2RA field. */
+#define MWU_NMIEN_REGION2RA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_REGION2RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 4 : Enable or disable non-maskable interrupt for REGION[2].WA event */
+#define MWU_NMIEN_REGION2WA_Pos (4UL) /*!< Position of REGION2WA field. */
+#define MWU_NMIEN_REGION2WA_Msk (0x1UL << MWU_NMIEN_REGION2WA_Pos) /*!< Bit mask of REGION2WA field. */
+#define MWU_NMIEN_REGION2WA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_REGION2WA_Enabled (1UL) /*!< Enable */
+
+/* Bit 3 : Enable or disable non-maskable interrupt for REGION[1].RA event */
+#define MWU_NMIEN_REGION1RA_Pos (3UL) /*!< Position of REGION1RA field. */
+#define MWU_NMIEN_REGION1RA_Msk (0x1UL << MWU_NMIEN_REGION1RA_Pos) /*!< Bit mask of REGION1RA field. */
+#define MWU_NMIEN_REGION1RA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_REGION1RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 2 : Enable or disable non-maskable interrupt for REGION[1].WA event */
+#define MWU_NMIEN_REGION1WA_Pos (2UL) /*!< Position of REGION1WA field. */
+#define MWU_NMIEN_REGION1WA_Msk (0x1UL << MWU_NMIEN_REGION1WA_Pos) /*!< Bit mask of REGION1WA field. */
+#define MWU_NMIEN_REGION1WA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_REGION1WA_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable non-maskable interrupt for REGION[0].RA event */
+#define MWU_NMIEN_REGION0RA_Pos (1UL) /*!< Position of REGION0RA field. */
+#define MWU_NMIEN_REGION0RA_Msk (0x1UL << MWU_NMIEN_REGION0RA_Pos) /*!< Bit mask of REGION0RA field. */
+#define MWU_NMIEN_REGION0RA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_REGION0RA_Enabled (1UL) /*!< Enable */
+
+/* Bit 0 : Enable or disable non-maskable interrupt for REGION[0].WA event */
+#define MWU_NMIEN_REGION0WA_Pos (0UL) /*!< Position of REGION0WA field. */
+#define MWU_NMIEN_REGION0WA_Msk (0x1UL << MWU_NMIEN_REGION0WA_Pos) /*!< Bit mask of REGION0WA field. */
+#define MWU_NMIEN_REGION0WA_Disabled (0UL) /*!< Disable */
+#define MWU_NMIEN_REGION0WA_Enabled (1UL) /*!< Enable */
+
+/* Register: MWU_NMIENSET */
+/* Description: Enable non-maskable interrupt */
+
+/* Bit 27 : Write '1' to Enable non-maskable interrupt for PREGION[1].RA event */
+#define MWU_NMIENSET_PREGION1RA_Pos (27UL) /*!< Position of PREGION1RA field. */
+#define MWU_NMIENSET_PREGION1RA_Msk (0x1UL << MWU_NMIENSET_PREGION1RA_Pos) /*!< Bit mask of PREGION1RA field. */
+#define MWU_NMIENSET_PREGION1RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_PREGION1RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_PREGION1RA_Set (1UL) /*!< Enable */
+
+/* Bit 26 : Write '1' to Enable non-maskable interrupt for PREGION[1].WA event */
+#define MWU_NMIENSET_PREGION1WA_Pos (26UL) /*!< Position of PREGION1WA field. */
+#define MWU_NMIENSET_PREGION1WA_Msk (0x1UL << MWU_NMIENSET_PREGION1WA_Pos) /*!< Bit mask of PREGION1WA field. */
+#define MWU_NMIENSET_PREGION1WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_PREGION1WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_PREGION1WA_Set (1UL) /*!< Enable */
+
+/* Bit 25 : Write '1' to Enable non-maskable interrupt for PREGION[0].RA event */
+#define MWU_NMIENSET_PREGION0RA_Pos (25UL) /*!< Position of PREGION0RA field. */
+#define MWU_NMIENSET_PREGION0RA_Msk (0x1UL << MWU_NMIENSET_PREGION0RA_Pos) /*!< Bit mask of PREGION0RA field. */
+#define MWU_NMIENSET_PREGION0RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_PREGION0RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_PREGION0RA_Set (1UL) /*!< Enable */
+
+/* Bit 24 : Write '1' to Enable non-maskable interrupt for PREGION[0].WA event */
+#define MWU_NMIENSET_PREGION0WA_Pos (24UL) /*!< Position of PREGION0WA field. */
+#define MWU_NMIENSET_PREGION0WA_Msk (0x1UL << MWU_NMIENSET_PREGION0WA_Pos) /*!< Bit mask of PREGION0WA field. */
+#define MWU_NMIENSET_PREGION0WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_PREGION0WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_PREGION0WA_Set (1UL) /*!< Enable */
+
+/* Bit 7 : Write '1' to Enable non-maskable interrupt for REGION[3].RA event */
+#define MWU_NMIENSET_REGION3RA_Pos (7UL) /*!< Position of REGION3RA field. */
+#define MWU_NMIENSET_REGION3RA_Msk (0x1UL << MWU_NMIENSET_REGION3RA_Pos) /*!< Bit mask of REGION3RA field. */
+#define MWU_NMIENSET_REGION3RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_REGION3RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_REGION3RA_Set (1UL) /*!< Enable */
+
+/* Bit 6 : Write '1' to Enable non-maskable interrupt for REGION[3].WA event */
+#define MWU_NMIENSET_REGION3WA_Pos (6UL) /*!< Position of REGION3WA field. */
+#define MWU_NMIENSET_REGION3WA_Msk (0x1UL << MWU_NMIENSET_REGION3WA_Pos) /*!< Bit mask of REGION3WA field. */
+#define MWU_NMIENSET_REGION3WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_REGION3WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_REGION3WA_Set (1UL) /*!< Enable */
+
+/* Bit 5 : Write '1' to Enable non-maskable interrupt for REGION[2].RA event */
+#define MWU_NMIENSET_REGION2RA_Pos (5UL) /*!< Position of REGION2RA field. */
+#define MWU_NMIENSET_REGION2RA_Msk (0x1UL << MWU_NMIENSET_REGION2RA_Pos) /*!< Bit mask of REGION2RA field. */
+#define MWU_NMIENSET_REGION2RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_REGION2RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_REGION2RA_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable non-maskable interrupt for REGION[2].WA event */
+#define MWU_NMIENSET_REGION2WA_Pos (4UL) /*!< Position of REGION2WA field. */
+#define MWU_NMIENSET_REGION2WA_Msk (0x1UL << MWU_NMIENSET_REGION2WA_Pos) /*!< Bit mask of REGION2WA field. */
+#define MWU_NMIENSET_REGION2WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_REGION2WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_REGION2WA_Set (1UL) /*!< Enable */
+
+/* Bit 3 : Write '1' to Enable non-maskable interrupt for REGION[1].RA event */
+#define MWU_NMIENSET_REGION1RA_Pos (3UL) /*!< Position of REGION1RA field. */
+#define MWU_NMIENSET_REGION1RA_Msk (0x1UL << MWU_NMIENSET_REGION1RA_Pos) /*!< Bit mask of REGION1RA field. */
+#define MWU_NMIENSET_REGION1RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_REGION1RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_REGION1RA_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable non-maskable interrupt for REGION[1].WA event */
+#define MWU_NMIENSET_REGION1WA_Pos (2UL) /*!< Position of REGION1WA field. */
+#define MWU_NMIENSET_REGION1WA_Msk (0x1UL << MWU_NMIENSET_REGION1WA_Pos) /*!< Bit mask of REGION1WA field. */
+#define MWU_NMIENSET_REGION1WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_REGION1WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_REGION1WA_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable non-maskable interrupt for REGION[0].RA event */
+#define MWU_NMIENSET_REGION0RA_Pos (1UL) /*!< Position of REGION0RA field. */
+#define MWU_NMIENSET_REGION0RA_Msk (0x1UL << MWU_NMIENSET_REGION0RA_Pos) /*!< Bit mask of REGION0RA field. */
+#define MWU_NMIENSET_REGION0RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_REGION0RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_REGION0RA_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable non-maskable interrupt for REGION[0].WA event */
+#define MWU_NMIENSET_REGION0WA_Pos (0UL) /*!< Position of REGION0WA field. */
+#define MWU_NMIENSET_REGION0WA_Msk (0x1UL << MWU_NMIENSET_REGION0WA_Pos) /*!< Bit mask of REGION0WA field. */
+#define MWU_NMIENSET_REGION0WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENSET_REGION0WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENSET_REGION0WA_Set (1UL) /*!< Enable */
+
+/* Register: MWU_NMIENCLR */
+/* Description: Disable non-maskable interrupt */
+
+/* Bit 27 : Write '1' to Disable non-maskable interrupt for PREGION[1].RA event */
+#define MWU_NMIENCLR_PREGION1RA_Pos (27UL) /*!< Position of PREGION1RA field. */
+#define MWU_NMIENCLR_PREGION1RA_Msk (0x1UL << MWU_NMIENCLR_PREGION1RA_Pos) /*!< Bit mask of PREGION1RA field. */
+#define MWU_NMIENCLR_PREGION1RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_PREGION1RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_PREGION1RA_Clear (1UL) /*!< Disable */
+
+/* Bit 26 : Write '1' to Disable non-maskable interrupt for PREGION[1].WA event */
+#define MWU_NMIENCLR_PREGION1WA_Pos (26UL) /*!< Position of PREGION1WA field. */
+#define MWU_NMIENCLR_PREGION1WA_Msk (0x1UL << MWU_NMIENCLR_PREGION1WA_Pos) /*!< Bit mask of PREGION1WA field. */
+#define MWU_NMIENCLR_PREGION1WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_PREGION1WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_PREGION1WA_Clear (1UL) /*!< Disable */
+
+/* Bit 25 : Write '1' to Disable non-maskable interrupt for PREGION[0].RA event */
+#define MWU_NMIENCLR_PREGION0RA_Pos (25UL) /*!< Position of PREGION0RA field. */
+#define MWU_NMIENCLR_PREGION0RA_Msk (0x1UL << MWU_NMIENCLR_PREGION0RA_Pos) /*!< Bit mask of PREGION0RA field. */
+#define MWU_NMIENCLR_PREGION0RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_PREGION0RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_PREGION0RA_Clear (1UL) /*!< Disable */
+
+/* Bit 24 : Write '1' to Disable non-maskable interrupt for PREGION[0].WA event */
+#define MWU_NMIENCLR_PREGION0WA_Pos (24UL) /*!< Position of PREGION0WA field. */
+#define MWU_NMIENCLR_PREGION0WA_Msk (0x1UL << MWU_NMIENCLR_PREGION0WA_Pos) /*!< Bit mask of PREGION0WA field. */
+#define MWU_NMIENCLR_PREGION0WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_PREGION0WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_PREGION0WA_Clear (1UL) /*!< Disable */
+
+/* Bit 7 : Write '1' to Disable non-maskable interrupt for REGION[3].RA event */
+#define MWU_NMIENCLR_REGION3RA_Pos (7UL) /*!< Position of REGION3RA field. */
+#define MWU_NMIENCLR_REGION3RA_Msk (0x1UL << MWU_NMIENCLR_REGION3RA_Pos) /*!< Bit mask of REGION3RA field. */
+#define MWU_NMIENCLR_REGION3RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_REGION3RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_REGION3RA_Clear (1UL) /*!< Disable */
+
+/* Bit 6 : Write '1' to Disable non-maskable interrupt for REGION[3].WA event */
+#define MWU_NMIENCLR_REGION3WA_Pos (6UL) /*!< Position of REGION3WA field. */
+#define MWU_NMIENCLR_REGION3WA_Msk (0x1UL << MWU_NMIENCLR_REGION3WA_Pos) /*!< Bit mask of REGION3WA field. */
+#define MWU_NMIENCLR_REGION3WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_REGION3WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_REGION3WA_Clear (1UL) /*!< Disable */
+
+/* Bit 5 : Write '1' to Disable non-maskable interrupt for REGION[2].RA event */
+#define MWU_NMIENCLR_REGION2RA_Pos (5UL) /*!< Position of REGION2RA field. */
+#define MWU_NMIENCLR_REGION2RA_Msk (0x1UL << MWU_NMIENCLR_REGION2RA_Pos) /*!< Bit mask of REGION2RA field. */
+#define MWU_NMIENCLR_REGION2RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_REGION2RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_REGION2RA_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable non-maskable interrupt for REGION[2].WA event */
+#define MWU_NMIENCLR_REGION2WA_Pos (4UL) /*!< Position of REGION2WA field. */
+#define MWU_NMIENCLR_REGION2WA_Msk (0x1UL << MWU_NMIENCLR_REGION2WA_Pos) /*!< Bit mask of REGION2WA field. */
+#define MWU_NMIENCLR_REGION2WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_REGION2WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_REGION2WA_Clear (1UL) /*!< Disable */
+
+/* Bit 3 : Write '1' to Disable non-maskable interrupt for REGION[1].RA event */
+#define MWU_NMIENCLR_REGION1RA_Pos (3UL) /*!< Position of REGION1RA field. */
+#define MWU_NMIENCLR_REGION1RA_Msk (0x1UL << MWU_NMIENCLR_REGION1RA_Pos) /*!< Bit mask of REGION1RA field. */
+#define MWU_NMIENCLR_REGION1RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_REGION1RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_REGION1RA_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable non-maskable interrupt for REGION[1].WA event */
+#define MWU_NMIENCLR_REGION1WA_Pos (2UL) /*!< Position of REGION1WA field. */
+#define MWU_NMIENCLR_REGION1WA_Msk (0x1UL << MWU_NMIENCLR_REGION1WA_Pos) /*!< Bit mask of REGION1WA field. */
+#define MWU_NMIENCLR_REGION1WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_REGION1WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_REGION1WA_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable non-maskable interrupt for REGION[0].RA event */
+#define MWU_NMIENCLR_REGION0RA_Pos (1UL) /*!< Position of REGION0RA field. */
+#define MWU_NMIENCLR_REGION0RA_Msk (0x1UL << MWU_NMIENCLR_REGION0RA_Pos) /*!< Bit mask of REGION0RA field. */
+#define MWU_NMIENCLR_REGION0RA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_REGION0RA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_REGION0RA_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable non-maskable interrupt for REGION[0].WA event */
+#define MWU_NMIENCLR_REGION0WA_Pos (0UL) /*!< Position of REGION0WA field. */
+#define MWU_NMIENCLR_REGION0WA_Msk (0x1UL << MWU_NMIENCLR_REGION0WA_Pos) /*!< Bit mask of REGION0WA field. */
+#define MWU_NMIENCLR_REGION0WA_Disabled (0UL) /*!< Read: Disabled */
+#define MWU_NMIENCLR_REGION0WA_Enabled (1UL) /*!< Read: Enabled */
+#define MWU_NMIENCLR_REGION0WA_Clear (1UL) /*!< Disable */
+
+/* Register: MWU_PERREGION_SUBSTATWA */
+/* Description: Description cluster[0]:  Source of event/interrupt in region 0, write access detected while corresponding subregion was enabled for watching */
+
+/* Bit 31 : Subregion 31 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR31_Pos (31UL) /*!< Position of SR31 field. */
+#define MWU_PERREGION_SUBSTATWA_SR31_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR31_Pos) /*!< Bit mask of SR31 field. */
+#define MWU_PERREGION_SUBSTATWA_SR31_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR31_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 30 : Subregion 30 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR30_Pos (30UL) /*!< Position of SR30 field. */
+#define MWU_PERREGION_SUBSTATWA_SR30_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR30_Pos) /*!< Bit mask of SR30 field. */
+#define MWU_PERREGION_SUBSTATWA_SR30_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR30_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 29 : Subregion 29 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR29_Pos (29UL) /*!< Position of SR29 field. */
+#define MWU_PERREGION_SUBSTATWA_SR29_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR29_Pos) /*!< Bit mask of SR29 field. */
+#define MWU_PERREGION_SUBSTATWA_SR29_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR29_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 28 : Subregion 28 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR28_Pos (28UL) /*!< Position of SR28 field. */
+#define MWU_PERREGION_SUBSTATWA_SR28_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR28_Pos) /*!< Bit mask of SR28 field. */
+#define MWU_PERREGION_SUBSTATWA_SR28_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR28_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 27 : Subregion 27 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR27_Pos (27UL) /*!< Position of SR27 field. */
+#define MWU_PERREGION_SUBSTATWA_SR27_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR27_Pos) /*!< Bit mask of SR27 field. */
+#define MWU_PERREGION_SUBSTATWA_SR27_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR27_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 26 : Subregion 26 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR26_Pos (26UL) /*!< Position of SR26 field. */
+#define MWU_PERREGION_SUBSTATWA_SR26_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR26_Pos) /*!< Bit mask of SR26 field. */
+#define MWU_PERREGION_SUBSTATWA_SR26_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR26_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 25 : Subregion 25 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR25_Pos (25UL) /*!< Position of SR25 field. */
+#define MWU_PERREGION_SUBSTATWA_SR25_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR25_Pos) /*!< Bit mask of SR25 field. */
+#define MWU_PERREGION_SUBSTATWA_SR25_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR25_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 24 : Subregion 24 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR24_Pos (24UL) /*!< Position of SR24 field. */
+#define MWU_PERREGION_SUBSTATWA_SR24_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR24_Pos) /*!< Bit mask of SR24 field. */
+#define MWU_PERREGION_SUBSTATWA_SR24_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR24_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 23 : Subregion 23 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR23_Pos (23UL) /*!< Position of SR23 field. */
+#define MWU_PERREGION_SUBSTATWA_SR23_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR23_Pos) /*!< Bit mask of SR23 field. */
+#define MWU_PERREGION_SUBSTATWA_SR23_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR23_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 22 : Subregion 22 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR22_Pos (22UL) /*!< Position of SR22 field. */
+#define MWU_PERREGION_SUBSTATWA_SR22_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR22_Pos) /*!< Bit mask of SR22 field. */
+#define MWU_PERREGION_SUBSTATWA_SR22_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR22_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 21 : Subregion 21 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR21_Pos (21UL) /*!< Position of SR21 field. */
+#define MWU_PERREGION_SUBSTATWA_SR21_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR21_Pos) /*!< Bit mask of SR21 field. */
+#define MWU_PERREGION_SUBSTATWA_SR21_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR21_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 20 : Subregion 20 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR20_Pos (20UL) /*!< Position of SR20 field. */
+#define MWU_PERREGION_SUBSTATWA_SR20_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR20_Pos) /*!< Bit mask of SR20 field. */
+#define MWU_PERREGION_SUBSTATWA_SR20_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR20_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 19 : Subregion 19 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR19_Pos (19UL) /*!< Position of SR19 field. */
+#define MWU_PERREGION_SUBSTATWA_SR19_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR19_Pos) /*!< Bit mask of SR19 field. */
+#define MWU_PERREGION_SUBSTATWA_SR19_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR19_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 18 : Subregion 18 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR18_Pos (18UL) /*!< Position of SR18 field. */
+#define MWU_PERREGION_SUBSTATWA_SR18_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR18_Pos) /*!< Bit mask of SR18 field. */
+#define MWU_PERREGION_SUBSTATWA_SR18_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR18_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 17 : Subregion 17 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR17_Pos (17UL) /*!< Position of SR17 field. */
+#define MWU_PERREGION_SUBSTATWA_SR17_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR17_Pos) /*!< Bit mask of SR17 field. */
+#define MWU_PERREGION_SUBSTATWA_SR17_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR17_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 16 : Subregion 16 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR16_Pos (16UL) /*!< Position of SR16 field. */
+#define MWU_PERREGION_SUBSTATWA_SR16_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR16_Pos) /*!< Bit mask of SR16 field. */
+#define MWU_PERREGION_SUBSTATWA_SR16_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR16_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 15 : Subregion 15 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR15_Pos (15UL) /*!< Position of SR15 field. */
+#define MWU_PERREGION_SUBSTATWA_SR15_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR15_Pos) /*!< Bit mask of SR15 field. */
+#define MWU_PERREGION_SUBSTATWA_SR15_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR15_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 14 : Subregion 14 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR14_Pos (14UL) /*!< Position of SR14 field. */
+#define MWU_PERREGION_SUBSTATWA_SR14_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR14_Pos) /*!< Bit mask of SR14 field. */
+#define MWU_PERREGION_SUBSTATWA_SR14_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR14_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 13 : Subregion 13 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR13_Pos (13UL) /*!< Position of SR13 field. */
+#define MWU_PERREGION_SUBSTATWA_SR13_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR13_Pos) /*!< Bit mask of SR13 field. */
+#define MWU_PERREGION_SUBSTATWA_SR13_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR13_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 12 : Subregion 12 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR12_Pos (12UL) /*!< Position of SR12 field. */
+#define MWU_PERREGION_SUBSTATWA_SR12_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR12_Pos) /*!< Bit mask of SR12 field. */
+#define MWU_PERREGION_SUBSTATWA_SR12_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR12_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 11 : Subregion 11 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR11_Pos (11UL) /*!< Position of SR11 field. */
+#define MWU_PERREGION_SUBSTATWA_SR11_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR11_Pos) /*!< Bit mask of SR11 field. */
+#define MWU_PERREGION_SUBSTATWA_SR11_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR11_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 10 : Subregion 10 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR10_Pos (10UL) /*!< Position of SR10 field. */
+#define MWU_PERREGION_SUBSTATWA_SR10_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR10_Pos) /*!< Bit mask of SR10 field. */
+#define MWU_PERREGION_SUBSTATWA_SR10_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR10_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 9 : Subregion 9 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR9_Pos (9UL) /*!< Position of SR9 field. */
+#define MWU_PERREGION_SUBSTATWA_SR9_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR9_Pos) /*!< Bit mask of SR9 field. */
+#define MWU_PERREGION_SUBSTATWA_SR9_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR9_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 8 : Subregion 8 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR8_Pos (8UL) /*!< Position of SR8 field. */
+#define MWU_PERREGION_SUBSTATWA_SR8_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR8_Pos) /*!< Bit mask of SR8 field. */
+#define MWU_PERREGION_SUBSTATWA_SR8_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR8_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 7 : Subregion 7 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR7_Pos (7UL) /*!< Position of SR7 field. */
+#define MWU_PERREGION_SUBSTATWA_SR7_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR7_Pos) /*!< Bit mask of SR7 field. */
+#define MWU_PERREGION_SUBSTATWA_SR7_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR7_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 6 : Subregion 6 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR6_Pos (6UL) /*!< Position of SR6 field. */
+#define MWU_PERREGION_SUBSTATWA_SR6_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR6_Pos) /*!< Bit mask of SR6 field. */
+#define MWU_PERREGION_SUBSTATWA_SR6_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR6_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 5 : Subregion 5 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR5_Pos (5UL) /*!< Position of SR5 field. */
+#define MWU_PERREGION_SUBSTATWA_SR5_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR5_Pos) /*!< Bit mask of SR5 field. */
+#define MWU_PERREGION_SUBSTATWA_SR5_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR5_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 4 : Subregion 4 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR4_Pos (4UL) /*!< Position of SR4 field. */
+#define MWU_PERREGION_SUBSTATWA_SR4_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR4_Pos) /*!< Bit mask of SR4 field. */
+#define MWU_PERREGION_SUBSTATWA_SR4_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR4_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 3 : Subregion 3 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR3_Pos (3UL) /*!< Position of SR3 field. */
+#define MWU_PERREGION_SUBSTATWA_SR3_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR3_Pos) /*!< Bit mask of SR3 field. */
+#define MWU_PERREGION_SUBSTATWA_SR3_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR3_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 2 : Subregion 2 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR2_Pos (2UL) /*!< Position of SR2 field. */
+#define MWU_PERREGION_SUBSTATWA_SR2_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR2_Pos) /*!< Bit mask of SR2 field. */
+#define MWU_PERREGION_SUBSTATWA_SR2_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR2_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 1 : Subregion 1 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR1_Pos (1UL) /*!< Position of SR1 field. */
+#define MWU_PERREGION_SUBSTATWA_SR1_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR1_Pos) /*!< Bit mask of SR1 field. */
+#define MWU_PERREGION_SUBSTATWA_SR1_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR1_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Bit 0 : Subregion 0 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATWA_SR0_Pos (0UL) /*!< Position of SR0 field. */
+#define MWU_PERREGION_SUBSTATWA_SR0_Msk (0x1UL << MWU_PERREGION_SUBSTATWA_SR0_Pos) /*!< Bit mask of SR0 field. */
+#define MWU_PERREGION_SUBSTATWA_SR0_NoAccess (0UL) /*!< No write access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATWA_SR0_Access (1UL) /*!< Write access(es) occurred in this subregion */
+
+/* Register: MWU_PERREGION_SUBSTATRA */
+/* Description: Description cluster[0]:  Source of event/interrupt in region 0, read access detected while corresponding subregion was enabled for watching */
+
+/* Bit 31 : Subregion 31 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR31_Pos (31UL) /*!< Position of SR31 field. */
+#define MWU_PERREGION_SUBSTATRA_SR31_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR31_Pos) /*!< Bit mask of SR31 field. */
+#define MWU_PERREGION_SUBSTATRA_SR31_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR31_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 30 : Subregion 30 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR30_Pos (30UL) /*!< Position of SR30 field. */
+#define MWU_PERREGION_SUBSTATRA_SR30_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR30_Pos) /*!< Bit mask of SR30 field. */
+#define MWU_PERREGION_SUBSTATRA_SR30_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR30_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 29 : Subregion 29 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR29_Pos (29UL) /*!< Position of SR29 field. */
+#define MWU_PERREGION_SUBSTATRA_SR29_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR29_Pos) /*!< Bit mask of SR29 field. */
+#define MWU_PERREGION_SUBSTATRA_SR29_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR29_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 28 : Subregion 28 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR28_Pos (28UL) /*!< Position of SR28 field. */
+#define MWU_PERREGION_SUBSTATRA_SR28_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR28_Pos) /*!< Bit mask of SR28 field. */
+#define MWU_PERREGION_SUBSTATRA_SR28_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR28_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 27 : Subregion 27 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR27_Pos (27UL) /*!< Position of SR27 field. */
+#define MWU_PERREGION_SUBSTATRA_SR27_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR27_Pos) /*!< Bit mask of SR27 field. */
+#define MWU_PERREGION_SUBSTATRA_SR27_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR27_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 26 : Subregion 26 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR26_Pos (26UL) /*!< Position of SR26 field. */
+#define MWU_PERREGION_SUBSTATRA_SR26_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR26_Pos) /*!< Bit mask of SR26 field. */
+#define MWU_PERREGION_SUBSTATRA_SR26_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR26_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 25 : Subregion 25 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR25_Pos (25UL) /*!< Position of SR25 field. */
+#define MWU_PERREGION_SUBSTATRA_SR25_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR25_Pos) /*!< Bit mask of SR25 field. */
+#define MWU_PERREGION_SUBSTATRA_SR25_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR25_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 24 : Subregion 24 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR24_Pos (24UL) /*!< Position of SR24 field. */
+#define MWU_PERREGION_SUBSTATRA_SR24_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR24_Pos) /*!< Bit mask of SR24 field. */
+#define MWU_PERREGION_SUBSTATRA_SR24_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR24_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 23 : Subregion 23 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR23_Pos (23UL) /*!< Position of SR23 field. */
+#define MWU_PERREGION_SUBSTATRA_SR23_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR23_Pos) /*!< Bit mask of SR23 field. */
+#define MWU_PERREGION_SUBSTATRA_SR23_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR23_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 22 : Subregion 22 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR22_Pos (22UL) /*!< Position of SR22 field. */
+#define MWU_PERREGION_SUBSTATRA_SR22_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR22_Pos) /*!< Bit mask of SR22 field. */
+#define MWU_PERREGION_SUBSTATRA_SR22_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR22_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 21 : Subregion 21 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR21_Pos (21UL) /*!< Position of SR21 field. */
+#define MWU_PERREGION_SUBSTATRA_SR21_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR21_Pos) /*!< Bit mask of SR21 field. */
+#define MWU_PERREGION_SUBSTATRA_SR21_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR21_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 20 : Subregion 20 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR20_Pos (20UL) /*!< Position of SR20 field. */
+#define MWU_PERREGION_SUBSTATRA_SR20_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR20_Pos) /*!< Bit mask of SR20 field. */
+#define MWU_PERREGION_SUBSTATRA_SR20_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR20_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 19 : Subregion 19 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR19_Pos (19UL) /*!< Position of SR19 field. */
+#define MWU_PERREGION_SUBSTATRA_SR19_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR19_Pos) /*!< Bit mask of SR19 field. */
+#define MWU_PERREGION_SUBSTATRA_SR19_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR19_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 18 : Subregion 18 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR18_Pos (18UL) /*!< Position of SR18 field. */
+#define MWU_PERREGION_SUBSTATRA_SR18_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR18_Pos) /*!< Bit mask of SR18 field. */
+#define MWU_PERREGION_SUBSTATRA_SR18_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR18_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 17 : Subregion 17 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR17_Pos (17UL) /*!< Position of SR17 field. */
+#define MWU_PERREGION_SUBSTATRA_SR17_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR17_Pos) /*!< Bit mask of SR17 field. */
+#define MWU_PERREGION_SUBSTATRA_SR17_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR17_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 16 : Subregion 16 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR16_Pos (16UL) /*!< Position of SR16 field. */
+#define MWU_PERREGION_SUBSTATRA_SR16_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR16_Pos) /*!< Bit mask of SR16 field. */
+#define MWU_PERREGION_SUBSTATRA_SR16_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR16_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 15 : Subregion 15 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR15_Pos (15UL) /*!< Position of SR15 field. */
+#define MWU_PERREGION_SUBSTATRA_SR15_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR15_Pos) /*!< Bit mask of SR15 field. */
+#define MWU_PERREGION_SUBSTATRA_SR15_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR15_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 14 : Subregion 14 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR14_Pos (14UL) /*!< Position of SR14 field. */
+#define MWU_PERREGION_SUBSTATRA_SR14_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR14_Pos) /*!< Bit mask of SR14 field. */
+#define MWU_PERREGION_SUBSTATRA_SR14_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR14_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 13 : Subregion 13 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR13_Pos (13UL) /*!< Position of SR13 field. */
+#define MWU_PERREGION_SUBSTATRA_SR13_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR13_Pos) /*!< Bit mask of SR13 field. */
+#define MWU_PERREGION_SUBSTATRA_SR13_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR13_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 12 : Subregion 12 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR12_Pos (12UL) /*!< Position of SR12 field. */
+#define MWU_PERREGION_SUBSTATRA_SR12_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR12_Pos) /*!< Bit mask of SR12 field. */
+#define MWU_PERREGION_SUBSTATRA_SR12_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR12_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 11 : Subregion 11 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR11_Pos (11UL) /*!< Position of SR11 field. */
+#define MWU_PERREGION_SUBSTATRA_SR11_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR11_Pos) /*!< Bit mask of SR11 field. */
+#define MWU_PERREGION_SUBSTATRA_SR11_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR11_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 10 : Subregion 10 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR10_Pos (10UL) /*!< Position of SR10 field. */
+#define MWU_PERREGION_SUBSTATRA_SR10_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR10_Pos) /*!< Bit mask of SR10 field. */
+#define MWU_PERREGION_SUBSTATRA_SR10_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR10_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 9 : Subregion 9 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR9_Pos (9UL) /*!< Position of SR9 field. */
+#define MWU_PERREGION_SUBSTATRA_SR9_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR9_Pos) /*!< Bit mask of SR9 field. */
+#define MWU_PERREGION_SUBSTATRA_SR9_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR9_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 8 : Subregion 8 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR8_Pos (8UL) /*!< Position of SR8 field. */
+#define MWU_PERREGION_SUBSTATRA_SR8_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR8_Pos) /*!< Bit mask of SR8 field. */
+#define MWU_PERREGION_SUBSTATRA_SR8_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR8_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 7 : Subregion 7 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR7_Pos (7UL) /*!< Position of SR7 field. */
+#define MWU_PERREGION_SUBSTATRA_SR7_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR7_Pos) /*!< Bit mask of SR7 field. */
+#define MWU_PERREGION_SUBSTATRA_SR7_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR7_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 6 : Subregion 6 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR6_Pos (6UL) /*!< Position of SR6 field. */
+#define MWU_PERREGION_SUBSTATRA_SR6_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR6_Pos) /*!< Bit mask of SR6 field. */
+#define MWU_PERREGION_SUBSTATRA_SR6_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR6_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 5 : Subregion 5 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR5_Pos (5UL) /*!< Position of SR5 field. */
+#define MWU_PERREGION_SUBSTATRA_SR5_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR5_Pos) /*!< Bit mask of SR5 field. */
+#define MWU_PERREGION_SUBSTATRA_SR5_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR5_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 4 : Subregion 4 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR4_Pos (4UL) /*!< Position of SR4 field. */
+#define MWU_PERREGION_SUBSTATRA_SR4_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR4_Pos) /*!< Bit mask of SR4 field. */
+#define MWU_PERREGION_SUBSTATRA_SR4_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR4_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 3 : Subregion 3 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR3_Pos (3UL) /*!< Position of SR3 field. */
+#define MWU_PERREGION_SUBSTATRA_SR3_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR3_Pos) /*!< Bit mask of SR3 field. */
+#define MWU_PERREGION_SUBSTATRA_SR3_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR3_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 2 : Subregion 2 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR2_Pos (2UL) /*!< Position of SR2 field. */
+#define MWU_PERREGION_SUBSTATRA_SR2_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR2_Pos) /*!< Bit mask of SR2 field. */
+#define MWU_PERREGION_SUBSTATRA_SR2_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR2_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 1 : Subregion 1 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR1_Pos (1UL) /*!< Position of SR1 field. */
+#define MWU_PERREGION_SUBSTATRA_SR1_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR1_Pos) /*!< Bit mask of SR1 field. */
+#define MWU_PERREGION_SUBSTATRA_SR1_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR1_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Bit 0 : Subregion 0 in region 0 (write '1' to clear) */
+#define MWU_PERREGION_SUBSTATRA_SR0_Pos (0UL) /*!< Position of SR0 field. */
+#define MWU_PERREGION_SUBSTATRA_SR0_Msk (0x1UL << MWU_PERREGION_SUBSTATRA_SR0_Pos) /*!< Bit mask of SR0 field. */
+#define MWU_PERREGION_SUBSTATRA_SR0_NoAccess (0UL) /*!< No read access occurred in this subregion */
+#define MWU_PERREGION_SUBSTATRA_SR0_Access (1UL) /*!< Read access(es) occurred in this subregion */
+
+/* Register: MWU_REGIONEN */
+/* Description: Enable/disable regions watch */
+
+/* Bit 27 : Enable/disable read access watch in PREGION[1] */
+#define MWU_REGIONEN_PRGN1RA_Pos (27UL) /*!< Position of PRGN1RA field. */
+#define MWU_REGIONEN_PRGN1RA_Msk (0x1UL << MWU_REGIONEN_PRGN1RA_Pos) /*!< Bit mask of PRGN1RA field. */
+#define MWU_REGIONEN_PRGN1RA_Disable (0UL) /*!< Disable read access watch in this PREGION */
+#define MWU_REGIONEN_PRGN1RA_Enable (1UL) /*!< Enable read access watch in this PREGION */
+
+/* Bit 26 : Enable/disable write access watch in PREGION[1] */
+#define MWU_REGIONEN_PRGN1WA_Pos (26UL) /*!< Position of PRGN1WA field. */
+#define MWU_REGIONEN_PRGN1WA_Msk (0x1UL << MWU_REGIONEN_PRGN1WA_Pos) /*!< Bit mask of PRGN1WA field. */
+#define MWU_REGIONEN_PRGN1WA_Disable (0UL) /*!< Disable write access watch in this PREGION */
+#define MWU_REGIONEN_PRGN1WA_Enable (1UL) /*!< Enable write access watch in this PREGION */
+
+/* Bit 25 : Enable/disable read access watch in PREGION[0] */
+#define MWU_REGIONEN_PRGN0RA_Pos (25UL) /*!< Position of PRGN0RA field. */
+#define MWU_REGIONEN_PRGN0RA_Msk (0x1UL << MWU_REGIONEN_PRGN0RA_Pos) /*!< Bit mask of PRGN0RA field. */
+#define MWU_REGIONEN_PRGN0RA_Disable (0UL) /*!< Disable read access watch in this PREGION */
+#define MWU_REGIONEN_PRGN0RA_Enable (1UL) /*!< Enable read access watch in this PREGION */
+
+/* Bit 24 : Enable/disable write access watch in PREGION[0] */
+#define MWU_REGIONEN_PRGN0WA_Pos (24UL) /*!< Position of PRGN0WA field. */
+#define MWU_REGIONEN_PRGN0WA_Msk (0x1UL << MWU_REGIONEN_PRGN0WA_Pos) /*!< Bit mask of PRGN0WA field. */
+#define MWU_REGIONEN_PRGN0WA_Disable (0UL) /*!< Disable write access watch in this PREGION */
+#define MWU_REGIONEN_PRGN0WA_Enable (1UL) /*!< Enable write access watch in this PREGION */
+
+/* Bit 7 : Enable/disable read access watch in region[3] */
+#define MWU_REGIONEN_RGN3RA_Pos (7UL) /*!< Position of RGN3RA field. */
+#define MWU_REGIONEN_RGN3RA_Msk (0x1UL << MWU_REGIONEN_RGN3RA_Pos) /*!< Bit mask of RGN3RA field. */
+#define MWU_REGIONEN_RGN3RA_Disable (0UL) /*!< Disable read access watch in this region */
+#define MWU_REGIONEN_RGN3RA_Enable (1UL) /*!< Enable read access watch in this region */
+
+/* Bit 6 : Enable/disable write access watch in region[3] */
+#define MWU_REGIONEN_RGN3WA_Pos (6UL) /*!< Position of RGN3WA field. */
+#define MWU_REGIONEN_RGN3WA_Msk (0x1UL << MWU_REGIONEN_RGN3WA_Pos) /*!< Bit mask of RGN3WA field. */
+#define MWU_REGIONEN_RGN3WA_Disable (0UL) /*!< Disable write access watch in this region */
+#define MWU_REGIONEN_RGN3WA_Enable (1UL) /*!< Enable write access watch in this region */
+
+/* Bit 5 : Enable/disable read access watch in region[2] */
+#define MWU_REGIONEN_RGN2RA_Pos (5UL) /*!< Position of RGN2RA field. */
+#define MWU_REGIONEN_RGN2RA_Msk (0x1UL << MWU_REGIONEN_RGN2RA_Pos) /*!< Bit mask of RGN2RA field. */
+#define MWU_REGIONEN_RGN2RA_Disable (0UL) /*!< Disable read access watch in this region */
+#define MWU_REGIONEN_RGN2RA_Enable (1UL) /*!< Enable read access watch in this region */
+
+/* Bit 4 : Enable/disable write access watch in region[2] */
+#define MWU_REGIONEN_RGN2WA_Pos (4UL) /*!< Position of RGN2WA field. */
+#define MWU_REGIONEN_RGN2WA_Msk (0x1UL << MWU_REGIONEN_RGN2WA_Pos) /*!< Bit mask of RGN2WA field. */
+#define MWU_REGIONEN_RGN2WA_Disable (0UL) /*!< Disable write access watch in this region */
+#define MWU_REGIONEN_RGN2WA_Enable (1UL) /*!< Enable write access watch in this region */
+
+/* Bit 3 : Enable/disable read access watch in region[1] */
+#define MWU_REGIONEN_RGN1RA_Pos (3UL) /*!< Position of RGN1RA field. */
+#define MWU_REGIONEN_RGN1RA_Msk (0x1UL << MWU_REGIONEN_RGN1RA_Pos) /*!< Bit mask of RGN1RA field. */
+#define MWU_REGIONEN_RGN1RA_Disable (0UL) /*!< Disable read access watch in this region */
+#define MWU_REGIONEN_RGN1RA_Enable (1UL) /*!< Enable read access watch in this region */
+
+/* Bit 2 : Enable/disable write access watch in region[1] */
+#define MWU_REGIONEN_RGN1WA_Pos (2UL) /*!< Position of RGN1WA field. */
+#define MWU_REGIONEN_RGN1WA_Msk (0x1UL << MWU_REGIONEN_RGN1WA_Pos) /*!< Bit mask of RGN1WA field. */
+#define MWU_REGIONEN_RGN1WA_Disable (0UL) /*!< Disable write access watch in this region */
+#define MWU_REGIONEN_RGN1WA_Enable (1UL) /*!< Enable write access watch in this region */
+
+/* Bit 1 : Enable/disable read access watch in region[0] */
+#define MWU_REGIONEN_RGN0RA_Pos (1UL) /*!< Position of RGN0RA field. */
+#define MWU_REGIONEN_RGN0RA_Msk (0x1UL << MWU_REGIONEN_RGN0RA_Pos) /*!< Bit mask of RGN0RA field. */
+#define MWU_REGIONEN_RGN0RA_Disable (0UL) /*!< Disable read access watch in this region */
+#define MWU_REGIONEN_RGN0RA_Enable (1UL) /*!< Enable read access watch in this region */
+
+/* Bit 0 : Enable/disable write access watch in region[0] */
+#define MWU_REGIONEN_RGN0WA_Pos (0UL) /*!< Position of RGN0WA field. */
+#define MWU_REGIONEN_RGN0WA_Msk (0x1UL << MWU_REGIONEN_RGN0WA_Pos) /*!< Bit mask of RGN0WA field. */
+#define MWU_REGIONEN_RGN0WA_Disable (0UL) /*!< Disable write access watch in this region */
+#define MWU_REGIONEN_RGN0WA_Enable (1UL) /*!< Enable write access watch in this region */
+
+/* Register: MWU_REGIONENSET */
+/* Description: Enable regions watch */
+
+/* Bit 27 : Enable read access watch in PREGION[1] */
+#define MWU_REGIONENSET_PRGN1RA_Pos (27UL) /*!< Position of PRGN1RA field. */
+#define MWU_REGIONENSET_PRGN1RA_Msk (0x1UL << MWU_REGIONENSET_PRGN1RA_Pos) /*!< Bit mask of PRGN1RA field. */
+#define MWU_REGIONENSET_PRGN1RA_Disabled (0UL) /*!< Read access watch in this PREGION is disabled */
+#define MWU_REGIONENSET_PRGN1RA_Enabled (1UL) /*!< Read access watch in this PREGION is enabled */
+#define MWU_REGIONENSET_PRGN1RA_Set (1UL) /*!< Enable read access watch in this PREGION */
+
+/* Bit 26 : Enable write access watch in PREGION[1] */
+#define MWU_REGIONENSET_PRGN1WA_Pos (26UL) /*!< Position of PRGN1WA field. */
+#define MWU_REGIONENSET_PRGN1WA_Msk (0x1UL << MWU_REGIONENSET_PRGN1WA_Pos) /*!< Bit mask of PRGN1WA field. */
+#define MWU_REGIONENSET_PRGN1WA_Disabled (0UL) /*!< Write access watch in this PREGION is disabled */
+#define MWU_REGIONENSET_PRGN1WA_Enabled (1UL) /*!< Write access watch in this PREGION is enabled */
+#define MWU_REGIONENSET_PRGN1WA_Set (1UL) /*!< Enable write access watch in this PREGION */
+
+/* Bit 25 : Enable read access watch in PREGION[0] */
+#define MWU_REGIONENSET_PRGN0RA_Pos (25UL) /*!< Position of PRGN0RA field. */
+#define MWU_REGIONENSET_PRGN0RA_Msk (0x1UL << MWU_REGIONENSET_PRGN0RA_Pos) /*!< Bit mask of PRGN0RA field. */
+#define MWU_REGIONENSET_PRGN0RA_Disabled (0UL) /*!< Read access watch in this PREGION is disabled */
+#define MWU_REGIONENSET_PRGN0RA_Enabled (1UL) /*!< Read access watch in this PREGION is enabled */
+#define MWU_REGIONENSET_PRGN0RA_Set (1UL) /*!< Enable read access watch in this PREGION */
+
+/* Bit 24 : Enable write access watch in PREGION[0] */
+#define MWU_REGIONENSET_PRGN0WA_Pos (24UL) /*!< Position of PRGN0WA field. */
+#define MWU_REGIONENSET_PRGN0WA_Msk (0x1UL << MWU_REGIONENSET_PRGN0WA_Pos) /*!< Bit mask of PRGN0WA field. */
+#define MWU_REGIONENSET_PRGN0WA_Disabled (0UL) /*!< Write access watch in this PREGION is disabled */
+#define MWU_REGIONENSET_PRGN0WA_Enabled (1UL) /*!< Write access watch in this PREGION is enabled */
+#define MWU_REGIONENSET_PRGN0WA_Set (1UL) /*!< Enable write access watch in this PREGION */
+
+/* Bit 7 : Enable read access watch in region[3] */
+#define MWU_REGIONENSET_RGN3RA_Pos (7UL) /*!< Position of RGN3RA field. */
+#define MWU_REGIONENSET_RGN3RA_Msk (0x1UL << MWU_REGIONENSET_RGN3RA_Pos) /*!< Bit mask of RGN3RA field. */
+#define MWU_REGIONENSET_RGN3RA_Disabled (0UL) /*!< Read access watch in this region is disabled */
+#define MWU_REGIONENSET_RGN3RA_Enabled (1UL) /*!< Read access watch in this region is enabled */
+#define MWU_REGIONENSET_RGN3RA_Set (1UL) /*!< Enable read access watch in this region */
+
+/* Bit 6 : Enable write access watch in region[3] */
+#define MWU_REGIONENSET_RGN3WA_Pos (6UL) /*!< Position of RGN3WA field. */
+#define MWU_REGIONENSET_RGN3WA_Msk (0x1UL << MWU_REGIONENSET_RGN3WA_Pos) /*!< Bit mask of RGN3WA field. */
+#define MWU_REGIONENSET_RGN3WA_Disabled (0UL) /*!< Write access watch in this region is disabled */
+#define MWU_REGIONENSET_RGN3WA_Enabled (1UL) /*!< Write access watch in this region is enabled */
+#define MWU_REGIONENSET_RGN3WA_Set (1UL) /*!< Enable write access watch in this region */
+
+/* Bit 5 : Enable read access watch in region[2] */
+#define MWU_REGIONENSET_RGN2RA_Pos (5UL) /*!< Position of RGN2RA field. */
+#define MWU_REGIONENSET_RGN2RA_Msk (0x1UL << MWU_REGIONENSET_RGN2RA_Pos) /*!< Bit mask of RGN2RA field. */
+#define MWU_REGIONENSET_RGN2RA_Disabled (0UL) /*!< Read access watch in this region is disabled */
+#define MWU_REGIONENSET_RGN2RA_Enabled (1UL) /*!< Read access watch in this region is enabled */
+#define MWU_REGIONENSET_RGN2RA_Set (1UL) /*!< Enable read access watch in this region */
+
+/* Bit 4 : Enable write access watch in region[2] */
+#define MWU_REGIONENSET_RGN2WA_Pos (4UL) /*!< Position of RGN2WA field. */
+#define MWU_REGIONENSET_RGN2WA_Msk (0x1UL << MWU_REGIONENSET_RGN2WA_Pos) /*!< Bit mask of RGN2WA field. */
+#define MWU_REGIONENSET_RGN2WA_Disabled (0UL) /*!< Write access watch in this region is disabled */
+#define MWU_REGIONENSET_RGN2WA_Enabled (1UL) /*!< Write access watch in this region is enabled */
+#define MWU_REGIONENSET_RGN2WA_Set (1UL) /*!< Enable write access watch in this region */
+
+/* Bit 3 : Enable read access watch in region[1] */
+#define MWU_REGIONENSET_RGN1RA_Pos (3UL) /*!< Position of RGN1RA field. */
+#define MWU_REGIONENSET_RGN1RA_Msk (0x1UL << MWU_REGIONENSET_RGN1RA_Pos) /*!< Bit mask of RGN1RA field. */
+#define MWU_REGIONENSET_RGN1RA_Disabled (0UL) /*!< Read access watch in this region is disabled */
+#define MWU_REGIONENSET_RGN1RA_Enabled (1UL) /*!< Read access watch in this region is enabled */
+#define MWU_REGIONENSET_RGN1RA_Set (1UL) /*!< Enable read access watch in this region */
+
+/* Bit 2 : Enable write access watch in region[1] */
+#define MWU_REGIONENSET_RGN1WA_Pos (2UL) /*!< Position of RGN1WA field. */
+#define MWU_REGIONENSET_RGN1WA_Msk (0x1UL << MWU_REGIONENSET_RGN1WA_Pos) /*!< Bit mask of RGN1WA field. */
+#define MWU_REGIONENSET_RGN1WA_Disabled (0UL) /*!< Write access watch in this region is disabled */
+#define MWU_REGIONENSET_RGN1WA_Enabled (1UL) /*!< Write access watch in this region is enabled */
+#define MWU_REGIONENSET_RGN1WA_Set (1UL) /*!< Enable write access watch in this region */
+
+/* Bit 1 : Enable read access watch in region[0] */
+#define MWU_REGIONENSET_RGN0RA_Pos (1UL) /*!< Position of RGN0RA field. */
+#define MWU_REGIONENSET_RGN0RA_Msk (0x1UL << MWU_REGIONENSET_RGN0RA_Pos) /*!< Bit mask of RGN0RA field. */
+#define MWU_REGIONENSET_RGN0RA_Disabled (0UL) /*!< Read access watch in this region is disabled */
+#define MWU_REGIONENSET_RGN0RA_Enabled (1UL) /*!< Read access watch in this region is enabled */
+#define MWU_REGIONENSET_RGN0RA_Set (1UL) /*!< Enable read access watch in this region */
+
+/* Bit 0 : Enable write access watch in region[0] */
+#define MWU_REGIONENSET_RGN0WA_Pos (0UL) /*!< Position of RGN0WA field. */
+#define MWU_REGIONENSET_RGN0WA_Msk (0x1UL << MWU_REGIONENSET_RGN0WA_Pos) /*!< Bit mask of RGN0WA field. */
+#define MWU_REGIONENSET_RGN0WA_Disabled (0UL) /*!< Write access watch in this region is disabled */
+#define MWU_REGIONENSET_RGN0WA_Enabled (1UL) /*!< Write access watch in this region is enabled */
+#define MWU_REGIONENSET_RGN0WA_Set (1UL) /*!< Enable write access watch in this region */
+
+/* Register: MWU_REGIONENCLR */
+/* Description: Disable regions watch */
+
+/* Bit 27 : Disable read access watch in PREGION[1] */
+#define MWU_REGIONENCLR_PRGN1RA_Pos (27UL) /*!< Position of PRGN1RA field. */
+#define MWU_REGIONENCLR_PRGN1RA_Msk (0x1UL << MWU_REGIONENCLR_PRGN1RA_Pos) /*!< Bit mask of PRGN1RA field. */
+#define MWU_REGIONENCLR_PRGN1RA_Disabled (0UL) /*!< Read access watch in this PREGION is disabled */
+#define MWU_REGIONENCLR_PRGN1RA_Enabled (1UL) /*!< Read access watch in this PREGION is enabled */
+#define MWU_REGIONENCLR_PRGN1RA_Clear (1UL) /*!< Disable read access watch in this PREGION */
+
+/* Bit 26 : Disable write access watch in PREGION[1] */
+#define MWU_REGIONENCLR_PRGN1WA_Pos (26UL) /*!< Position of PRGN1WA field. */
+#define MWU_REGIONENCLR_PRGN1WA_Msk (0x1UL << MWU_REGIONENCLR_PRGN1WA_Pos) /*!< Bit mask of PRGN1WA field. */
+#define MWU_REGIONENCLR_PRGN1WA_Disabled (0UL) /*!< Write access watch in this PREGION is disabled */
+#define MWU_REGIONENCLR_PRGN1WA_Enabled (1UL) /*!< Write access watch in this PREGION is enabled */
+#define MWU_REGIONENCLR_PRGN1WA_Clear (1UL) /*!< Disable write access watch in this PREGION */
+
+/* Bit 25 : Disable read access watch in PREGION[0] */
+#define MWU_REGIONENCLR_PRGN0RA_Pos (25UL) /*!< Position of PRGN0RA field. */
+#define MWU_REGIONENCLR_PRGN0RA_Msk (0x1UL << MWU_REGIONENCLR_PRGN0RA_Pos) /*!< Bit mask of PRGN0RA field. */
+#define MWU_REGIONENCLR_PRGN0RA_Disabled (0UL) /*!< Read access watch in this PREGION is disabled */
+#define MWU_REGIONENCLR_PRGN0RA_Enabled (1UL) /*!< Read access watch in this PREGION is enabled */
+#define MWU_REGIONENCLR_PRGN0RA_Clear (1UL) /*!< Disable read access watch in this PREGION */
+
+/* Bit 24 : Disable write access watch in PREGION[0] */
+#define MWU_REGIONENCLR_PRGN0WA_Pos (24UL) /*!< Position of PRGN0WA field. */
+#define MWU_REGIONENCLR_PRGN0WA_Msk (0x1UL << MWU_REGIONENCLR_PRGN0WA_Pos) /*!< Bit mask of PRGN0WA field. */
+#define MWU_REGIONENCLR_PRGN0WA_Disabled (0UL) /*!< Write access watch in this PREGION is disabled */
+#define MWU_REGIONENCLR_PRGN0WA_Enabled (1UL) /*!< Write access watch in this PREGION is enabled */
+#define MWU_REGIONENCLR_PRGN0WA_Clear (1UL) /*!< Disable write access watch in this PREGION */
+
+/* Bit 7 : Disable read access watch in region[3] */
+#define MWU_REGIONENCLR_RGN3RA_Pos (7UL) /*!< Position of RGN3RA field. */
+#define MWU_REGIONENCLR_RGN3RA_Msk (0x1UL << MWU_REGIONENCLR_RGN3RA_Pos) /*!< Bit mask of RGN3RA field. */
+#define MWU_REGIONENCLR_RGN3RA_Disabled (0UL) /*!< Read access watch in this region is disabled */
+#define MWU_REGIONENCLR_RGN3RA_Enabled (1UL) /*!< Read access watch in this region is enabled */
+#define MWU_REGIONENCLR_RGN3RA_Clear (1UL) /*!< Disable read access watch in this region */
+
+/* Bit 6 : Disable write access watch in region[3] */
+#define MWU_REGIONENCLR_RGN3WA_Pos (6UL) /*!< Position of RGN3WA field. */
+#define MWU_REGIONENCLR_RGN3WA_Msk (0x1UL << MWU_REGIONENCLR_RGN3WA_Pos) /*!< Bit mask of RGN3WA field. */
+#define MWU_REGIONENCLR_RGN3WA_Disabled (0UL) /*!< Write access watch in this region is disabled */
+#define MWU_REGIONENCLR_RGN3WA_Enabled (1UL) /*!< Write access watch in this region is enabled */
+#define MWU_REGIONENCLR_RGN3WA_Clear (1UL) /*!< Disable write access watch in this region */
+
+/* Bit 5 : Disable read access watch in region[2] */
+#define MWU_REGIONENCLR_RGN2RA_Pos (5UL) /*!< Position of RGN2RA field. */
+#define MWU_REGIONENCLR_RGN2RA_Msk (0x1UL << MWU_REGIONENCLR_RGN2RA_Pos) /*!< Bit mask of RGN2RA field. */
+#define MWU_REGIONENCLR_RGN2RA_Disabled (0UL) /*!< Read access watch in this region is disabled */
+#define MWU_REGIONENCLR_RGN2RA_Enabled (1UL) /*!< Read access watch in this region is enabled */
+#define MWU_REGIONENCLR_RGN2RA_Clear (1UL) /*!< Disable read access watch in this region */
+
+/* Bit 4 : Disable write access watch in region[2] */
+#define MWU_REGIONENCLR_RGN2WA_Pos (4UL) /*!< Position of RGN2WA field. */
+#define MWU_REGIONENCLR_RGN2WA_Msk (0x1UL << MWU_REGIONENCLR_RGN2WA_Pos) /*!< Bit mask of RGN2WA field. */
+#define MWU_REGIONENCLR_RGN2WA_Disabled (0UL) /*!< Write access watch in this region is disabled */
+#define MWU_REGIONENCLR_RGN2WA_Enabled (1UL) /*!< Write access watch in this region is enabled */
+#define MWU_REGIONENCLR_RGN2WA_Clear (1UL) /*!< Disable write access watch in this region */
+
+/* Bit 3 : Disable read access watch in region[1] */
+#define MWU_REGIONENCLR_RGN1RA_Pos (3UL) /*!< Position of RGN1RA field. */
+#define MWU_REGIONENCLR_RGN1RA_Msk (0x1UL << MWU_REGIONENCLR_RGN1RA_Pos) /*!< Bit mask of RGN1RA field. */
+#define MWU_REGIONENCLR_RGN1RA_Disabled (0UL) /*!< Read access watch in this region is disabled */
+#define MWU_REGIONENCLR_RGN1RA_Enabled (1UL) /*!< Read access watch in this region is enabled */
+#define MWU_REGIONENCLR_RGN1RA_Clear (1UL) /*!< Disable read access watch in this region */
+
+/* Bit 2 : Disable write access watch in region[1] */
+#define MWU_REGIONENCLR_RGN1WA_Pos (2UL) /*!< Position of RGN1WA field. */
+#define MWU_REGIONENCLR_RGN1WA_Msk (0x1UL << MWU_REGIONENCLR_RGN1WA_Pos) /*!< Bit mask of RGN1WA field. */
+#define MWU_REGIONENCLR_RGN1WA_Disabled (0UL) /*!< Write access watch in this region is disabled */
+#define MWU_REGIONENCLR_RGN1WA_Enabled (1UL) /*!< Write access watch in this region is enabled */
+#define MWU_REGIONENCLR_RGN1WA_Clear (1UL) /*!< Disable write access watch in this region */
+
+/* Bit 1 : Disable read access watch in region[0] */
+#define MWU_REGIONENCLR_RGN0RA_Pos (1UL) /*!< Position of RGN0RA field. */
+#define MWU_REGIONENCLR_RGN0RA_Msk (0x1UL << MWU_REGIONENCLR_RGN0RA_Pos) /*!< Bit mask of RGN0RA field. */
+#define MWU_REGIONENCLR_RGN0RA_Disabled (0UL) /*!< Read access watch in this region is disabled */
+#define MWU_REGIONENCLR_RGN0RA_Enabled (1UL) /*!< Read access watch in this region is enabled */
+#define MWU_REGIONENCLR_RGN0RA_Clear (1UL) /*!< Disable read access watch in this region */
+
+/* Bit 0 : Disable write access watch in region[0] */
+#define MWU_REGIONENCLR_RGN0WA_Pos (0UL) /*!< Position of RGN0WA field. */
+#define MWU_REGIONENCLR_RGN0WA_Msk (0x1UL << MWU_REGIONENCLR_RGN0WA_Pos) /*!< Bit mask of RGN0WA field. */
+#define MWU_REGIONENCLR_RGN0WA_Disabled (0UL) /*!< Write access watch in this region is disabled */
+#define MWU_REGIONENCLR_RGN0WA_Enabled (1UL) /*!< Write access watch in this region is enabled */
+#define MWU_REGIONENCLR_RGN0WA_Clear (1UL) /*!< Disable write access watch in this region */
+
+/* Register: MWU_REGION_START */
+/* Description: Description cluster[0]:  Start address for region 0 */
+
+/* Bits 31..0 : Start address for region */
+#define MWU_REGION_START_START_Pos (0UL) /*!< Position of START field. */
+#define MWU_REGION_START_START_Msk (0xFFFFFFFFUL << MWU_REGION_START_START_Pos) /*!< Bit mask of START field. */
+
+/* Register: MWU_REGION_END */
+/* Description: Description cluster[0]:  End address of region 0 */
+
+/* Bits 31..0 : End address of region. Value 0 has a special meaning, see below. */
+#define MWU_REGION_END_END_Pos (0UL) /*!< Position of END field. */
+#define MWU_REGION_END_END_Msk (0xFFFFFFFFUL << MWU_REGION_END_END_Pos) /*!< Bit mask of END field. */
+
+/* Register: MWU_PREGION_START */
+/* Description: Description cluster[0]:  Reserved for future use */
+
+/* Bits 31..0 : Reserved for future use */
+#define MWU_PREGION_START_START_Pos (0UL) /*!< Position of START field. */
+#define MWU_PREGION_START_START_Msk (0xFFFFFFFFUL << MWU_PREGION_START_START_Pos) /*!< Bit mask of START field. */
+
+/* Register: MWU_PREGION_END */
+/* Description: Description cluster[0]:  Reserved for future use */
+
+/* Bits 31..0 : Reserved for future use */
+#define MWU_PREGION_END_END_Pos (0UL) /*!< Position of END field. */
+#define MWU_PREGION_END_END_Msk (0xFFFFFFFFUL << MWU_PREGION_END_END_Pos) /*!< Bit mask of END field. */
+
+/* Register: MWU_PREGION_SUBS */
+/* Description: Description cluster[0]:  Subregions of region 0 */
+
+/* Bit 31 : Include or exclude subregion 31 in region */
+#define MWU_PREGION_SUBS_SR31_Pos (31UL) /*!< Position of SR31 field. */
+#define MWU_PREGION_SUBS_SR31_Msk (0x1UL << MWU_PREGION_SUBS_SR31_Pos) /*!< Bit mask of SR31 field. */
+#define MWU_PREGION_SUBS_SR31_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR31_Include (1UL) /*!< Include */
+
+/* Bit 30 : Include or exclude subregion 30 in region */
+#define MWU_PREGION_SUBS_SR30_Pos (30UL) /*!< Position of SR30 field. */
+#define MWU_PREGION_SUBS_SR30_Msk (0x1UL << MWU_PREGION_SUBS_SR30_Pos) /*!< Bit mask of SR30 field. */
+#define MWU_PREGION_SUBS_SR30_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR30_Include (1UL) /*!< Include */
+
+/* Bit 29 : Include or exclude subregion 29 in region */
+#define MWU_PREGION_SUBS_SR29_Pos (29UL) /*!< Position of SR29 field. */
+#define MWU_PREGION_SUBS_SR29_Msk (0x1UL << MWU_PREGION_SUBS_SR29_Pos) /*!< Bit mask of SR29 field. */
+#define MWU_PREGION_SUBS_SR29_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR29_Include (1UL) /*!< Include */
+
+/* Bit 28 : Include or exclude subregion 28 in region */
+#define MWU_PREGION_SUBS_SR28_Pos (28UL) /*!< Position of SR28 field. */
+#define MWU_PREGION_SUBS_SR28_Msk (0x1UL << MWU_PREGION_SUBS_SR28_Pos) /*!< Bit mask of SR28 field. */
+#define MWU_PREGION_SUBS_SR28_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR28_Include (1UL) /*!< Include */
+
+/* Bit 27 : Include or exclude subregion 27 in region */
+#define MWU_PREGION_SUBS_SR27_Pos (27UL) /*!< Position of SR27 field. */
+#define MWU_PREGION_SUBS_SR27_Msk (0x1UL << MWU_PREGION_SUBS_SR27_Pos) /*!< Bit mask of SR27 field. */
+#define MWU_PREGION_SUBS_SR27_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR27_Include (1UL) /*!< Include */
+
+/* Bit 26 : Include or exclude subregion 26 in region */
+#define MWU_PREGION_SUBS_SR26_Pos (26UL) /*!< Position of SR26 field. */
+#define MWU_PREGION_SUBS_SR26_Msk (0x1UL << MWU_PREGION_SUBS_SR26_Pos) /*!< Bit mask of SR26 field. */
+#define MWU_PREGION_SUBS_SR26_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR26_Include (1UL) /*!< Include */
+
+/* Bit 25 : Include or exclude subregion 25 in region */
+#define MWU_PREGION_SUBS_SR25_Pos (25UL) /*!< Position of SR25 field. */
+#define MWU_PREGION_SUBS_SR25_Msk (0x1UL << MWU_PREGION_SUBS_SR25_Pos) /*!< Bit mask of SR25 field. */
+#define MWU_PREGION_SUBS_SR25_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR25_Include (1UL) /*!< Include */
+
+/* Bit 24 : Include or exclude subregion 24 in region */
+#define MWU_PREGION_SUBS_SR24_Pos (24UL) /*!< Position of SR24 field. */
+#define MWU_PREGION_SUBS_SR24_Msk (0x1UL << MWU_PREGION_SUBS_SR24_Pos) /*!< Bit mask of SR24 field. */
+#define MWU_PREGION_SUBS_SR24_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR24_Include (1UL) /*!< Include */
+
+/* Bit 23 : Include or exclude subregion 23 in region */
+#define MWU_PREGION_SUBS_SR23_Pos (23UL) /*!< Position of SR23 field. */
+#define MWU_PREGION_SUBS_SR23_Msk (0x1UL << MWU_PREGION_SUBS_SR23_Pos) /*!< Bit mask of SR23 field. */
+#define MWU_PREGION_SUBS_SR23_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR23_Include (1UL) /*!< Include */
+
+/* Bit 22 : Include or exclude subregion 22 in region */
+#define MWU_PREGION_SUBS_SR22_Pos (22UL) /*!< Position of SR22 field. */
+#define MWU_PREGION_SUBS_SR22_Msk (0x1UL << MWU_PREGION_SUBS_SR22_Pos) /*!< Bit mask of SR22 field. */
+#define MWU_PREGION_SUBS_SR22_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR22_Include (1UL) /*!< Include */
+
+/* Bit 21 : Include or exclude subregion 21 in region */
+#define MWU_PREGION_SUBS_SR21_Pos (21UL) /*!< Position of SR21 field. */
+#define MWU_PREGION_SUBS_SR21_Msk (0x1UL << MWU_PREGION_SUBS_SR21_Pos) /*!< Bit mask of SR21 field. */
+#define MWU_PREGION_SUBS_SR21_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR21_Include (1UL) /*!< Include */
+
+/* Bit 20 : Include or exclude subregion 20 in region */
+#define MWU_PREGION_SUBS_SR20_Pos (20UL) /*!< Position of SR20 field. */
+#define MWU_PREGION_SUBS_SR20_Msk (0x1UL << MWU_PREGION_SUBS_SR20_Pos) /*!< Bit mask of SR20 field. */
+#define MWU_PREGION_SUBS_SR20_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR20_Include (1UL) /*!< Include */
+
+/* Bit 19 : Include or exclude subregion 19 in region */
+#define MWU_PREGION_SUBS_SR19_Pos (19UL) /*!< Position of SR19 field. */
+#define MWU_PREGION_SUBS_SR19_Msk (0x1UL << MWU_PREGION_SUBS_SR19_Pos) /*!< Bit mask of SR19 field. */
+#define MWU_PREGION_SUBS_SR19_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR19_Include (1UL) /*!< Include */
+
+/* Bit 18 : Include or exclude subregion 18 in region */
+#define MWU_PREGION_SUBS_SR18_Pos (18UL) /*!< Position of SR18 field. */
+#define MWU_PREGION_SUBS_SR18_Msk (0x1UL << MWU_PREGION_SUBS_SR18_Pos) /*!< Bit mask of SR18 field. */
+#define MWU_PREGION_SUBS_SR18_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR18_Include (1UL) /*!< Include */
+
+/* Bit 17 : Include or exclude subregion 17 in region */
+#define MWU_PREGION_SUBS_SR17_Pos (17UL) /*!< Position of SR17 field. */
+#define MWU_PREGION_SUBS_SR17_Msk (0x1UL << MWU_PREGION_SUBS_SR17_Pos) /*!< Bit mask of SR17 field. */
+#define MWU_PREGION_SUBS_SR17_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR17_Include (1UL) /*!< Include */
+
+/* Bit 16 : Include or exclude subregion 16 in region */
+#define MWU_PREGION_SUBS_SR16_Pos (16UL) /*!< Position of SR16 field. */
+#define MWU_PREGION_SUBS_SR16_Msk (0x1UL << MWU_PREGION_SUBS_SR16_Pos) /*!< Bit mask of SR16 field. */
+#define MWU_PREGION_SUBS_SR16_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR16_Include (1UL) /*!< Include */
+
+/* Bit 15 : Include or exclude subregion 15 in region */
+#define MWU_PREGION_SUBS_SR15_Pos (15UL) /*!< Position of SR15 field. */
+#define MWU_PREGION_SUBS_SR15_Msk (0x1UL << MWU_PREGION_SUBS_SR15_Pos) /*!< Bit mask of SR15 field. */
+#define MWU_PREGION_SUBS_SR15_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR15_Include (1UL) /*!< Include */
+
+/* Bit 14 : Include or exclude subregion 14 in region */
+#define MWU_PREGION_SUBS_SR14_Pos (14UL) /*!< Position of SR14 field. */
+#define MWU_PREGION_SUBS_SR14_Msk (0x1UL << MWU_PREGION_SUBS_SR14_Pos) /*!< Bit mask of SR14 field. */
+#define MWU_PREGION_SUBS_SR14_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR14_Include (1UL) /*!< Include */
+
+/* Bit 13 : Include or exclude subregion 13 in region */
+#define MWU_PREGION_SUBS_SR13_Pos (13UL) /*!< Position of SR13 field. */
+#define MWU_PREGION_SUBS_SR13_Msk (0x1UL << MWU_PREGION_SUBS_SR13_Pos) /*!< Bit mask of SR13 field. */
+#define MWU_PREGION_SUBS_SR13_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR13_Include (1UL) /*!< Include */
+
+/* Bit 12 : Include or exclude subregion 12 in region */
+#define MWU_PREGION_SUBS_SR12_Pos (12UL) /*!< Position of SR12 field. */
+#define MWU_PREGION_SUBS_SR12_Msk (0x1UL << MWU_PREGION_SUBS_SR12_Pos) /*!< Bit mask of SR12 field. */
+#define MWU_PREGION_SUBS_SR12_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR12_Include (1UL) /*!< Include */
+
+/* Bit 11 : Include or exclude subregion 11 in region */
+#define MWU_PREGION_SUBS_SR11_Pos (11UL) /*!< Position of SR11 field. */
+#define MWU_PREGION_SUBS_SR11_Msk (0x1UL << MWU_PREGION_SUBS_SR11_Pos) /*!< Bit mask of SR11 field. */
+#define MWU_PREGION_SUBS_SR11_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR11_Include (1UL) /*!< Include */
+
+/* Bit 10 : Include or exclude subregion 10 in region */
+#define MWU_PREGION_SUBS_SR10_Pos (10UL) /*!< Position of SR10 field. */
+#define MWU_PREGION_SUBS_SR10_Msk (0x1UL << MWU_PREGION_SUBS_SR10_Pos) /*!< Bit mask of SR10 field. */
+#define MWU_PREGION_SUBS_SR10_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR10_Include (1UL) /*!< Include */
+
+/* Bit 9 : Include or exclude subregion 9 in region */
+#define MWU_PREGION_SUBS_SR9_Pos (9UL) /*!< Position of SR9 field. */
+#define MWU_PREGION_SUBS_SR9_Msk (0x1UL << MWU_PREGION_SUBS_SR9_Pos) /*!< Bit mask of SR9 field. */
+#define MWU_PREGION_SUBS_SR9_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR9_Include (1UL) /*!< Include */
+
+/* Bit 8 : Include or exclude subregion 8 in region */
+#define MWU_PREGION_SUBS_SR8_Pos (8UL) /*!< Position of SR8 field. */
+#define MWU_PREGION_SUBS_SR8_Msk (0x1UL << MWU_PREGION_SUBS_SR8_Pos) /*!< Bit mask of SR8 field. */
+#define MWU_PREGION_SUBS_SR8_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR8_Include (1UL) /*!< Include */
+
+/* Bit 7 : Include or exclude subregion 7 in region */
+#define MWU_PREGION_SUBS_SR7_Pos (7UL) /*!< Position of SR7 field. */
+#define MWU_PREGION_SUBS_SR7_Msk (0x1UL << MWU_PREGION_SUBS_SR7_Pos) /*!< Bit mask of SR7 field. */
+#define MWU_PREGION_SUBS_SR7_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR7_Include (1UL) /*!< Include */
+
+/* Bit 6 : Include or exclude subregion 6 in region */
+#define MWU_PREGION_SUBS_SR6_Pos (6UL) /*!< Position of SR6 field. */
+#define MWU_PREGION_SUBS_SR6_Msk (0x1UL << MWU_PREGION_SUBS_SR6_Pos) /*!< Bit mask of SR6 field. */
+#define MWU_PREGION_SUBS_SR6_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR6_Include (1UL) /*!< Include */
+
+/* Bit 5 : Include or exclude subregion 5 in region */
+#define MWU_PREGION_SUBS_SR5_Pos (5UL) /*!< Position of SR5 field. */
+#define MWU_PREGION_SUBS_SR5_Msk (0x1UL << MWU_PREGION_SUBS_SR5_Pos) /*!< Bit mask of SR5 field. */
+#define MWU_PREGION_SUBS_SR5_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR5_Include (1UL) /*!< Include */
+
+/* Bit 4 : Include or exclude subregion 4 in region */
+#define MWU_PREGION_SUBS_SR4_Pos (4UL) /*!< Position of SR4 field. */
+#define MWU_PREGION_SUBS_SR4_Msk (0x1UL << MWU_PREGION_SUBS_SR4_Pos) /*!< Bit mask of SR4 field. */
+#define MWU_PREGION_SUBS_SR4_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR4_Include (1UL) /*!< Include */
+
+/* Bit 3 : Include or exclude subregion 3 in region */
+#define MWU_PREGION_SUBS_SR3_Pos (3UL) /*!< Position of SR3 field. */
+#define MWU_PREGION_SUBS_SR3_Msk (0x1UL << MWU_PREGION_SUBS_SR3_Pos) /*!< Bit mask of SR3 field. */
+#define MWU_PREGION_SUBS_SR3_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR3_Include (1UL) /*!< Include */
+
+/* Bit 2 : Include or exclude subregion 2 in region */
+#define MWU_PREGION_SUBS_SR2_Pos (2UL) /*!< Position of SR2 field. */
+#define MWU_PREGION_SUBS_SR2_Msk (0x1UL << MWU_PREGION_SUBS_SR2_Pos) /*!< Bit mask of SR2 field. */
+#define MWU_PREGION_SUBS_SR2_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR2_Include (1UL) /*!< Include */
+
+/* Bit 1 : Include or exclude subregion 1 in region */
+#define MWU_PREGION_SUBS_SR1_Pos (1UL) /*!< Position of SR1 field. */
+#define MWU_PREGION_SUBS_SR1_Msk (0x1UL << MWU_PREGION_SUBS_SR1_Pos) /*!< Bit mask of SR1 field. */
+#define MWU_PREGION_SUBS_SR1_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR1_Include (1UL) /*!< Include */
+
+/* Bit 0 : Include or exclude subregion 0 in region */
+#define MWU_PREGION_SUBS_SR0_Pos (0UL) /*!< Position of SR0 field. */
+#define MWU_PREGION_SUBS_SR0_Msk (0x1UL << MWU_PREGION_SUBS_SR0_Pos) /*!< Bit mask of SR0 field. */
+#define MWU_PREGION_SUBS_SR0_Exclude (0UL) /*!< Exclude */
+#define MWU_PREGION_SUBS_SR0_Include (1UL) /*!< Include */
+
+
+/* Peripheral: NFCT */
+/* Description: NFC-A compatible radio */
+
+/* Register: NFCT_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 1 : Shortcut between FIELDLOST event and SENSE task */
+#define NFCT_SHORTS_FIELDLOST_SENSE_Pos (1UL) /*!< Position of FIELDLOST_SENSE field. */
+#define NFCT_SHORTS_FIELDLOST_SENSE_Msk (0x1UL << NFCT_SHORTS_FIELDLOST_SENSE_Pos) /*!< Bit mask of FIELDLOST_SENSE field. */
+#define NFCT_SHORTS_FIELDLOST_SENSE_Disabled (0UL) /*!< Disable shortcut */
+#define NFCT_SHORTS_FIELDLOST_SENSE_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 0 : Shortcut between FIELDDETECTED event and ACTIVATE task */
+#define NFCT_SHORTS_FIELDDETECTED_ACTIVATE_Pos (0UL) /*!< Position of FIELDDETECTED_ACTIVATE field. */
+#define NFCT_SHORTS_FIELDDETECTED_ACTIVATE_Msk (0x1UL << NFCT_SHORTS_FIELDDETECTED_ACTIVATE_Pos) /*!< Bit mask of FIELDDETECTED_ACTIVATE field. */
+#define NFCT_SHORTS_FIELDDETECTED_ACTIVATE_Disabled (0UL) /*!< Disable shortcut */
+#define NFCT_SHORTS_FIELDDETECTED_ACTIVATE_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: NFCT_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 20 : Enable or disable interrupt for STARTED event */
+#define NFCT_INTEN_STARTED_Pos (20UL) /*!< Position of STARTED field. */
+#define NFCT_INTEN_STARTED_Msk (0x1UL << NFCT_INTEN_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define NFCT_INTEN_STARTED_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_STARTED_Enabled (1UL) /*!< Enable */
+
+/* Bit 19 : Enable or disable interrupt for SELECTED event */
+#define NFCT_INTEN_SELECTED_Pos (19UL) /*!< Position of SELECTED field. */
+#define NFCT_INTEN_SELECTED_Msk (0x1UL << NFCT_INTEN_SELECTED_Pos) /*!< Bit mask of SELECTED field. */
+#define NFCT_INTEN_SELECTED_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_SELECTED_Enabled (1UL) /*!< Enable */
+
+/* Bit 18 : Enable or disable interrupt for COLLISION event */
+#define NFCT_INTEN_COLLISION_Pos (18UL) /*!< Position of COLLISION field. */
+#define NFCT_INTEN_COLLISION_Msk (0x1UL << NFCT_INTEN_COLLISION_Pos) /*!< Bit mask of COLLISION field. */
+#define NFCT_INTEN_COLLISION_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_COLLISION_Enabled (1UL) /*!< Enable */
+
+/* Bit 14 : Enable or disable interrupt for AUTOCOLRESSTARTED event */
+#define NFCT_INTEN_AUTOCOLRESSTARTED_Pos (14UL) /*!< Position of AUTOCOLRESSTARTED field. */
+#define NFCT_INTEN_AUTOCOLRESSTARTED_Msk (0x1UL << NFCT_INTEN_AUTOCOLRESSTARTED_Pos) /*!< Bit mask of AUTOCOLRESSTARTED field. */
+#define NFCT_INTEN_AUTOCOLRESSTARTED_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_AUTOCOLRESSTARTED_Enabled (1UL) /*!< Enable */
+
+/* Bit 12 : Enable or disable interrupt for ENDTX event */
+#define NFCT_INTEN_ENDTX_Pos (12UL) /*!< Position of ENDTX field. */
+#define NFCT_INTEN_ENDTX_Msk (0x1UL << NFCT_INTEN_ENDTX_Pos) /*!< Bit mask of ENDTX field. */
+#define NFCT_INTEN_ENDTX_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_ENDTX_Enabled (1UL) /*!< Enable */
+
+/* Bit 11 : Enable or disable interrupt for ENDRX event */
+#define NFCT_INTEN_ENDRX_Pos (11UL) /*!< Position of ENDRX field. */
+#define NFCT_INTEN_ENDRX_Msk (0x1UL << NFCT_INTEN_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define NFCT_INTEN_ENDRX_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_ENDRX_Enabled (1UL) /*!< Enable */
+
+/* Bit 10 : Enable or disable interrupt for RXERROR event */
+#define NFCT_INTEN_RXERROR_Pos (10UL) /*!< Position of RXERROR field. */
+#define NFCT_INTEN_RXERROR_Msk (0x1UL << NFCT_INTEN_RXERROR_Pos) /*!< Bit mask of RXERROR field. */
+#define NFCT_INTEN_RXERROR_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_RXERROR_Enabled (1UL) /*!< Enable */
+
+/* Bit 7 : Enable or disable interrupt for ERROR event */
+#define NFCT_INTEN_ERROR_Pos (7UL) /*!< Position of ERROR field. */
+#define NFCT_INTEN_ERROR_Msk (0x1UL << NFCT_INTEN_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define NFCT_INTEN_ERROR_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_ERROR_Enabled (1UL) /*!< Enable */
+
+/* Bit 6 : Enable or disable interrupt for RXFRAMEEND event */
+#define NFCT_INTEN_RXFRAMEEND_Pos (6UL) /*!< Position of RXFRAMEEND field. */
+#define NFCT_INTEN_RXFRAMEEND_Msk (0x1UL << NFCT_INTEN_RXFRAMEEND_Pos) /*!< Bit mask of RXFRAMEEND field. */
+#define NFCT_INTEN_RXFRAMEEND_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_RXFRAMEEND_Enabled (1UL) /*!< Enable */
+
+/* Bit 5 : Enable or disable interrupt for RXFRAMESTART event */
+#define NFCT_INTEN_RXFRAMESTART_Pos (5UL) /*!< Position of RXFRAMESTART field. */
+#define NFCT_INTEN_RXFRAMESTART_Msk (0x1UL << NFCT_INTEN_RXFRAMESTART_Pos) /*!< Bit mask of RXFRAMESTART field. */
+#define NFCT_INTEN_RXFRAMESTART_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_RXFRAMESTART_Enabled (1UL) /*!< Enable */
+
+/* Bit 4 : Enable or disable interrupt for TXFRAMEEND event */
+#define NFCT_INTEN_TXFRAMEEND_Pos (4UL) /*!< Position of TXFRAMEEND field. */
+#define NFCT_INTEN_TXFRAMEEND_Msk (0x1UL << NFCT_INTEN_TXFRAMEEND_Pos) /*!< Bit mask of TXFRAMEEND field. */
+#define NFCT_INTEN_TXFRAMEEND_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_TXFRAMEEND_Enabled (1UL) /*!< Enable */
+
+/* Bit 3 : Enable or disable interrupt for TXFRAMESTART event */
+#define NFCT_INTEN_TXFRAMESTART_Pos (3UL) /*!< Position of TXFRAMESTART field. */
+#define NFCT_INTEN_TXFRAMESTART_Msk (0x1UL << NFCT_INTEN_TXFRAMESTART_Pos) /*!< Bit mask of TXFRAMESTART field. */
+#define NFCT_INTEN_TXFRAMESTART_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_TXFRAMESTART_Enabled (1UL) /*!< Enable */
+
+/* Bit 2 : Enable or disable interrupt for FIELDLOST event */
+#define NFCT_INTEN_FIELDLOST_Pos (2UL) /*!< Position of FIELDLOST field. */
+#define NFCT_INTEN_FIELDLOST_Msk (0x1UL << NFCT_INTEN_FIELDLOST_Pos) /*!< Bit mask of FIELDLOST field. */
+#define NFCT_INTEN_FIELDLOST_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_FIELDLOST_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for FIELDDETECTED event */
+#define NFCT_INTEN_FIELDDETECTED_Pos (1UL) /*!< Position of FIELDDETECTED field. */
+#define NFCT_INTEN_FIELDDETECTED_Msk (0x1UL << NFCT_INTEN_FIELDDETECTED_Pos) /*!< Bit mask of FIELDDETECTED field. */
+#define NFCT_INTEN_FIELDDETECTED_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_FIELDDETECTED_Enabled (1UL) /*!< Enable */
+
+/* Bit 0 : Enable or disable interrupt for READY event */
+#define NFCT_INTEN_READY_Pos (0UL) /*!< Position of READY field. */
+#define NFCT_INTEN_READY_Msk (0x1UL << NFCT_INTEN_READY_Pos) /*!< Bit mask of READY field. */
+#define NFCT_INTEN_READY_Disabled (0UL) /*!< Disable */
+#define NFCT_INTEN_READY_Enabled (1UL) /*!< Enable */
+
+/* Register: NFCT_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 20 : Write '1' to Enable interrupt for STARTED event */
+#define NFCT_INTENSET_STARTED_Pos (20UL) /*!< Position of STARTED field. */
+#define NFCT_INTENSET_STARTED_Msk (0x1UL << NFCT_INTENSET_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define NFCT_INTENSET_STARTED_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_STARTED_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_STARTED_Set (1UL) /*!< Enable */
+
+/* Bit 19 : Write '1' to Enable interrupt for SELECTED event */
+#define NFCT_INTENSET_SELECTED_Pos (19UL) /*!< Position of SELECTED field. */
+#define NFCT_INTENSET_SELECTED_Msk (0x1UL << NFCT_INTENSET_SELECTED_Pos) /*!< Bit mask of SELECTED field. */
+#define NFCT_INTENSET_SELECTED_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_SELECTED_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_SELECTED_Set (1UL) /*!< Enable */
+
+/* Bit 18 : Write '1' to Enable interrupt for COLLISION event */
+#define NFCT_INTENSET_COLLISION_Pos (18UL) /*!< Position of COLLISION field. */
+#define NFCT_INTENSET_COLLISION_Msk (0x1UL << NFCT_INTENSET_COLLISION_Pos) /*!< Bit mask of COLLISION field. */
+#define NFCT_INTENSET_COLLISION_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_COLLISION_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_COLLISION_Set (1UL) /*!< Enable */
+
+/* Bit 14 : Write '1' to Enable interrupt for AUTOCOLRESSTARTED event */
+#define NFCT_INTENSET_AUTOCOLRESSTARTED_Pos (14UL) /*!< Position of AUTOCOLRESSTARTED field. */
+#define NFCT_INTENSET_AUTOCOLRESSTARTED_Msk (0x1UL << NFCT_INTENSET_AUTOCOLRESSTARTED_Pos) /*!< Bit mask of AUTOCOLRESSTARTED field. */
+#define NFCT_INTENSET_AUTOCOLRESSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_AUTOCOLRESSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_AUTOCOLRESSTARTED_Set (1UL) /*!< Enable */
+
+/* Bit 12 : Write '1' to Enable interrupt for ENDTX event */
+#define NFCT_INTENSET_ENDTX_Pos (12UL) /*!< Position of ENDTX field. */
+#define NFCT_INTENSET_ENDTX_Msk (0x1UL << NFCT_INTENSET_ENDTX_Pos) /*!< Bit mask of ENDTX field. */
+#define NFCT_INTENSET_ENDTX_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_ENDTX_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_ENDTX_Set (1UL) /*!< Enable */
+
+/* Bit 11 : Write '1' to Enable interrupt for ENDRX event */
+#define NFCT_INTENSET_ENDRX_Pos (11UL) /*!< Position of ENDRX field. */
+#define NFCT_INTENSET_ENDRX_Msk (0x1UL << NFCT_INTENSET_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define NFCT_INTENSET_ENDRX_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_ENDRX_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_ENDRX_Set (1UL) /*!< Enable */
+
+/* Bit 10 : Write '1' to Enable interrupt for RXERROR event */
+#define NFCT_INTENSET_RXERROR_Pos (10UL) /*!< Position of RXERROR field. */
+#define NFCT_INTENSET_RXERROR_Msk (0x1UL << NFCT_INTENSET_RXERROR_Pos) /*!< Bit mask of RXERROR field. */
+#define NFCT_INTENSET_RXERROR_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_RXERROR_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_RXERROR_Set (1UL) /*!< Enable */
+
+/* Bit 7 : Write '1' to Enable interrupt for ERROR event */
+#define NFCT_INTENSET_ERROR_Pos (7UL) /*!< Position of ERROR field. */
+#define NFCT_INTENSET_ERROR_Msk (0x1UL << NFCT_INTENSET_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define NFCT_INTENSET_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_ERROR_Set (1UL) /*!< Enable */
+
+/* Bit 6 : Write '1' to Enable interrupt for RXFRAMEEND event */
+#define NFCT_INTENSET_RXFRAMEEND_Pos (6UL) /*!< Position of RXFRAMEEND field. */
+#define NFCT_INTENSET_RXFRAMEEND_Msk (0x1UL << NFCT_INTENSET_RXFRAMEEND_Pos) /*!< Bit mask of RXFRAMEEND field. */
+#define NFCT_INTENSET_RXFRAMEEND_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_RXFRAMEEND_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_RXFRAMEEND_Set (1UL) /*!< Enable */
+
+/* Bit 5 : Write '1' to Enable interrupt for RXFRAMESTART event */
+#define NFCT_INTENSET_RXFRAMESTART_Pos (5UL) /*!< Position of RXFRAMESTART field. */
+#define NFCT_INTENSET_RXFRAMESTART_Msk (0x1UL << NFCT_INTENSET_RXFRAMESTART_Pos) /*!< Bit mask of RXFRAMESTART field. */
+#define NFCT_INTENSET_RXFRAMESTART_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_RXFRAMESTART_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_RXFRAMESTART_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable interrupt for TXFRAMEEND event */
+#define NFCT_INTENSET_TXFRAMEEND_Pos (4UL) /*!< Position of TXFRAMEEND field. */
+#define NFCT_INTENSET_TXFRAMEEND_Msk (0x1UL << NFCT_INTENSET_TXFRAMEEND_Pos) /*!< Bit mask of TXFRAMEEND field. */
+#define NFCT_INTENSET_TXFRAMEEND_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_TXFRAMEEND_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_TXFRAMEEND_Set (1UL) /*!< Enable */
+
+/* Bit 3 : Write '1' to Enable interrupt for TXFRAMESTART event */
+#define NFCT_INTENSET_TXFRAMESTART_Pos (3UL) /*!< Position of TXFRAMESTART field. */
+#define NFCT_INTENSET_TXFRAMESTART_Msk (0x1UL << NFCT_INTENSET_TXFRAMESTART_Pos) /*!< Bit mask of TXFRAMESTART field. */
+#define NFCT_INTENSET_TXFRAMESTART_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_TXFRAMESTART_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_TXFRAMESTART_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for FIELDLOST event */
+#define NFCT_INTENSET_FIELDLOST_Pos (2UL) /*!< Position of FIELDLOST field. */
+#define NFCT_INTENSET_FIELDLOST_Msk (0x1UL << NFCT_INTENSET_FIELDLOST_Pos) /*!< Bit mask of FIELDLOST field. */
+#define NFCT_INTENSET_FIELDLOST_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_FIELDLOST_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_FIELDLOST_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for FIELDDETECTED event */
+#define NFCT_INTENSET_FIELDDETECTED_Pos (1UL) /*!< Position of FIELDDETECTED field. */
+#define NFCT_INTENSET_FIELDDETECTED_Msk (0x1UL << NFCT_INTENSET_FIELDDETECTED_Pos) /*!< Bit mask of FIELDDETECTED field. */
+#define NFCT_INTENSET_FIELDDETECTED_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_FIELDDETECTED_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_FIELDDETECTED_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for READY event */
+#define NFCT_INTENSET_READY_Pos (0UL) /*!< Position of READY field. */
+#define NFCT_INTENSET_READY_Msk (0x1UL << NFCT_INTENSET_READY_Pos) /*!< Bit mask of READY field. */
+#define NFCT_INTENSET_READY_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENSET_READY_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENSET_READY_Set (1UL) /*!< Enable */
+
+/* Register: NFCT_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 20 : Write '1' to Disable interrupt for STARTED event */
+#define NFCT_INTENCLR_STARTED_Pos (20UL) /*!< Position of STARTED field. */
+#define NFCT_INTENCLR_STARTED_Msk (0x1UL << NFCT_INTENCLR_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define NFCT_INTENCLR_STARTED_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_STARTED_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_STARTED_Clear (1UL) /*!< Disable */
+
+/* Bit 19 : Write '1' to Disable interrupt for SELECTED event */
+#define NFCT_INTENCLR_SELECTED_Pos (19UL) /*!< Position of SELECTED field. */
+#define NFCT_INTENCLR_SELECTED_Msk (0x1UL << NFCT_INTENCLR_SELECTED_Pos) /*!< Bit mask of SELECTED field. */
+#define NFCT_INTENCLR_SELECTED_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_SELECTED_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_SELECTED_Clear (1UL) /*!< Disable */
+
+/* Bit 18 : Write '1' to Disable interrupt for COLLISION event */
+#define NFCT_INTENCLR_COLLISION_Pos (18UL) /*!< Position of COLLISION field. */
+#define NFCT_INTENCLR_COLLISION_Msk (0x1UL << NFCT_INTENCLR_COLLISION_Pos) /*!< Bit mask of COLLISION field. */
+#define NFCT_INTENCLR_COLLISION_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_COLLISION_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_COLLISION_Clear (1UL) /*!< Disable */
+
+/* Bit 14 : Write '1' to Disable interrupt for AUTOCOLRESSTARTED event */
+#define NFCT_INTENCLR_AUTOCOLRESSTARTED_Pos (14UL) /*!< Position of AUTOCOLRESSTARTED field. */
+#define NFCT_INTENCLR_AUTOCOLRESSTARTED_Msk (0x1UL << NFCT_INTENCLR_AUTOCOLRESSTARTED_Pos) /*!< Bit mask of AUTOCOLRESSTARTED field. */
+#define NFCT_INTENCLR_AUTOCOLRESSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_AUTOCOLRESSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_AUTOCOLRESSTARTED_Clear (1UL) /*!< Disable */
+
+/* Bit 12 : Write '1' to Disable interrupt for ENDTX event */
+#define NFCT_INTENCLR_ENDTX_Pos (12UL) /*!< Position of ENDTX field. */
+#define NFCT_INTENCLR_ENDTX_Msk (0x1UL << NFCT_INTENCLR_ENDTX_Pos) /*!< Bit mask of ENDTX field. */
+#define NFCT_INTENCLR_ENDTX_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_ENDTX_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_ENDTX_Clear (1UL) /*!< Disable */
+
+/* Bit 11 : Write '1' to Disable interrupt for ENDRX event */
+#define NFCT_INTENCLR_ENDRX_Pos (11UL) /*!< Position of ENDRX field. */
+#define NFCT_INTENCLR_ENDRX_Msk (0x1UL << NFCT_INTENCLR_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define NFCT_INTENCLR_ENDRX_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_ENDRX_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_ENDRX_Clear (1UL) /*!< Disable */
+
+/* Bit 10 : Write '1' to Disable interrupt for RXERROR event */
+#define NFCT_INTENCLR_RXERROR_Pos (10UL) /*!< Position of RXERROR field. */
+#define NFCT_INTENCLR_RXERROR_Msk (0x1UL << NFCT_INTENCLR_RXERROR_Pos) /*!< Bit mask of RXERROR field. */
+#define NFCT_INTENCLR_RXERROR_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_RXERROR_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_RXERROR_Clear (1UL) /*!< Disable */
+
+/* Bit 7 : Write '1' to Disable interrupt for ERROR event */
+#define NFCT_INTENCLR_ERROR_Pos (7UL) /*!< Position of ERROR field. */
+#define NFCT_INTENCLR_ERROR_Msk (0x1UL << NFCT_INTENCLR_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define NFCT_INTENCLR_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_ERROR_Clear (1UL) /*!< Disable */
+
+/* Bit 6 : Write '1' to Disable interrupt for RXFRAMEEND event */
+#define NFCT_INTENCLR_RXFRAMEEND_Pos (6UL) /*!< Position of RXFRAMEEND field. */
+#define NFCT_INTENCLR_RXFRAMEEND_Msk (0x1UL << NFCT_INTENCLR_RXFRAMEEND_Pos) /*!< Bit mask of RXFRAMEEND field. */
+#define NFCT_INTENCLR_RXFRAMEEND_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_RXFRAMEEND_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_RXFRAMEEND_Clear (1UL) /*!< Disable */
+
+/* Bit 5 : Write '1' to Disable interrupt for RXFRAMESTART event */
+#define NFCT_INTENCLR_RXFRAMESTART_Pos (5UL) /*!< Position of RXFRAMESTART field. */
+#define NFCT_INTENCLR_RXFRAMESTART_Msk (0x1UL << NFCT_INTENCLR_RXFRAMESTART_Pos) /*!< Bit mask of RXFRAMESTART field. */
+#define NFCT_INTENCLR_RXFRAMESTART_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_RXFRAMESTART_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_RXFRAMESTART_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable interrupt for TXFRAMEEND event */
+#define NFCT_INTENCLR_TXFRAMEEND_Pos (4UL) /*!< Position of TXFRAMEEND field. */
+#define NFCT_INTENCLR_TXFRAMEEND_Msk (0x1UL << NFCT_INTENCLR_TXFRAMEEND_Pos) /*!< Bit mask of TXFRAMEEND field. */
+#define NFCT_INTENCLR_TXFRAMEEND_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_TXFRAMEEND_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_TXFRAMEEND_Clear (1UL) /*!< Disable */
+
+/* Bit 3 : Write '1' to Disable interrupt for TXFRAMESTART event */
+#define NFCT_INTENCLR_TXFRAMESTART_Pos (3UL) /*!< Position of TXFRAMESTART field. */
+#define NFCT_INTENCLR_TXFRAMESTART_Msk (0x1UL << NFCT_INTENCLR_TXFRAMESTART_Pos) /*!< Bit mask of TXFRAMESTART field. */
+#define NFCT_INTENCLR_TXFRAMESTART_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_TXFRAMESTART_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_TXFRAMESTART_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for FIELDLOST event */
+#define NFCT_INTENCLR_FIELDLOST_Pos (2UL) /*!< Position of FIELDLOST field. */
+#define NFCT_INTENCLR_FIELDLOST_Msk (0x1UL << NFCT_INTENCLR_FIELDLOST_Pos) /*!< Bit mask of FIELDLOST field. */
+#define NFCT_INTENCLR_FIELDLOST_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_FIELDLOST_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_FIELDLOST_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for FIELDDETECTED event */
+#define NFCT_INTENCLR_FIELDDETECTED_Pos (1UL) /*!< Position of FIELDDETECTED field. */
+#define NFCT_INTENCLR_FIELDDETECTED_Msk (0x1UL << NFCT_INTENCLR_FIELDDETECTED_Pos) /*!< Bit mask of FIELDDETECTED field. */
+#define NFCT_INTENCLR_FIELDDETECTED_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_FIELDDETECTED_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_FIELDDETECTED_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for READY event */
+#define NFCT_INTENCLR_READY_Pos (0UL) /*!< Position of READY field. */
+#define NFCT_INTENCLR_READY_Msk (0x1UL << NFCT_INTENCLR_READY_Pos) /*!< Bit mask of READY field. */
+#define NFCT_INTENCLR_READY_Disabled (0UL) /*!< Read: Disabled */
+#define NFCT_INTENCLR_READY_Enabled (1UL) /*!< Read: Enabled */
+#define NFCT_INTENCLR_READY_Clear (1UL) /*!< Disable */
+
+/* Register: NFCT_ERRORSTATUS */
+/* Description: NFC Error Status register */
+
+/* Bit 6 : No valid End of Frame detected */
+#define NFCT_ERRORSTATUS_EOFERROR_Pos (6UL) /*!< Position of EOFERROR field. */
+#define NFCT_ERRORSTATUS_EOFERROR_Msk (0x1UL << NFCT_ERRORSTATUS_EOFERROR_Pos) /*!< Bit mask of EOFERROR field. */
+
+/* Bit 3 : Field level is too low at min load resistance */
+#define NFCT_ERRORSTATUS_NFCFIELDTOOWEAK_Pos (3UL) /*!< Position of NFCFIELDTOOWEAK field. */
+#define NFCT_ERRORSTATUS_NFCFIELDTOOWEAK_Msk (0x1UL << NFCT_ERRORSTATUS_NFCFIELDTOOWEAK_Pos) /*!< Bit mask of NFCFIELDTOOWEAK field. */
+
+/* Bit 2 : Field level is too high at max load resistance */
+#define NFCT_ERRORSTATUS_NFCFIELDTOOSTRONG_Pos (2UL) /*!< Position of NFCFIELDTOOSTRONG field. */
+#define NFCT_ERRORSTATUS_NFCFIELDTOOSTRONG_Msk (0x1UL << NFCT_ERRORSTATUS_NFCFIELDTOOSTRONG_Pos) /*!< Bit mask of NFCFIELDTOOSTRONG field. */
+
+/* Bit 1 : The received pulse does not match a valid NFC-A symbol */
+#define NFCT_ERRORSTATUS_INVALIDNFCSYMBOL_Pos (1UL) /*!< Position of INVALIDNFCSYMBOL field. */
+#define NFCT_ERRORSTATUS_INVALIDNFCSYMBOL_Msk (0x1UL << NFCT_ERRORSTATUS_INVALIDNFCSYMBOL_Pos) /*!< Bit mask of INVALIDNFCSYMBOL field. */
+
+/* Bit 0 : No STARTTX task triggered before expiration of the time set in FRAMEDELAYMAX */
+#define NFCT_ERRORSTATUS_FRAMEDELAYTIMEOUT_Pos (0UL) /*!< Position of FRAMEDELAYTIMEOUT field. */
+#define NFCT_ERRORSTATUS_FRAMEDELAYTIMEOUT_Msk (0x1UL << NFCT_ERRORSTATUS_FRAMEDELAYTIMEOUT_Pos) /*!< Bit mask of FRAMEDELAYTIMEOUT field. */
+
+/* Register: NFCT_FRAMESTATUS_RX */
+/* Description: Result of last incoming frames */
+
+/* Bit 3 : Overrun detected */
+#define NFCT_FRAMESTATUS_RX_OVERRUN_Pos (3UL) /*!< Position of OVERRUN field. */
+#define NFCT_FRAMESTATUS_RX_OVERRUN_Msk (0x1UL << NFCT_FRAMESTATUS_RX_OVERRUN_Pos) /*!< Bit mask of OVERRUN field. */
+#define NFCT_FRAMESTATUS_RX_OVERRUN_NoOverrun (0UL) /*!< No overrun detected */
+#define NFCT_FRAMESTATUS_RX_OVERRUN_Overrun (1UL) /*!< Overrun error */
+
+/* Bit 2 : Parity status of received frame */
+#define NFCT_FRAMESTATUS_RX_PARITYSTATUS_Pos (2UL) /*!< Position of PARITYSTATUS field. */
+#define NFCT_FRAMESTATUS_RX_PARITYSTATUS_Msk (0x1UL << NFCT_FRAMESTATUS_RX_PARITYSTATUS_Pos) /*!< Bit mask of PARITYSTATUS field. */
+#define NFCT_FRAMESTATUS_RX_PARITYSTATUS_ParityOK (0UL) /*!< Frame received with parity OK */
+#define NFCT_FRAMESTATUS_RX_PARITYSTATUS_ParityError (1UL) /*!< Frame received with parity error */
+
+/* Bit 0 : No valid End of Frame detected */
+#define NFCT_FRAMESTATUS_RX_CRCERROR_Pos (0UL) /*!< Position of CRCERROR field. */
+#define NFCT_FRAMESTATUS_RX_CRCERROR_Msk (0x1UL << NFCT_FRAMESTATUS_RX_CRCERROR_Pos) /*!< Bit mask of CRCERROR field. */
+#define NFCT_FRAMESTATUS_RX_CRCERROR_CRCCorrect (0UL) /*!< Valid CRC detected */
+#define NFCT_FRAMESTATUS_RX_CRCERROR_CRCError (1UL) /*!< CRC received does not match local check */
+
+/* Register: NFCT_CURRENTLOADCTRL */
+/* Description: Current value driven to the NFC Load Control */
+
+/* Bits 5..0 : Current value driven to the NFC Load Control */
+#define NFCT_CURRENTLOADCTRL_CURRENTLOADCTRL_Pos (0UL) /*!< Position of CURRENTLOADCTRL field. */
+#define NFCT_CURRENTLOADCTRL_CURRENTLOADCTRL_Msk (0x3FUL << NFCT_CURRENTLOADCTRL_CURRENTLOADCTRL_Pos) /*!< Bit mask of CURRENTLOADCTRL field. */
+
+/* Register: NFCT_FIELDPRESENT */
+/* Description: Indicates the presence or not of a valid field */
+
+/* Bit 1 : Indicates if the low level has locked to the field */
+#define NFCT_FIELDPRESENT_LOCKDETECT_Pos (1UL) /*!< Position of LOCKDETECT field. */
+#define NFCT_FIELDPRESENT_LOCKDETECT_Msk (0x1UL << NFCT_FIELDPRESENT_LOCKDETECT_Pos) /*!< Bit mask of LOCKDETECT field. */
+#define NFCT_FIELDPRESENT_LOCKDETECT_NotLocked (0UL) /*!< Not locked to field */
+#define NFCT_FIELDPRESENT_LOCKDETECT_Locked (1UL) /*!< Locked to field */
+
+/* Bit 0 : Indicates the presence or not of a valid field. Available only in the activated state. */
+#define NFCT_FIELDPRESENT_FIELDPRESENT_Pos (0UL) /*!< Position of FIELDPRESENT field. */
+#define NFCT_FIELDPRESENT_FIELDPRESENT_Msk (0x1UL << NFCT_FIELDPRESENT_FIELDPRESENT_Pos) /*!< Bit mask of FIELDPRESENT field. */
+#define NFCT_FIELDPRESENT_FIELDPRESENT_NoField (0UL) /*!< No valid field detected */
+#define NFCT_FIELDPRESENT_FIELDPRESENT_FieldPresent (1UL) /*!< Valid field detected */
+
+/* Register: NFCT_FRAMEDELAYMIN */
+/* Description: Minimum frame delay */
+
+/* Bits 15..0 : Minimum frame delay in number of 13.56 MHz clocks */
+#define NFCT_FRAMEDELAYMIN_FRAMEDELAYMIN_Pos (0UL) /*!< Position of FRAMEDELAYMIN field. */
+#define NFCT_FRAMEDELAYMIN_FRAMEDELAYMIN_Msk (0xFFFFUL << NFCT_FRAMEDELAYMIN_FRAMEDELAYMIN_Pos) /*!< Bit mask of FRAMEDELAYMIN field. */
+
+/* Register: NFCT_FRAMEDELAYMAX */
+/* Description: Maximum frame delay */
+
+/* Bits 15..0 : Maximum frame delay in number of 13.56 MHz clocks */
+#define NFCT_FRAMEDELAYMAX_FRAMEDELAYMAX_Pos (0UL) /*!< Position of FRAMEDELAYMAX field. */
+#define NFCT_FRAMEDELAYMAX_FRAMEDELAYMAX_Msk (0xFFFFUL << NFCT_FRAMEDELAYMAX_FRAMEDELAYMAX_Pos) /*!< Bit mask of FRAMEDELAYMAX field. */
+
+/* Register: NFCT_FRAMEDELAYMODE */
+/* Description: Configuration register for the Frame Delay Timer */
+
+/* Bits 1..0 : Configuration register for the Frame Delay Timer */
+#define NFCT_FRAMEDELAYMODE_FRAMEDELAYMODE_Pos (0UL) /*!< Position of FRAMEDELAYMODE field. */
+#define NFCT_FRAMEDELAYMODE_FRAMEDELAYMODE_Msk (0x3UL << NFCT_FRAMEDELAYMODE_FRAMEDELAYMODE_Pos) /*!< Bit mask of FRAMEDELAYMODE field. */
+#define NFCT_FRAMEDELAYMODE_FRAMEDELAYMODE_FreeRun (0UL) /*!< Transmission is independent of frame timer and will start when the STARTTX task is triggered. No timeout. */
+#define NFCT_FRAMEDELAYMODE_FRAMEDELAYMODE_Window (1UL) /*!< Frame is transmitted between FRAMEDELAYMIN and FRAMEDELAYMAX */
+#define NFCT_FRAMEDELAYMODE_FRAMEDELAYMODE_ExactVal (2UL) /*!< Frame is transmitted exactly at FRAMEDELAYMAX */
+#define NFCT_FRAMEDELAYMODE_FRAMEDELAYMODE_WindowGrid (3UL) /*!< Frame is transmitted on a bit grid between FRAMEDELAYMIN and FRAMEDELAYMAX */
+
+/* Register: NFCT_PACKETPTR */
+/* Description: Packet pointer for TXD and RXD data storage in Data RAM */
+
+/* Bits 31..0 : Packet pointer for TXD and RXD data storage in Data RAM. This address is a byte aligned RAM address. */
+#define NFCT_PACKETPTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define NFCT_PACKETPTR_PTR_Msk (0xFFFFFFFFUL << NFCT_PACKETPTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: NFCT_MAXLEN */
+/* Description: Size of allocated for TXD and RXD data storage buffer in Data RAM */
+
+/* Bits 8..0 : Size of allocated for TXD and RXD data storage buffer in Data RAM */
+#define NFCT_MAXLEN_MAXLEN_Pos (0UL) /*!< Position of MAXLEN field. */
+#define NFCT_MAXLEN_MAXLEN_Msk (0x1FFUL << NFCT_MAXLEN_MAXLEN_Pos) /*!< Bit mask of MAXLEN field. */
+
+/* Register: NFCT_TXD_FRAMECONFIG */
+/* Description: Configuration of outgoing frames */
+
+/* Bit 4 : CRC mode for outgoing frames */
+#define NFCT_TXD_FRAMECONFIG_CRCMODETX_Pos (4UL) /*!< Position of CRCMODETX field. */
+#define NFCT_TXD_FRAMECONFIG_CRCMODETX_Msk (0x1UL << NFCT_TXD_FRAMECONFIG_CRCMODETX_Pos) /*!< Bit mask of CRCMODETX field. */
+#define NFCT_TXD_FRAMECONFIG_CRCMODETX_NoCRCTX (0UL) /*!< CRC is not added to the frame */
+#define NFCT_TXD_FRAMECONFIG_CRCMODETX_CRC16TX (1UL) /*!< 16 bit CRC added to the frame based on all the data read from RAM that is used in the frame */
+
+/* Bit 2 : Adding SoF or not in TX frames */
+#define NFCT_TXD_FRAMECONFIG_SOF_Pos (2UL) /*!< Position of SOF field. */
+#define NFCT_TXD_FRAMECONFIG_SOF_Msk (0x1UL << NFCT_TXD_FRAMECONFIG_SOF_Pos) /*!< Bit mask of SOF field. */
+#define NFCT_TXD_FRAMECONFIG_SOF_NoSoF (0UL) /*!< Start of Frame symbol not added */
+#define NFCT_TXD_FRAMECONFIG_SOF_SoF (1UL) /*!< Start of Frame symbol added */
+
+/* Bit 1 : Discarding unused bits in start or at end of a Frame */
+#define NFCT_TXD_FRAMECONFIG_DISCARDMODE_Pos (1UL) /*!< Position of DISCARDMODE field. */
+#define NFCT_TXD_FRAMECONFIG_DISCARDMODE_Msk (0x1UL << NFCT_TXD_FRAMECONFIG_DISCARDMODE_Pos) /*!< Bit mask of DISCARDMODE field. */
+#define NFCT_TXD_FRAMECONFIG_DISCARDMODE_DiscardEnd (0UL) /*!< Unused bits is discarded at end of frame */
+#define NFCT_TXD_FRAMECONFIG_DISCARDMODE_DiscardStart (1UL) /*!< Unused bits is discarded at start of frame */
+
+/* Bit 0 : Adding parity or not in the frame */
+#define NFCT_TXD_FRAMECONFIG_PARITY_Pos (0UL) /*!< Position of PARITY field. */
+#define NFCT_TXD_FRAMECONFIG_PARITY_Msk (0x1UL << NFCT_TXD_FRAMECONFIG_PARITY_Pos) /*!< Bit mask of PARITY field. */
+#define NFCT_TXD_FRAMECONFIG_PARITY_NoParity (0UL) /*!< Parity is not added in TX frames */
+#define NFCT_TXD_FRAMECONFIG_PARITY_Parity (1UL) /*!< Parity is added TX frames */
+
+/* Register: NFCT_TXD_AMOUNT */
+/* Description: Size of outgoing frame */
+
+/* Bits 11..3 : Number of complete bytes that shall be included in the frame, excluding CRC, parity and framing */
+#define NFCT_TXD_AMOUNT_TXDATABYTES_Pos (3UL) /*!< Position of TXDATABYTES field. */
+#define NFCT_TXD_AMOUNT_TXDATABYTES_Msk (0x1FFUL << NFCT_TXD_AMOUNT_TXDATABYTES_Pos) /*!< Bit mask of TXDATABYTES field. */
+
+/* Bits 2..0 : Number of bits in the last or first byte read from RAM that shall be included in the frame (excluding parity bit). */
+#define NFCT_TXD_AMOUNT_TXDATABITS_Pos (0UL) /*!< Position of TXDATABITS field. */
+#define NFCT_TXD_AMOUNT_TXDATABITS_Msk (0x7UL << NFCT_TXD_AMOUNT_TXDATABITS_Pos) /*!< Bit mask of TXDATABITS field. */
+
+/* Register: NFCT_RXD_FRAMECONFIG */
+/* Description: Configuration of incoming frames */
+
+/* Bit 4 : CRC mode for incoming frames */
+#define NFCT_RXD_FRAMECONFIG_CRCMODERX_Pos (4UL) /*!< Position of CRCMODERX field. */
+#define NFCT_RXD_FRAMECONFIG_CRCMODERX_Msk (0x1UL << NFCT_RXD_FRAMECONFIG_CRCMODERX_Pos) /*!< Bit mask of CRCMODERX field. */
+#define NFCT_RXD_FRAMECONFIG_CRCMODERX_NoCRCRX (0UL) /*!< CRC is not expected in RX frames */
+#define NFCT_RXD_FRAMECONFIG_CRCMODERX_CRC16RX (1UL) /*!< Last 16 bits in RX frame is CRC, CRC is checked and CRCSTATUS updated */
+
+/* Bit 2 : SoF expected or not in RX frames */
+#define NFCT_RXD_FRAMECONFIG_SOF_Pos (2UL) /*!< Position of SOF field. */
+#define NFCT_RXD_FRAMECONFIG_SOF_Msk (0x1UL << NFCT_RXD_FRAMECONFIG_SOF_Pos) /*!< Bit mask of SOF field. */
+#define NFCT_RXD_FRAMECONFIG_SOF_NoSoF (0UL) /*!< Start of Frame symbol is not expected in RX frames */
+#define NFCT_RXD_FRAMECONFIG_SOF_SoF (1UL) /*!< Start of Frame symbol is expected in RX frames */
+
+/* Bit 0 : Parity expected or not in RX frame */
+#define NFCT_RXD_FRAMECONFIG_PARITY_Pos (0UL) /*!< Position of PARITY field. */
+#define NFCT_RXD_FRAMECONFIG_PARITY_Msk (0x1UL << NFCT_RXD_FRAMECONFIG_PARITY_Pos) /*!< Bit mask of PARITY field. */
+#define NFCT_RXD_FRAMECONFIG_PARITY_NoParity (0UL) /*!< Parity is not expected in RX frames */
+#define NFCT_RXD_FRAMECONFIG_PARITY_Parity (1UL) /*!< Parity is expected in RX frames */
+
+/* Register: NFCT_RXD_AMOUNT */
+/* Description: Size of last incoming frame */
+
+/* Bits 11..3 : Number of complete bytes received in the frame (including CRC, but excluding parity and SoF/EoF framing) */
+#define NFCT_RXD_AMOUNT_RXDATABYTES_Pos (3UL) /*!< Position of RXDATABYTES field. */
+#define NFCT_RXD_AMOUNT_RXDATABYTES_Msk (0x1FFUL << NFCT_RXD_AMOUNT_RXDATABYTES_Pos) /*!< Bit mask of RXDATABYTES field. */
+
+/* Bits 2..0 : Number of bits in the last byte in the frame, if less than 8 (including CRC, but excluding parity and SoF/EoF framing). */
+#define NFCT_RXD_AMOUNT_RXDATABITS_Pos (0UL) /*!< Position of RXDATABITS field. */
+#define NFCT_RXD_AMOUNT_RXDATABITS_Msk (0x7UL << NFCT_RXD_AMOUNT_RXDATABITS_Pos) /*!< Bit mask of RXDATABITS field. */
+
+/* Register: NFCT_NFCID1_LAST */
+/* Description: Last NFCID1 part (4, 7 or 10 bytes ID) */
+
+/* Bits 31..24 : NFCID1 byte W */
+#define NFCT_NFCID1_LAST_NFCID1_W_Pos (24UL) /*!< Position of NFCID1_W field. */
+#define NFCT_NFCID1_LAST_NFCID1_W_Msk (0xFFUL << NFCT_NFCID1_LAST_NFCID1_W_Pos) /*!< Bit mask of NFCID1_W field. */
+
+/* Bits 23..16 : NFCID1 byte X */
+#define NFCT_NFCID1_LAST_NFCID1_X_Pos (16UL) /*!< Position of NFCID1_X field. */
+#define NFCT_NFCID1_LAST_NFCID1_X_Msk (0xFFUL << NFCT_NFCID1_LAST_NFCID1_X_Pos) /*!< Bit mask of NFCID1_X field. */
+
+/* Bits 15..8 : NFCID1 byte Y */
+#define NFCT_NFCID1_LAST_NFCID1_Y_Pos (8UL) /*!< Position of NFCID1_Y field. */
+#define NFCT_NFCID1_LAST_NFCID1_Y_Msk (0xFFUL << NFCT_NFCID1_LAST_NFCID1_Y_Pos) /*!< Bit mask of NFCID1_Y field. */
+
+/* Bits 7..0 : NFCID1 byte Z (very last byte sent) */
+#define NFCT_NFCID1_LAST_NFCID1_Z_Pos (0UL) /*!< Position of NFCID1_Z field. */
+#define NFCT_NFCID1_LAST_NFCID1_Z_Msk (0xFFUL << NFCT_NFCID1_LAST_NFCID1_Z_Pos) /*!< Bit mask of NFCID1_Z field. */
+
+/* Register: NFCT_NFCID1_2ND_LAST */
+/* Description: Second last NFCID1 part (7 or 10 bytes ID) */
+
+/* Bits 23..16 : NFCID1 byte T */
+#define NFCT_NFCID1_2ND_LAST_NFCID1_T_Pos (16UL) /*!< Position of NFCID1_T field. */
+#define NFCT_NFCID1_2ND_LAST_NFCID1_T_Msk (0xFFUL << NFCT_NFCID1_2ND_LAST_NFCID1_T_Pos) /*!< Bit mask of NFCID1_T field. */
+
+/* Bits 15..8 : NFCID1 byte U */
+#define NFCT_NFCID1_2ND_LAST_NFCID1_U_Pos (8UL) /*!< Position of NFCID1_U field. */
+#define NFCT_NFCID1_2ND_LAST_NFCID1_U_Msk (0xFFUL << NFCT_NFCID1_2ND_LAST_NFCID1_U_Pos) /*!< Bit mask of NFCID1_U field. */
+
+/* Bits 7..0 : NFCID1 byte V */
+#define NFCT_NFCID1_2ND_LAST_NFCID1_V_Pos (0UL) /*!< Position of NFCID1_V field. */
+#define NFCT_NFCID1_2ND_LAST_NFCID1_V_Msk (0xFFUL << NFCT_NFCID1_2ND_LAST_NFCID1_V_Pos) /*!< Bit mask of NFCID1_V field. */
+
+/* Register: NFCT_NFCID1_3RD_LAST */
+/* Description: Third last NFCID1 part (10 bytes ID) */
+
+/* Bits 23..16 : NFCID1 byte Q */
+#define NFCT_NFCID1_3RD_LAST_NFCID1_Q_Pos (16UL) /*!< Position of NFCID1_Q field. */
+#define NFCT_NFCID1_3RD_LAST_NFCID1_Q_Msk (0xFFUL << NFCT_NFCID1_3RD_LAST_NFCID1_Q_Pos) /*!< Bit mask of NFCID1_Q field. */
+
+/* Bits 15..8 : NFCID1 byte R */
+#define NFCT_NFCID1_3RD_LAST_NFCID1_R_Pos (8UL) /*!< Position of NFCID1_R field. */
+#define NFCT_NFCID1_3RD_LAST_NFCID1_R_Msk (0xFFUL << NFCT_NFCID1_3RD_LAST_NFCID1_R_Pos) /*!< Bit mask of NFCID1_R field. */
+
+/* Bits 7..0 : NFCID1 byte S */
+#define NFCT_NFCID1_3RD_LAST_NFCID1_S_Pos (0UL) /*!< Position of NFCID1_S field. */
+#define NFCT_NFCID1_3RD_LAST_NFCID1_S_Msk (0xFFUL << NFCT_NFCID1_3RD_LAST_NFCID1_S_Pos) /*!< Bit mask of NFCID1_S field. */
+
+/* Register: NFCT_SENSRES */
+/* Description: NFC-A SENS_RES auto-response settings */
+
+/* Bits 15..12 : Reserved for future use. Shall be 0. */
+#define NFCT_SENSRES_RFU74_Pos (12UL) /*!< Position of RFU74 field. */
+#define NFCT_SENSRES_RFU74_Msk (0xFUL << NFCT_SENSRES_RFU74_Pos) /*!< Bit mask of RFU74 field. */
+
+/* Bits 11..8 : Tag platform configuration as defined by the b4:b1 of byte 2 in SENS_RES response in the NFC Forum, NFC Digital Protocol Technical Specification */
+#define NFCT_SENSRES_PLATFCONFIG_Pos (8UL) /*!< Position of PLATFCONFIG field. */
+#define NFCT_SENSRES_PLATFCONFIG_Msk (0xFUL << NFCT_SENSRES_PLATFCONFIG_Pos) /*!< Bit mask of PLATFCONFIG field. */
+
+/* Bits 7..6 : NFCID1 size. This value is used by the Auto collision resolution engine. */
+#define NFCT_SENSRES_NFCIDSIZE_Pos (6UL) /*!< Position of NFCIDSIZE field. */
+#define NFCT_SENSRES_NFCIDSIZE_Msk (0x3UL << NFCT_SENSRES_NFCIDSIZE_Pos) /*!< Bit mask of NFCIDSIZE field. */
+#define NFCT_SENSRES_NFCIDSIZE_NFCID1Single (0UL) /*!< NFCID1 size: single (4 bytes) */
+#define NFCT_SENSRES_NFCIDSIZE_NFCID1Double (1UL) /*!< NFCID1 size: double (7 bytes) */
+#define NFCT_SENSRES_NFCIDSIZE_NFCID1Triple (2UL) /*!< NFCID1 size: triple (10 bytes) */
+
+/* Bit 5 : Reserved for future use. Shall be 0. */
+#define NFCT_SENSRES_RFU5_Pos (5UL) /*!< Position of RFU5 field. */
+#define NFCT_SENSRES_RFU5_Msk (0x1UL << NFCT_SENSRES_RFU5_Pos) /*!< Bit mask of RFU5 field. */
+
+/* Bits 4..0 : Bit frame SDD as defined by the b5:b1 of byte 1 in SENS_RES response in the NFC Forum, NFC Digital Protocol Technical Specification */
+#define NFCT_SENSRES_BITFRAMESDD_Pos (0UL) /*!< Position of BITFRAMESDD field. */
+#define NFCT_SENSRES_BITFRAMESDD_Msk (0x1FUL << NFCT_SENSRES_BITFRAMESDD_Pos) /*!< Bit mask of BITFRAMESDD field. */
+#define NFCT_SENSRES_BITFRAMESDD_SDD00000 (0UL) /*!< SDD pattern 00000 */
+#define NFCT_SENSRES_BITFRAMESDD_SDD00001 (1UL) /*!< SDD pattern 00001 */
+#define NFCT_SENSRES_BITFRAMESDD_SDD00010 (2UL) /*!< SDD pattern 00010 */
+#define NFCT_SENSRES_BITFRAMESDD_SDD00100 (4UL) /*!< SDD pattern 00100 */
+#define NFCT_SENSRES_BITFRAMESDD_SDD01000 (8UL) /*!< SDD pattern 01000 */
+#define NFCT_SENSRES_BITFRAMESDD_SDD10000 (16UL) /*!< SDD pattern 10000 */
+
+/* Register: NFCT_SELRES */
+/* Description: NFC-A SEL_RES auto-response settings */
+
+/* Bit 7 : Reserved for future use. Shall be 0. */
+#define NFCT_SELRES_RFU7_Pos (7UL) /*!< Position of RFU7 field. */
+#define NFCT_SELRES_RFU7_Msk (0x1UL << NFCT_SELRES_RFU7_Pos) /*!< Bit mask of RFU7 field. */
+
+/* Bits 6..5 : Protocol as defined by the b7:b6 of SEL_RES response in the NFC Forum, NFC Digital Protocol Technical Specification */
+#define NFCT_SELRES_PROTOCOL_Pos (5UL) /*!< Position of PROTOCOL field. */
+#define NFCT_SELRES_PROTOCOL_Msk (0x3UL << NFCT_SELRES_PROTOCOL_Pos) /*!< Bit mask of PROTOCOL field. */
+
+/* Bits 4..3 : Reserved for future use. Shall be 0. */
+#define NFCT_SELRES_RFU43_Pos (3UL) /*!< Position of RFU43 field. */
+#define NFCT_SELRES_RFU43_Msk (0x3UL << NFCT_SELRES_RFU43_Pos) /*!< Bit mask of RFU43 field. */
+
+/* Bit 2 : Cascade bit (controlled by hardware, write has no effect) */
+#define NFCT_SELRES_CASCADE_Pos (2UL) /*!< Position of CASCADE field. */
+#define NFCT_SELRES_CASCADE_Msk (0x1UL << NFCT_SELRES_CASCADE_Pos) /*!< Bit mask of CASCADE field. */
+#define NFCT_SELRES_CASCADE_Complete (0UL) /*!< NFCID1 complete */
+#define NFCT_SELRES_CASCADE_NotComplete (1UL) /*!< NFCID1 not complete */
+
+/* Bits 1..0 : Reserved for future use. Shall be 0. */
+#define NFCT_SELRES_RFU10_Pos (0UL) /*!< Position of RFU10 field. */
+#define NFCT_SELRES_RFU10_Msk (0x3UL << NFCT_SELRES_RFU10_Pos) /*!< Bit mask of RFU10 field. */
+
+
+/* Peripheral: NVMC */
+/* Description: Non Volatile Memory Controller */
+
+/* Register: NVMC_READY */
+/* Description: Ready flag */
+
+/* Bit 0 : NVMC is ready or busy */
+#define NVMC_READY_READY_Pos (0UL) /*!< Position of READY field. */
+#define NVMC_READY_READY_Msk (0x1UL << NVMC_READY_READY_Pos) /*!< Bit mask of READY field. */
+#define NVMC_READY_READY_Busy (0UL) /*!< NVMC is busy (on-going write or erase operation) */
+#define NVMC_READY_READY_Ready (1UL) /*!< NVMC is ready */
+
+/* Register: NVMC_CONFIG */
+/* Description: Configuration register */
+
+/* Bits 1..0 : Program memory access mode. It is strongly recommended to only activate erase and write modes when they are actively used. Enabling write or erase will invalidate the cache and keep it invalidated. */
+#define NVMC_CONFIG_WEN_Pos (0UL) /*!< Position of WEN field. */
+#define NVMC_CONFIG_WEN_Msk (0x3UL << NVMC_CONFIG_WEN_Pos) /*!< Bit mask of WEN field. */
+#define NVMC_CONFIG_WEN_Ren (0UL) /*!< Read only access */
+#define NVMC_CONFIG_WEN_Wen (1UL) /*!< Write Enabled */
+#define NVMC_CONFIG_WEN_Een (2UL) /*!< Erase enabled */
+
+/* Register: NVMC_ERASEPAGE */
+/* Description: Register for erasing a page in Code area */
+
+/* Bits 31..0 : Register for starting erase of a page in Code area */
+#define NVMC_ERASEPAGE_ERASEPAGE_Pos (0UL) /*!< Position of ERASEPAGE field. */
+#define NVMC_ERASEPAGE_ERASEPAGE_Msk (0xFFFFFFFFUL << NVMC_ERASEPAGE_ERASEPAGE_Pos) /*!< Bit mask of ERASEPAGE field. */
+
+/* Register: NVMC_ERASEPCR1 */
+/* Description: Deprecated register -  Register for erasing a page in Code area. Equivalent to ERASEPAGE. */
+
+/* Bits 31..0 : Register for erasing a page in Code area. Equivalent to ERASEPAGE. */
+#define NVMC_ERASEPCR1_ERASEPCR1_Pos (0UL) /*!< Position of ERASEPCR1 field. */
+#define NVMC_ERASEPCR1_ERASEPCR1_Msk (0xFFFFFFFFUL << NVMC_ERASEPCR1_ERASEPCR1_Pos) /*!< Bit mask of ERASEPCR1 field. */
+
+/* Register: NVMC_ERASEALL */
+/* Description: Register for erasing all non-volatile user memory */
+
+/* Bit 0 : Erase all non-volatile memory including UICR registers. Note that code erase has to be enabled by CONFIG.EEN before the UICR can be erased. */
+#define NVMC_ERASEALL_ERASEALL_Pos (0UL) /*!< Position of ERASEALL field. */
+#define NVMC_ERASEALL_ERASEALL_Msk (0x1UL << NVMC_ERASEALL_ERASEALL_Pos) /*!< Bit mask of ERASEALL field. */
+#define NVMC_ERASEALL_ERASEALL_NoOperation (0UL) /*!< No operation */
+#define NVMC_ERASEALL_ERASEALL_Erase (1UL) /*!< Start chip erase */
+
+/* Register: NVMC_ERASEPCR0 */
+/* Description: Deprecated register -  Register for erasing a page in Code area. Equivalent to ERASEPAGE. */
+
+/* Bits 31..0 : Register for starting erase of a page in Code area. Equivalent to ERASEPAGE. */
+#define NVMC_ERASEPCR0_ERASEPCR0_Pos (0UL) /*!< Position of ERASEPCR0 field. */
+#define NVMC_ERASEPCR0_ERASEPCR0_Msk (0xFFFFFFFFUL << NVMC_ERASEPCR0_ERASEPCR0_Pos) /*!< Bit mask of ERASEPCR0 field. */
+
+/* Register: NVMC_ERASEUICR */
+/* Description: Register for erasing User Information Configuration Registers */
+
+/* Bit 0 : Register starting erase of all User Information Configuration Registers. Note that code erase has to be enabled by CONFIG.EEN before the UICR can be erased. */
+#define NVMC_ERASEUICR_ERASEUICR_Pos (0UL) /*!< Position of ERASEUICR field. */
+#define NVMC_ERASEUICR_ERASEUICR_Msk (0x1UL << NVMC_ERASEUICR_ERASEUICR_Pos) /*!< Bit mask of ERASEUICR field. */
+#define NVMC_ERASEUICR_ERASEUICR_NoOperation (0UL) /*!< No operation */
+#define NVMC_ERASEUICR_ERASEUICR_Erase (1UL) /*!< Start erase of UICR */
+
+/* Register: NVMC_ICACHECNF */
+/* Description: I-Code cache configuration register. */
+
+/* Bit 8 : Cache profiling enable */
+#define NVMC_ICACHECNF_CACHEPROFEN_Pos (8UL) /*!< Position of CACHEPROFEN field. */
+#define NVMC_ICACHECNF_CACHEPROFEN_Msk (0x1UL << NVMC_ICACHECNF_CACHEPROFEN_Pos) /*!< Bit mask of CACHEPROFEN field. */
+#define NVMC_ICACHECNF_CACHEPROFEN_Disabled (0UL) /*!< Disable cache profiling */
+#define NVMC_ICACHECNF_CACHEPROFEN_Enabled (1UL) /*!< Enable cache profiling */
+
+/* Bit 0 : Cache enable */
+#define NVMC_ICACHECNF_CACHEEN_Pos (0UL) /*!< Position of CACHEEN field. */
+#define NVMC_ICACHECNF_CACHEEN_Msk (0x1UL << NVMC_ICACHECNF_CACHEEN_Pos) /*!< Bit mask of CACHEEN field. */
+#define NVMC_ICACHECNF_CACHEEN_Disabled (0UL) /*!< Disable cache. Invalidates all cache entries. */
+#define NVMC_ICACHECNF_CACHEEN_Enabled (1UL) /*!< Enable cache */
+
+/* Register: NVMC_IHIT */
+/* Description: I-Code cache hit counter. */
+
+/* Bits 31..0 : Number of cache hits */
+#define NVMC_IHIT_HITS_Pos (0UL) /*!< Position of HITS field. */
+#define NVMC_IHIT_HITS_Msk (0xFFFFFFFFUL << NVMC_IHIT_HITS_Pos) /*!< Bit mask of HITS field. */
+
+/* Register: NVMC_IMISS */
+/* Description: I-Code cache miss counter. */
+
+/* Bits 31..0 : Number of cache misses */
+#define NVMC_IMISS_MISSES_Pos (0UL) /*!< Position of MISSES field. */
+#define NVMC_IMISS_MISSES_Msk (0xFFFFFFFFUL << NVMC_IMISS_MISSES_Pos) /*!< Bit mask of MISSES field. */
+
+
+/* Peripheral: GPIO */
+/* Description: GPIO Port 1 */
+
+/* Register: GPIO_OUT */
+/* Description: Write GPIO port */
+
+/* Bit 31 : P0.31 pin */
+#define GPIO_OUT_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_OUT_PIN31_Msk (0x1UL << GPIO_OUT_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_OUT_PIN31_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN31_High (1UL) /*!< Pin driver is high */
+
+/* Bit 30 : P0.30 pin */
+#define GPIO_OUT_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_OUT_PIN30_Msk (0x1UL << GPIO_OUT_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_OUT_PIN30_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN30_High (1UL) /*!< Pin driver is high */
+
+/* Bit 29 : P0.29 pin */
+#define GPIO_OUT_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_OUT_PIN29_Msk (0x1UL << GPIO_OUT_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_OUT_PIN29_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN29_High (1UL) /*!< Pin driver is high */
+
+/* Bit 28 : P0.28 pin */
+#define GPIO_OUT_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_OUT_PIN28_Msk (0x1UL << GPIO_OUT_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_OUT_PIN28_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN28_High (1UL) /*!< Pin driver is high */
+
+/* Bit 27 : P0.27 pin */
+#define GPIO_OUT_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_OUT_PIN27_Msk (0x1UL << GPIO_OUT_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_OUT_PIN27_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN27_High (1UL) /*!< Pin driver is high */
+
+/* Bit 26 : P0.26 pin */
+#define GPIO_OUT_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_OUT_PIN26_Msk (0x1UL << GPIO_OUT_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_OUT_PIN26_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN26_High (1UL) /*!< Pin driver is high */
+
+/* Bit 25 : P0.25 pin */
+#define GPIO_OUT_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_OUT_PIN25_Msk (0x1UL << GPIO_OUT_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_OUT_PIN25_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN25_High (1UL) /*!< Pin driver is high */
+
+/* Bit 24 : P0.24 pin */
+#define GPIO_OUT_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_OUT_PIN24_Msk (0x1UL << GPIO_OUT_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_OUT_PIN24_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN24_High (1UL) /*!< Pin driver is high */
+
+/* Bit 23 : P0.23 pin */
+#define GPIO_OUT_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_OUT_PIN23_Msk (0x1UL << GPIO_OUT_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_OUT_PIN23_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN23_High (1UL) /*!< Pin driver is high */
+
+/* Bit 22 : P0.22 pin */
+#define GPIO_OUT_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_OUT_PIN22_Msk (0x1UL << GPIO_OUT_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_OUT_PIN22_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN22_High (1UL) /*!< Pin driver is high */
+
+/* Bit 21 : P0.21 pin */
+#define GPIO_OUT_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_OUT_PIN21_Msk (0x1UL << GPIO_OUT_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_OUT_PIN21_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN21_High (1UL) /*!< Pin driver is high */
+
+/* Bit 20 : P0.20 pin */
+#define GPIO_OUT_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_OUT_PIN20_Msk (0x1UL << GPIO_OUT_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_OUT_PIN20_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN20_High (1UL) /*!< Pin driver is high */
+
+/* Bit 19 : P0.19 pin */
+#define GPIO_OUT_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_OUT_PIN19_Msk (0x1UL << GPIO_OUT_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_OUT_PIN19_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN19_High (1UL) /*!< Pin driver is high */
+
+/* Bit 18 : P0.18 pin */
+#define GPIO_OUT_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_OUT_PIN18_Msk (0x1UL << GPIO_OUT_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_OUT_PIN18_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN18_High (1UL) /*!< Pin driver is high */
+
+/* Bit 17 : P0.17 pin */
+#define GPIO_OUT_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_OUT_PIN17_Msk (0x1UL << GPIO_OUT_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_OUT_PIN17_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN17_High (1UL) /*!< Pin driver is high */
+
+/* Bit 16 : P0.16 pin */
+#define GPIO_OUT_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_OUT_PIN16_Msk (0x1UL << GPIO_OUT_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_OUT_PIN16_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN16_High (1UL) /*!< Pin driver is high */
+
+/* Bit 15 : P0.15 pin */
+#define GPIO_OUT_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_OUT_PIN15_Msk (0x1UL << GPIO_OUT_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_OUT_PIN15_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN15_High (1UL) /*!< Pin driver is high */
+
+/* Bit 14 : P0.14 pin */
+#define GPIO_OUT_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_OUT_PIN14_Msk (0x1UL << GPIO_OUT_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_OUT_PIN14_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN14_High (1UL) /*!< Pin driver is high */
+
+/* Bit 13 : P0.13 pin */
+#define GPIO_OUT_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_OUT_PIN13_Msk (0x1UL << GPIO_OUT_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_OUT_PIN13_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN13_High (1UL) /*!< Pin driver is high */
+
+/* Bit 12 : P0.12 pin */
+#define GPIO_OUT_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_OUT_PIN12_Msk (0x1UL << GPIO_OUT_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_OUT_PIN12_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN12_High (1UL) /*!< Pin driver is high */
+
+/* Bit 11 : P0.11 pin */
+#define GPIO_OUT_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_OUT_PIN11_Msk (0x1UL << GPIO_OUT_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_OUT_PIN11_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN11_High (1UL) /*!< Pin driver is high */
+
+/* Bit 10 : P0.10 pin */
+#define GPIO_OUT_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_OUT_PIN10_Msk (0x1UL << GPIO_OUT_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_OUT_PIN10_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN10_High (1UL) /*!< Pin driver is high */
+
+/* Bit 9 : P0.9 pin */
+#define GPIO_OUT_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_OUT_PIN9_Msk (0x1UL << GPIO_OUT_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_OUT_PIN9_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN9_High (1UL) /*!< Pin driver is high */
+
+/* Bit 8 : P0.8 pin */
+#define GPIO_OUT_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_OUT_PIN8_Msk (0x1UL << GPIO_OUT_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_OUT_PIN8_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN8_High (1UL) /*!< Pin driver is high */
+
+/* Bit 7 : P0.7 pin */
+#define GPIO_OUT_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_OUT_PIN7_Msk (0x1UL << GPIO_OUT_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_OUT_PIN7_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN7_High (1UL) /*!< Pin driver is high */
+
+/* Bit 6 : P0.6 pin */
+#define GPIO_OUT_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_OUT_PIN6_Msk (0x1UL << GPIO_OUT_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_OUT_PIN6_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN6_High (1UL) /*!< Pin driver is high */
+
+/* Bit 5 : P0.5 pin */
+#define GPIO_OUT_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_OUT_PIN5_Msk (0x1UL << GPIO_OUT_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_OUT_PIN5_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN5_High (1UL) /*!< Pin driver is high */
+
+/* Bit 4 : P0.4 pin */
+#define GPIO_OUT_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_OUT_PIN4_Msk (0x1UL << GPIO_OUT_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_OUT_PIN4_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN4_High (1UL) /*!< Pin driver is high */
+
+/* Bit 3 : P0.3 pin */
+#define GPIO_OUT_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_OUT_PIN3_Msk (0x1UL << GPIO_OUT_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_OUT_PIN3_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN3_High (1UL) /*!< Pin driver is high */
+
+/* Bit 2 : P0.2 pin */
+#define GPIO_OUT_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_OUT_PIN2_Msk (0x1UL << GPIO_OUT_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_OUT_PIN2_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN2_High (1UL) /*!< Pin driver is high */
+
+/* Bit 1 : P0.1 pin */
+#define GPIO_OUT_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_OUT_PIN1_Msk (0x1UL << GPIO_OUT_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_OUT_PIN1_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN1_High (1UL) /*!< Pin driver is high */
+
+/* Bit 0 : P0.0 pin */
+#define GPIO_OUT_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_OUT_PIN0_Msk (0x1UL << GPIO_OUT_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_OUT_PIN0_Low (0UL) /*!< Pin driver is low */
+#define GPIO_OUT_PIN0_High (1UL) /*!< Pin driver is high */
+
+/* Register: GPIO_OUTSET */
+/* Description: Set individual bits in GPIO port */
+
+/* Bit 31 : P0.31 pin */
+#define GPIO_OUTSET_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_OUTSET_PIN31_Msk (0x1UL << GPIO_OUTSET_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_OUTSET_PIN31_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN31_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN31_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 30 : P0.30 pin */
+#define GPIO_OUTSET_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_OUTSET_PIN30_Msk (0x1UL << GPIO_OUTSET_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_OUTSET_PIN30_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN30_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN30_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 29 : P0.29 pin */
+#define GPIO_OUTSET_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_OUTSET_PIN29_Msk (0x1UL << GPIO_OUTSET_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_OUTSET_PIN29_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN29_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN29_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 28 : P0.28 pin */
+#define GPIO_OUTSET_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_OUTSET_PIN28_Msk (0x1UL << GPIO_OUTSET_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_OUTSET_PIN28_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN28_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN28_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 27 : P0.27 pin */
+#define GPIO_OUTSET_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_OUTSET_PIN27_Msk (0x1UL << GPIO_OUTSET_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_OUTSET_PIN27_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN27_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN27_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 26 : P0.26 pin */
+#define GPIO_OUTSET_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_OUTSET_PIN26_Msk (0x1UL << GPIO_OUTSET_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_OUTSET_PIN26_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN26_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN26_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 25 : P0.25 pin */
+#define GPIO_OUTSET_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_OUTSET_PIN25_Msk (0x1UL << GPIO_OUTSET_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_OUTSET_PIN25_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN25_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN25_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 24 : P0.24 pin */
+#define GPIO_OUTSET_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_OUTSET_PIN24_Msk (0x1UL << GPIO_OUTSET_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_OUTSET_PIN24_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN24_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN24_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 23 : P0.23 pin */
+#define GPIO_OUTSET_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_OUTSET_PIN23_Msk (0x1UL << GPIO_OUTSET_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_OUTSET_PIN23_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN23_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN23_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 22 : P0.22 pin */
+#define GPIO_OUTSET_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_OUTSET_PIN22_Msk (0x1UL << GPIO_OUTSET_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_OUTSET_PIN22_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN22_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN22_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 21 : P0.21 pin */
+#define GPIO_OUTSET_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_OUTSET_PIN21_Msk (0x1UL << GPIO_OUTSET_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_OUTSET_PIN21_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN21_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN21_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 20 : P0.20 pin */
+#define GPIO_OUTSET_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_OUTSET_PIN20_Msk (0x1UL << GPIO_OUTSET_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_OUTSET_PIN20_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN20_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN20_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 19 : P0.19 pin */
+#define GPIO_OUTSET_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_OUTSET_PIN19_Msk (0x1UL << GPIO_OUTSET_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_OUTSET_PIN19_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN19_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN19_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 18 : P0.18 pin */
+#define GPIO_OUTSET_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_OUTSET_PIN18_Msk (0x1UL << GPIO_OUTSET_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_OUTSET_PIN18_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN18_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN18_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 17 : P0.17 pin */
+#define GPIO_OUTSET_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_OUTSET_PIN17_Msk (0x1UL << GPIO_OUTSET_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_OUTSET_PIN17_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN17_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN17_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 16 : P0.16 pin */
+#define GPIO_OUTSET_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_OUTSET_PIN16_Msk (0x1UL << GPIO_OUTSET_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_OUTSET_PIN16_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN16_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN16_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 15 : P0.15 pin */
+#define GPIO_OUTSET_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_OUTSET_PIN15_Msk (0x1UL << GPIO_OUTSET_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_OUTSET_PIN15_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN15_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN15_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 14 : P0.14 pin */
+#define GPIO_OUTSET_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_OUTSET_PIN14_Msk (0x1UL << GPIO_OUTSET_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_OUTSET_PIN14_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN14_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN14_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 13 : P0.13 pin */
+#define GPIO_OUTSET_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_OUTSET_PIN13_Msk (0x1UL << GPIO_OUTSET_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_OUTSET_PIN13_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN13_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN13_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 12 : P0.12 pin */
+#define GPIO_OUTSET_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_OUTSET_PIN12_Msk (0x1UL << GPIO_OUTSET_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_OUTSET_PIN12_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN12_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN12_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 11 : P0.11 pin */
+#define GPIO_OUTSET_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_OUTSET_PIN11_Msk (0x1UL << GPIO_OUTSET_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_OUTSET_PIN11_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN11_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN11_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 10 : P0.10 pin */
+#define GPIO_OUTSET_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_OUTSET_PIN10_Msk (0x1UL << GPIO_OUTSET_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_OUTSET_PIN10_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN10_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN10_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 9 : P0.9 pin */
+#define GPIO_OUTSET_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_OUTSET_PIN9_Msk (0x1UL << GPIO_OUTSET_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_OUTSET_PIN9_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN9_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN9_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 8 : P0.8 pin */
+#define GPIO_OUTSET_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_OUTSET_PIN8_Msk (0x1UL << GPIO_OUTSET_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_OUTSET_PIN8_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN8_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN8_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 7 : P0.7 pin */
+#define GPIO_OUTSET_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_OUTSET_PIN7_Msk (0x1UL << GPIO_OUTSET_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_OUTSET_PIN7_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN7_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN7_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 6 : P0.6 pin */
+#define GPIO_OUTSET_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_OUTSET_PIN6_Msk (0x1UL << GPIO_OUTSET_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_OUTSET_PIN6_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN6_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN6_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 5 : P0.5 pin */
+#define GPIO_OUTSET_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_OUTSET_PIN5_Msk (0x1UL << GPIO_OUTSET_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_OUTSET_PIN5_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN5_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN5_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 4 : P0.4 pin */
+#define GPIO_OUTSET_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_OUTSET_PIN4_Msk (0x1UL << GPIO_OUTSET_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_OUTSET_PIN4_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN4_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN4_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 3 : P0.3 pin */
+#define GPIO_OUTSET_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_OUTSET_PIN3_Msk (0x1UL << GPIO_OUTSET_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_OUTSET_PIN3_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN3_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN3_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 2 : P0.2 pin */
+#define GPIO_OUTSET_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_OUTSET_PIN2_Msk (0x1UL << GPIO_OUTSET_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_OUTSET_PIN2_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN2_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN2_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 1 : P0.1 pin */
+#define GPIO_OUTSET_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_OUTSET_PIN1_Msk (0x1UL << GPIO_OUTSET_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_OUTSET_PIN1_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN1_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN1_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Bit 0 : P0.0 pin */
+#define GPIO_OUTSET_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_OUTSET_PIN0_Msk (0x1UL << GPIO_OUTSET_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_OUTSET_PIN0_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTSET_PIN0_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTSET_PIN0_Set (1UL) /*!< Write: writing a '1' sets the pin high; writing a '0' has no effect */
+
+/* Register: GPIO_OUTCLR */
+/* Description: Clear individual bits in GPIO port */
+
+/* Bit 31 : P0.31 pin */
+#define GPIO_OUTCLR_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_OUTCLR_PIN31_Msk (0x1UL << GPIO_OUTCLR_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_OUTCLR_PIN31_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN31_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN31_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 30 : P0.30 pin */
+#define GPIO_OUTCLR_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_OUTCLR_PIN30_Msk (0x1UL << GPIO_OUTCLR_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_OUTCLR_PIN30_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN30_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN30_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 29 : P0.29 pin */
+#define GPIO_OUTCLR_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_OUTCLR_PIN29_Msk (0x1UL << GPIO_OUTCLR_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_OUTCLR_PIN29_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN29_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN29_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 28 : P0.28 pin */
+#define GPIO_OUTCLR_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_OUTCLR_PIN28_Msk (0x1UL << GPIO_OUTCLR_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_OUTCLR_PIN28_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN28_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN28_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 27 : P0.27 pin */
+#define GPIO_OUTCLR_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_OUTCLR_PIN27_Msk (0x1UL << GPIO_OUTCLR_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_OUTCLR_PIN27_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN27_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN27_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 26 : P0.26 pin */
+#define GPIO_OUTCLR_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_OUTCLR_PIN26_Msk (0x1UL << GPIO_OUTCLR_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_OUTCLR_PIN26_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN26_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN26_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 25 : P0.25 pin */
+#define GPIO_OUTCLR_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_OUTCLR_PIN25_Msk (0x1UL << GPIO_OUTCLR_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_OUTCLR_PIN25_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN25_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN25_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 24 : P0.24 pin */
+#define GPIO_OUTCLR_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_OUTCLR_PIN24_Msk (0x1UL << GPIO_OUTCLR_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_OUTCLR_PIN24_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN24_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN24_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 23 : P0.23 pin */
+#define GPIO_OUTCLR_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_OUTCLR_PIN23_Msk (0x1UL << GPIO_OUTCLR_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_OUTCLR_PIN23_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN23_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN23_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 22 : P0.22 pin */
+#define GPIO_OUTCLR_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_OUTCLR_PIN22_Msk (0x1UL << GPIO_OUTCLR_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_OUTCLR_PIN22_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN22_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN22_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 21 : P0.21 pin */
+#define GPIO_OUTCLR_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_OUTCLR_PIN21_Msk (0x1UL << GPIO_OUTCLR_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_OUTCLR_PIN21_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN21_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN21_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 20 : P0.20 pin */
+#define GPIO_OUTCLR_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_OUTCLR_PIN20_Msk (0x1UL << GPIO_OUTCLR_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_OUTCLR_PIN20_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN20_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN20_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 19 : P0.19 pin */
+#define GPIO_OUTCLR_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_OUTCLR_PIN19_Msk (0x1UL << GPIO_OUTCLR_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_OUTCLR_PIN19_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN19_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN19_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 18 : P0.18 pin */
+#define GPIO_OUTCLR_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_OUTCLR_PIN18_Msk (0x1UL << GPIO_OUTCLR_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_OUTCLR_PIN18_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN18_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN18_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 17 : P0.17 pin */
+#define GPIO_OUTCLR_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_OUTCLR_PIN17_Msk (0x1UL << GPIO_OUTCLR_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_OUTCLR_PIN17_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN17_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN17_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 16 : P0.16 pin */
+#define GPIO_OUTCLR_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_OUTCLR_PIN16_Msk (0x1UL << GPIO_OUTCLR_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_OUTCLR_PIN16_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN16_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN16_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 15 : P0.15 pin */
+#define GPIO_OUTCLR_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_OUTCLR_PIN15_Msk (0x1UL << GPIO_OUTCLR_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_OUTCLR_PIN15_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN15_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN15_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 14 : P0.14 pin */
+#define GPIO_OUTCLR_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_OUTCLR_PIN14_Msk (0x1UL << GPIO_OUTCLR_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_OUTCLR_PIN14_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN14_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN14_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 13 : P0.13 pin */
+#define GPIO_OUTCLR_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_OUTCLR_PIN13_Msk (0x1UL << GPIO_OUTCLR_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_OUTCLR_PIN13_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN13_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN13_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 12 : P0.12 pin */
+#define GPIO_OUTCLR_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_OUTCLR_PIN12_Msk (0x1UL << GPIO_OUTCLR_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_OUTCLR_PIN12_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN12_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN12_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 11 : P0.11 pin */
+#define GPIO_OUTCLR_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_OUTCLR_PIN11_Msk (0x1UL << GPIO_OUTCLR_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_OUTCLR_PIN11_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN11_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN11_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 10 : P0.10 pin */
+#define GPIO_OUTCLR_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_OUTCLR_PIN10_Msk (0x1UL << GPIO_OUTCLR_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_OUTCLR_PIN10_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN10_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN10_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 9 : P0.9 pin */
+#define GPIO_OUTCLR_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_OUTCLR_PIN9_Msk (0x1UL << GPIO_OUTCLR_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_OUTCLR_PIN9_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN9_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN9_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 8 : P0.8 pin */
+#define GPIO_OUTCLR_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_OUTCLR_PIN8_Msk (0x1UL << GPIO_OUTCLR_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_OUTCLR_PIN8_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN8_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN8_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 7 : P0.7 pin */
+#define GPIO_OUTCLR_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_OUTCLR_PIN7_Msk (0x1UL << GPIO_OUTCLR_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_OUTCLR_PIN7_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN7_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN7_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 6 : P0.6 pin */
+#define GPIO_OUTCLR_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_OUTCLR_PIN6_Msk (0x1UL << GPIO_OUTCLR_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_OUTCLR_PIN6_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN6_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN6_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 5 : P0.5 pin */
+#define GPIO_OUTCLR_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_OUTCLR_PIN5_Msk (0x1UL << GPIO_OUTCLR_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_OUTCLR_PIN5_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN5_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN5_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 4 : P0.4 pin */
+#define GPIO_OUTCLR_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_OUTCLR_PIN4_Msk (0x1UL << GPIO_OUTCLR_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_OUTCLR_PIN4_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN4_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN4_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 3 : P0.3 pin */
+#define GPIO_OUTCLR_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_OUTCLR_PIN3_Msk (0x1UL << GPIO_OUTCLR_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_OUTCLR_PIN3_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN3_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN3_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 2 : P0.2 pin */
+#define GPIO_OUTCLR_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_OUTCLR_PIN2_Msk (0x1UL << GPIO_OUTCLR_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_OUTCLR_PIN2_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN2_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN2_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 1 : P0.1 pin */
+#define GPIO_OUTCLR_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_OUTCLR_PIN1_Msk (0x1UL << GPIO_OUTCLR_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_OUTCLR_PIN1_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN1_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN1_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Bit 0 : P0.0 pin */
+#define GPIO_OUTCLR_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_OUTCLR_PIN0_Msk (0x1UL << GPIO_OUTCLR_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_OUTCLR_PIN0_Low (0UL) /*!< Read: pin driver is low */
+#define GPIO_OUTCLR_PIN0_High (1UL) /*!< Read: pin driver is high */
+#define GPIO_OUTCLR_PIN0_Clear (1UL) /*!< Write: writing a '1' sets the pin low; writing a '0' has no effect */
+
+/* Register: GPIO_IN */
+/* Description: Read GPIO port */
+
+/* Bit 31 : P0.31 pin */
+#define GPIO_IN_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_IN_PIN31_Msk (0x1UL << GPIO_IN_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_IN_PIN31_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN31_High (1UL) /*!< Pin input is high */
+
+/* Bit 30 : P0.30 pin */
+#define GPIO_IN_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_IN_PIN30_Msk (0x1UL << GPIO_IN_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_IN_PIN30_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN30_High (1UL) /*!< Pin input is high */
+
+/* Bit 29 : P0.29 pin */
+#define GPIO_IN_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_IN_PIN29_Msk (0x1UL << GPIO_IN_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_IN_PIN29_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN29_High (1UL) /*!< Pin input is high */
+
+/* Bit 28 : P0.28 pin */
+#define GPIO_IN_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_IN_PIN28_Msk (0x1UL << GPIO_IN_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_IN_PIN28_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN28_High (1UL) /*!< Pin input is high */
+
+/* Bit 27 : P0.27 pin */
+#define GPIO_IN_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_IN_PIN27_Msk (0x1UL << GPIO_IN_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_IN_PIN27_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN27_High (1UL) /*!< Pin input is high */
+
+/* Bit 26 : P0.26 pin */
+#define GPIO_IN_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_IN_PIN26_Msk (0x1UL << GPIO_IN_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_IN_PIN26_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN26_High (1UL) /*!< Pin input is high */
+
+/* Bit 25 : P0.25 pin */
+#define GPIO_IN_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_IN_PIN25_Msk (0x1UL << GPIO_IN_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_IN_PIN25_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN25_High (1UL) /*!< Pin input is high */
+
+/* Bit 24 : P0.24 pin */
+#define GPIO_IN_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_IN_PIN24_Msk (0x1UL << GPIO_IN_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_IN_PIN24_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN24_High (1UL) /*!< Pin input is high */
+
+/* Bit 23 : P0.23 pin */
+#define GPIO_IN_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_IN_PIN23_Msk (0x1UL << GPIO_IN_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_IN_PIN23_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN23_High (1UL) /*!< Pin input is high */
+
+/* Bit 22 : P0.22 pin */
+#define GPIO_IN_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_IN_PIN22_Msk (0x1UL << GPIO_IN_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_IN_PIN22_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN22_High (1UL) /*!< Pin input is high */
+
+/* Bit 21 : P0.21 pin */
+#define GPIO_IN_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_IN_PIN21_Msk (0x1UL << GPIO_IN_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_IN_PIN21_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN21_High (1UL) /*!< Pin input is high */
+
+/* Bit 20 : P0.20 pin */
+#define GPIO_IN_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_IN_PIN20_Msk (0x1UL << GPIO_IN_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_IN_PIN20_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN20_High (1UL) /*!< Pin input is high */
+
+/* Bit 19 : P0.19 pin */
+#define GPIO_IN_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_IN_PIN19_Msk (0x1UL << GPIO_IN_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_IN_PIN19_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN19_High (1UL) /*!< Pin input is high */
+
+/* Bit 18 : P0.18 pin */
+#define GPIO_IN_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_IN_PIN18_Msk (0x1UL << GPIO_IN_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_IN_PIN18_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN18_High (1UL) /*!< Pin input is high */
+
+/* Bit 17 : P0.17 pin */
+#define GPIO_IN_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_IN_PIN17_Msk (0x1UL << GPIO_IN_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_IN_PIN17_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN17_High (1UL) /*!< Pin input is high */
+
+/* Bit 16 : P0.16 pin */
+#define GPIO_IN_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_IN_PIN16_Msk (0x1UL << GPIO_IN_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_IN_PIN16_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN16_High (1UL) /*!< Pin input is high */
+
+/* Bit 15 : P0.15 pin */
+#define GPIO_IN_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_IN_PIN15_Msk (0x1UL << GPIO_IN_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_IN_PIN15_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN15_High (1UL) /*!< Pin input is high */
+
+/* Bit 14 : P0.14 pin */
+#define GPIO_IN_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_IN_PIN14_Msk (0x1UL << GPIO_IN_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_IN_PIN14_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN14_High (1UL) /*!< Pin input is high */
+
+/* Bit 13 : P0.13 pin */
+#define GPIO_IN_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_IN_PIN13_Msk (0x1UL << GPIO_IN_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_IN_PIN13_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN13_High (1UL) /*!< Pin input is high */
+
+/* Bit 12 : P0.12 pin */
+#define GPIO_IN_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_IN_PIN12_Msk (0x1UL << GPIO_IN_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_IN_PIN12_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN12_High (1UL) /*!< Pin input is high */
+
+/* Bit 11 : P0.11 pin */
+#define GPIO_IN_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_IN_PIN11_Msk (0x1UL << GPIO_IN_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_IN_PIN11_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN11_High (1UL) /*!< Pin input is high */
+
+/* Bit 10 : P0.10 pin */
+#define GPIO_IN_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_IN_PIN10_Msk (0x1UL << GPIO_IN_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_IN_PIN10_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN10_High (1UL) /*!< Pin input is high */
+
+/* Bit 9 : P0.9 pin */
+#define GPIO_IN_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_IN_PIN9_Msk (0x1UL << GPIO_IN_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_IN_PIN9_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN9_High (1UL) /*!< Pin input is high */
+
+/* Bit 8 : P0.8 pin */
+#define GPIO_IN_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_IN_PIN8_Msk (0x1UL << GPIO_IN_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_IN_PIN8_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN8_High (1UL) /*!< Pin input is high */
+
+/* Bit 7 : P0.7 pin */
+#define GPIO_IN_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_IN_PIN7_Msk (0x1UL << GPIO_IN_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_IN_PIN7_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN7_High (1UL) /*!< Pin input is high */
+
+/* Bit 6 : P0.6 pin */
+#define GPIO_IN_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_IN_PIN6_Msk (0x1UL << GPIO_IN_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_IN_PIN6_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN6_High (1UL) /*!< Pin input is high */
+
+/* Bit 5 : P0.5 pin */
+#define GPIO_IN_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_IN_PIN5_Msk (0x1UL << GPIO_IN_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_IN_PIN5_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN5_High (1UL) /*!< Pin input is high */
+
+/* Bit 4 : P0.4 pin */
+#define GPIO_IN_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_IN_PIN4_Msk (0x1UL << GPIO_IN_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_IN_PIN4_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN4_High (1UL) /*!< Pin input is high */
+
+/* Bit 3 : P0.3 pin */
+#define GPIO_IN_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_IN_PIN3_Msk (0x1UL << GPIO_IN_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_IN_PIN3_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN3_High (1UL) /*!< Pin input is high */
+
+/* Bit 2 : P0.2 pin */
+#define GPIO_IN_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_IN_PIN2_Msk (0x1UL << GPIO_IN_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_IN_PIN2_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN2_High (1UL) /*!< Pin input is high */
+
+/* Bit 1 : P0.1 pin */
+#define GPIO_IN_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_IN_PIN1_Msk (0x1UL << GPIO_IN_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_IN_PIN1_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN1_High (1UL) /*!< Pin input is high */
+
+/* Bit 0 : P0.0 pin */
+#define GPIO_IN_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_IN_PIN0_Msk (0x1UL << GPIO_IN_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_IN_PIN0_Low (0UL) /*!< Pin input is low */
+#define GPIO_IN_PIN0_High (1UL) /*!< Pin input is high */
+
+/* Register: GPIO_DIR */
+/* Description: Direction of GPIO pins */
+
+/* Bit 31 : P0.31 pin */
+#define GPIO_DIR_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_DIR_PIN31_Msk (0x1UL << GPIO_DIR_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_DIR_PIN31_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN31_Output (1UL) /*!< Pin set as output */
+
+/* Bit 30 : P0.30 pin */
+#define GPIO_DIR_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_DIR_PIN30_Msk (0x1UL << GPIO_DIR_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_DIR_PIN30_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN30_Output (1UL) /*!< Pin set as output */
+
+/* Bit 29 : P0.29 pin */
+#define GPIO_DIR_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_DIR_PIN29_Msk (0x1UL << GPIO_DIR_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_DIR_PIN29_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN29_Output (1UL) /*!< Pin set as output */
+
+/* Bit 28 : P0.28 pin */
+#define GPIO_DIR_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_DIR_PIN28_Msk (0x1UL << GPIO_DIR_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_DIR_PIN28_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN28_Output (1UL) /*!< Pin set as output */
+
+/* Bit 27 : P0.27 pin */
+#define GPIO_DIR_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_DIR_PIN27_Msk (0x1UL << GPIO_DIR_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_DIR_PIN27_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN27_Output (1UL) /*!< Pin set as output */
+
+/* Bit 26 : P0.26 pin */
+#define GPIO_DIR_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_DIR_PIN26_Msk (0x1UL << GPIO_DIR_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_DIR_PIN26_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN26_Output (1UL) /*!< Pin set as output */
+
+/* Bit 25 : P0.25 pin */
+#define GPIO_DIR_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_DIR_PIN25_Msk (0x1UL << GPIO_DIR_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_DIR_PIN25_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN25_Output (1UL) /*!< Pin set as output */
+
+/* Bit 24 : P0.24 pin */
+#define GPIO_DIR_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_DIR_PIN24_Msk (0x1UL << GPIO_DIR_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_DIR_PIN24_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN24_Output (1UL) /*!< Pin set as output */
+
+/* Bit 23 : P0.23 pin */
+#define GPIO_DIR_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_DIR_PIN23_Msk (0x1UL << GPIO_DIR_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_DIR_PIN23_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN23_Output (1UL) /*!< Pin set as output */
+
+/* Bit 22 : P0.22 pin */
+#define GPIO_DIR_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_DIR_PIN22_Msk (0x1UL << GPIO_DIR_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_DIR_PIN22_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN22_Output (1UL) /*!< Pin set as output */
+
+/* Bit 21 : P0.21 pin */
+#define GPIO_DIR_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_DIR_PIN21_Msk (0x1UL << GPIO_DIR_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_DIR_PIN21_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN21_Output (1UL) /*!< Pin set as output */
+
+/* Bit 20 : P0.20 pin */
+#define GPIO_DIR_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_DIR_PIN20_Msk (0x1UL << GPIO_DIR_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_DIR_PIN20_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN20_Output (1UL) /*!< Pin set as output */
+
+/* Bit 19 : P0.19 pin */
+#define GPIO_DIR_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_DIR_PIN19_Msk (0x1UL << GPIO_DIR_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_DIR_PIN19_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN19_Output (1UL) /*!< Pin set as output */
+
+/* Bit 18 : P0.18 pin */
+#define GPIO_DIR_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_DIR_PIN18_Msk (0x1UL << GPIO_DIR_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_DIR_PIN18_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN18_Output (1UL) /*!< Pin set as output */
+
+/* Bit 17 : P0.17 pin */
+#define GPIO_DIR_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_DIR_PIN17_Msk (0x1UL << GPIO_DIR_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_DIR_PIN17_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN17_Output (1UL) /*!< Pin set as output */
+
+/* Bit 16 : P0.16 pin */
+#define GPIO_DIR_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_DIR_PIN16_Msk (0x1UL << GPIO_DIR_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_DIR_PIN16_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN16_Output (1UL) /*!< Pin set as output */
+
+/* Bit 15 : P0.15 pin */
+#define GPIO_DIR_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_DIR_PIN15_Msk (0x1UL << GPIO_DIR_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_DIR_PIN15_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN15_Output (1UL) /*!< Pin set as output */
+
+/* Bit 14 : P0.14 pin */
+#define GPIO_DIR_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_DIR_PIN14_Msk (0x1UL << GPIO_DIR_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_DIR_PIN14_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN14_Output (1UL) /*!< Pin set as output */
+
+/* Bit 13 : P0.13 pin */
+#define GPIO_DIR_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_DIR_PIN13_Msk (0x1UL << GPIO_DIR_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_DIR_PIN13_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN13_Output (1UL) /*!< Pin set as output */
+
+/* Bit 12 : P0.12 pin */
+#define GPIO_DIR_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_DIR_PIN12_Msk (0x1UL << GPIO_DIR_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_DIR_PIN12_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN12_Output (1UL) /*!< Pin set as output */
+
+/* Bit 11 : P0.11 pin */
+#define GPIO_DIR_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_DIR_PIN11_Msk (0x1UL << GPIO_DIR_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_DIR_PIN11_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN11_Output (1UL) /*!< Pin set as output */
+
+/* Bit 10 : P0.10 pin */
+#define GPIO_DIR_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_DIR_PIN10_Msk (0x1UL << GPIO_DIR_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_DIR_PIN10_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN10_Output (1UL) /*!< Pin set as output */
+
+/* Bit 9 : P0.9 pin */
+#define GPIO_DIR_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_DIR_PIN9_Msk (0x1UL << GPIO_DIR_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_DIR_PIN9_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN9_Output (1UL) /*!< Pin set as output */
+
+/* Bit 8 : P0.8 pin */
+#define GPIO_DIR_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_DIR_PIN8_Msk (0x1UL << GPIO_DIR_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_DIR_PIN8_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN8_Output (1UL) /*!< Pin set as output */
+
+/* Bit 7 : P0.7 pin */
+#define GPIO_DIR_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_DIR_PIN7_Msk (0x1UL << GPIO_DIR_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_DIR_PIN7_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN7_Output (1UL) /*!< Pin set as output */
+
+/* Bit 6 : P0.6 pin */
+#define GPIO_DIR_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_DIR_PIN6_Msk (0x1UL << GPIO_DIR_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_DIR_PIN6_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN6_Output (1UL) /*!< Pin set as output */
+
+/* Bit 5 : P0.5 pin */
+#define GPIO_DIR_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_DIR_PIN5_Msk (0x1UL << GPIO_DIR_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_DIR_PIN5_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN5_Output (1UL) /*!< Pin set as output */
+
+/* Bit 4 : P0.4 pin */
+#define GPIO_DIR_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_DIR_PIN4_Msk (0x1UL << GPIO_DIR_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_DIR_PIN4_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN4_Output (1UL) /*!< Pin set as output */
+
+/* Bit 3 : P0.3 pin */
+#define GPIO_DIR_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_DIR_PIN3_Msk (0x1UL << GPIO_DIR_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_DIR_PIN3_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN3_Output (1UL) /*!< Pin set as output */
+
+/* Bit 2 : P0.2 pin */
+#define GPIO_DIR_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_DIR_PIN2_Msk (0x1UL << GPIO_DIR_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_DIR_PIN2_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN2_Output (1UL) /*!< Pin set as output */
+
+/* Bit 1 : P0.1 pin */
+#define GPIO_DIR_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_DIR_PIN1_Msk (0x1UL << GPIO_DIR_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_DIR_PIN1_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN1_Output (1UL) /*!< Pin set as output */
+
+/* Bit 0 : P0.0 pin */
+#define GPIO_DIR_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_DIR_PIN0_Msk (0x1UL << GPIO_DIR_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_DIR_PIN0_Input (0UL) /*!< Pin set as input */
+#define GPIO_DIR_PIN0_Output (1UL) /*!< Pin set as output */
+
+/* Register: GPIO_DIRSET */
+/* Description: DIR set register */
+
+/* Bit 31 : Set as output pin 31 */
+#define GPIO_DIRSET_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_DIRSET_PIN31_Msk (0x1UL << GPIO_DIRSET_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_DIRSET_PIN31_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN31_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN31_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 30 : Set as output pin 30 */
+#define GPIO_DIRSET_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_DIRSET_PIN30_Msk (0x1UL << GPIO_DIRSET_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_DIRSET_PIN30_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN30_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN30_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 29 : Set as output pin 29 */
+#define GPIO_DIRSET_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_DIRSET_PIN29_Msk (0x1UL << GPIO_DIRSET_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_DIRSET_PIN29_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN29_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN29_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 28 : Set as output pin 28 */
+#define GPIO_DIRSET_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_DIRSET_PIN28_Msk (0x1UL << GPIO_DIRSET_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_DIRSET_PIN28_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN28_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN28_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 27 : Set as output pin 27 */
+#define GPIO_DIRSET_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_DIRSET_PIN27_Msk (0x1UL << GPIO_DIRSET_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_DIRSET_PIN27_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN27_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN27_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 26 : Set as output pin 26 */
+#define GPIO_DIRSET_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_DIRSET_PIN26_Msk (0x1UL << GPIO_DIRSET_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_DIRSET_PIN26_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN26_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN26_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 25 : Set as output pin 25 */
+#define GPIO_DIRSET_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_DIRSET_PIN25_Msk (0x1UL << GPIO_DIRSET_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_DIRSET_PIN25_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN25_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN25_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 24 : Set as output pin 24 */
+#define GPIO_DIRSET_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_DIRSET_PIN24_Msk (0x1UL << GPIO_DIRSET_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_DIRSET_PIN24_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN24_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN24_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 23 : Set as output pin 23 */
+#define GPIO_DIRSET_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_DIRSET_PIN23_Msk (0x1UL << GPIO_DIRSET_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_DIRSET_PIN23_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN23_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN23_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 22 : Set as output pin 22 */
+#define GPIO_DIRSET_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_DIRSET_PIN22_Msk (0x1UL << GPIO_DIRSET_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_DIRSET_PIN22_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN22_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN22_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 21 : Set as output pin 21 */
+#define GPIO_DIRSET_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_DIRSET_PIN21_Msk (0x1UL << GPIO_DIRSET_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_DIRSET_PIN21_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN21_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN21_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 20 : Set as output pin 20 */
+#define GPIO_DIRSET_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_DIRSET_PIN20_Msk (0x1UL << GPIO_DIRSET_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_DIRSET_PIN20_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN20_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN20_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 19 : Set as output pin 19 */
+#define GPIO_DIRSET_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_DIRSET_PIN19_Msk (0x1UL << GPIO_DIRSET_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_DIRSET_PIN19_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN19_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN19_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 18 : Set as output pin 18 */
+#define GPIO_DIRSET_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_DIRSET_PIN18_Msk (0x1UL << GPIO_DIRSET_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_DIRSET_PIN18_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN18_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN18_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 17 : Set as output pin 17 */
+#define GPIO_DIRSET_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_DIRSET_PIN17_Msk (0x1UL << GPIO_DIRSET_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_DIRSET_PIN17_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN17_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN17_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 16 : Set as output pin 16 */
+#define GPIO_DIRSET_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_DIRSET_PIN16_Msk (0x1UL << GPIO_DIRSET_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_DIRSET_PIN16_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN16_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN16_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 15 : Set as output pin 15 */
+#define GPIO_DIRSET_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_DIRSET_PIN15_Msk (0x1UL << GPIO_DIRSET_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_DIRSET_PIN15_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN15_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN15_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 14 : Set as output pin 14 */
+#define GPIO_DIRSET_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_DIRSET_PIN14_Msk (0x1UL << GPIO_DIRSET_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_DIRSET_PIN14_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN14_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN14_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 13 : Set as output pin 13 */
+#define GPIO_DIRSET_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_DIRSET_PIN13_Msk (0x1UL << GPIO_DIRSET_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_DIRSET_PIN13_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN13_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN13_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 12 : Set as output pin 12 */
+#define GPIO_DIRSET_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_DIRSET_PIN12_Msk (0x1UL << GPIO_DIRSET_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_DIRSET_PIN12_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN12_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN12_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 11 : Set as output pin 11 */
+#define GPIO_DIRSET_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_DIRSET_PIN11_Msk (0x1UL << GPIO_DIRSET_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_DIRSET_PIN11_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN11_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN11_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 10 : Set as output pin 10 */
+#define GPIO_DIRSET_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_DIRSET_PIN10_Msk (0x1UL << GPIO_DIRSET_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_DIRSET_PIN10_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN10_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN10_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 9 : Set as output pin 9 */
+#define GPIO_DIRSET_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_DIRSET_PIN9_Msk (0x1UL << GPIO_DIRSET_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_DIRSET_PIN9_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN9_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN9_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 8 : Set as output pin 8 */
+#define GPIO_DIRSET_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_DIRSET_PIN8_Msk (0x1UL << GPIO_DIRSET_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_DIRSET_PIN8_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN8_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN8_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 7 : Set as output pin 7 */
+#define GPIO_DIRSET_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_DIRSET_PIN7_Msk (0x1UL << GPIO_DIRSET_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_DIRSET_PIN7_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN7_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN7_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 6 : Set as output pin 6 */
+#define GPIO_DIRSET_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_DIRSET_PIN6_Msk (0x1UL << GPIO_DIRSET_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_DIRSET_PIN6_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN6_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN6_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 5 : Set as output pin 5 */
+#define GPIO_DIRSET_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_DIRSET_PIN5_Msk (0x1UL << GPIO_DIRSET_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_DIRSET_PIN5_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN5_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN5_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 4 : Set as output pin 4 */
+#define GPIO_DIRSET_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_DIRSET_PIN4_Msk (0x1UL << GPIO_DIRSET_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_DIRSET_PIN4_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN4_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN4_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 3 : Set as output pin 3 */
+#define GPIO_DIRSET_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_DIRSET_PIN3_Msk (0x1UL << GPIO_DIRSET_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_DIRSET_PIN3_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN3_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN3_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 2 : Set as output pin 2 */
+#define GPIO_DIRSET_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_DIRSET_PIN2_Msk (0x1UL << GPIO_DIRSET_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_DIRSET_PIN2_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN2_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN2_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 1 : Set as output pin 1 */
+#define GPIO_DIRSET_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_DIRSET_PIN1_Msk (0x1UL << GPIO_DIRSET_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_DIRSET_PIN1_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN1_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN1_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Bit 0 : Set as output pin 0 */
+#define GPIO_DIRSET_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_DIRSET_PIN0_Msk (0x1UL << GPIO_DIRSET_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_DIRSET_PIN0_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRSET_PIN0_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRSET_PIN0_Set (1UL) /*!< Write: writing a '1' sets pin to output; writing a '0' has no effect */
+
+/* Register: GPIO_DIRCLR */
+/* Description: DIR clear register */
+
+/* Bit 31 : Set as input pin 31 */
+#define GPIO_DIRCLR_PIN31_Pos (31UL) /*!< Position of PIN31 field. */
+#define GPIO_DIRCLR_PIN31_Msk (0x1UL << GPIO_DIRCLR_PIN31_Pos) /*!< Bit mask of PIN31 field. */
+#define GPIO_DIRCLR_PIN31_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN31_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN31_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 30 : Set as input pin 30 */
+#define GPIO_DIRCLR_PIN30_Pos (30UL) /*!< Position of PIN30 field. */
+#define GPIO_DIRCLR_PIN30_Msk (0x1UL << GPIO_DIRCLR_PIN30_Pos) /*!< Bit mask of PIN30 field. */
+#define GPIO_DIRCLR_PIN30_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN30_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN30_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 29 : Set as input pin 29 */
+#define GPIO_DIRCLR_PIN29_Pos (29UL) /*!< Position of PIN29 field. */
+#define GPIO_DIRCLR_PIN29_Msk (0x1UL << GPIO_DIRCLR_PIN29_Pos) /*!< Bit mask of PIN29 field. */
+#define GPIO_DIRCLR_PIN29_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN29_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN29_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 28 : Set as input pin 28 */
+#define GPIO_DIRCLR_PIN28_Pos (28UL) /*!< Position of PIN28 field. */
+#define GPIO_DIRCLR_PIN28_Msk (0x1UL << GPIO_DIRCLR_PIN28_Pos) /*!< Bit mask of PIN28 field. */
+#define GPIO_DIRCLR_PIN28_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN28_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN28_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 27 : Set as input pin 27 */
+#define GPIO_DIRCLR_PIN27_Pos (27UL) /*!< Position of PIN27 field. */
+#define GPIO_DIRCLR_PIN27_Msk (0x1UL << GPIO_DIRCLR_PIN27_Pos) /*!< Bit mask of PIN27 field. */
+#define GPIO_DIRCLR_PIN27_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN27_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN27_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 26 : Set as input pin 26 */
+#define GPIO_DIRCLR_PIN26_Pos (26UL) /*!< Position of PIN26 field. */
+#define GPIO_DIRCLR_PIN26_Msk (0x1UL << GPIO_DIRCLR_PIN26_Pos) /*!< Bit mask of PIN26 field. */
+#define GPIO_DIRCLR_PIN26_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN26_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN26_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 25 : Set as input pin 25 */
+#define GPIO_DIRCLR_PIN25_Pos (25UL) /*!< Position of PIN25 field. */
+#define GPIO_DIRCLR_PIN25_Msk (0x1UL << GPIO_DIRCLR_PIN25_Pos) /*!< Bit mask of PIN25 field. */
+#define GPIO_DIRCLR_PIN25_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN25_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN25_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 24 : Set as input pin 24 */
+#define GPIO_DIRCLR_PIN24_Pos (24UL) /*!< Position of PIN24 field. */
+#define GPIO_DIRCLR_PIN24_Msk (0x1UL << GPIO_DIRCLR_PIN24_Pos) /*!< Bit mask of PIN24 field. */
+#define GPIO_DIRCLR_PIN24_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN24_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN24_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 23 : Set as input pin 23 */
+#define GPIO_DIRCLR_PIN23_Pos (23UL) /*!< Position of PIN23 field. */
+#define GPIO_DIRCLR_PIN23_Msk (0x1UL << GPIO_DIRCLR_PIN23_Pos) /*!< Bit mask of PIN23 field. */
+#define GPIO_DIRCLR_PIN23_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN23_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN23_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 22 : Set as input pin 22 */
+#define GPIO_DIRCLR_PIN22_Pos (22UL) /*!< Position of PIN22 field. */
+#define GPIO_DIRCLR_PIN22_Msk (0x1UL << GPIO_DIRCLR_PIN22_Pos) /*!< Bit mask of PIN22 field. */
+#define GPIO_DIRCLR_PIN22_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN22_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN22_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 21 : Set as input pin 21 */
+#define GPIO_DIRCLR_PIN21_Pos (21UL) /*!< Position of PIN21 field. */
+#define GPIO_DIRCLR_PIN21_Msk (0x1UL << GPIO_DIRCLR_PIN21_Pos) /*!< Bit mask of PIN21 field. */
+#define GPIO_DIRCLR_PIN21_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN21_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN21_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 20 : Set as input pin 20 */
+#define GPIO_DIRCLR_PIN20_Pos (20UL) /*!< Position of PIN20 field. */
+#define GPIO_DIRCLR_PIN20_Msk (0x1UL << GPIO_DIRCLR_PIN20_Pos) /*!< Bit mask of PIN20 field. */
+#define GPIO_DIRCLR_PIN20_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN20_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN20_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 19 : Set as input pin 19 */
+#define GPIO_DIRCLR_PIN19_Pos (19UL) /*!< Position of PIN19 field. */
+#define GPIO_DIRCLR_PIN19_Msk (0x1UL << GPIO_DIRCLR_PIN19_Pos) /*!< Bit mask of PIN19 field. */
+#define GPIO_DIRCLR_PIN19_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN19_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN19_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 18 : Set as input pin 18 */
+#define GPIO_DIRCLR_PIN18_Pos (18UL) /*!< Position of PIN18 field. */
+#define GPIO_DIRCLR_PIN18_Msk (0x1UL << GPIO_DIRCLR_PIN18_Pos) /*!< Bit mask of PIN18 field. */
+#define GPIO_DIRCLR_PIN18_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN18_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN18_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 17 : Set as input pin 17 */
+#define GPIO_DIRCLR_PIN17_Pos (17UL) /*!< Position of PIN17 field. */
+#define GPIO_DIRCLR_PIN17_Msk (0x1UL << GPIO_DIRCLR_PIN17_Pos) /*!< Bit mask of PIN17 field. */
+#define GPIO_DIRCLR_PIN17_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN17_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN17_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 16 : Set as input pin 16 */
+#define GPIO_DIRCLR_PIN16_Pos (16UL) /*!< Position of PIN16 field. */
+#define GPIO_DIRCLR_PIN16_Msk (0x1UL << GPIO_DIRCLR_PIN16_Pos) /*!< Bit mask of PIN16 field. */
+#define GPIO_DIRCLR_PIN16_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN16_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN16_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 15 : Set as input pin 15 */
+#define GPIO_DIRCLR_PIN15_Pos (15UL) /*!< Position of PIN15 field. */
+#define GPIO_DIRCLR_PIN15_Msk (0x1UL << GPIO_DIRCLR_PIN15_Pos) /*!< Bit mask of PIN15 field. */
+#define GPIO_DIRCLR_PIN15_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN15_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN15_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 14 : Set as input pin 14 */
+#define GPIO_DIRCLR_PIN14_Pos (14UL) /*!< Position of PIN14 field. */
+#define GPIO_DIRCLR_PIN14_Msk (0x1UL << GPIO_DIRCLR_PIN14_Pos) /*!< Bit mask of PIN14 field. */
+#define GPIO_DIRCLR_PIN14_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN14_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN14_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 13 : Set as input pin 13 */
+#define GPIO_DIRCLR_PIN13_Pos (13UL) /*!< Position of PIN13 field. */
+#define GPIO_DIRCLR_PIN13_Msk (0x1UL << GPIO_DIRCLR_PIN13_Pos) /*!< Bit mask of PIN13 field. */
+#define GPIO_DIRCLR_PIN13_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN13_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN13_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 12 : Set as input pin 12 */
+#define GPIO_DIRCLR_PIN12_Pos (12UL) /*!< Position of PIN12 field. */
+#define GPIO_DIRCLR_PIN12_Msk (0x1UL << GPIO_DIRCLR_PIN12_Pos) /*!< Bit mask of PIN12 field. */
+#define GPIO_DIRCLR_PIN12_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN12_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN12_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 11 : Set as input pin 11 */
+#define GPIO_DIRCLR_PIN11_Pos (11UL) /*!< Position of PIN11 field. */
+#define GPIO_DIRCLR_PIN11_Msk (0x1UL << GPIO_DIRCLR_PIN11_Pos) /*!< Bit mask of PIN11 field. */
+#define GPIO_DIRCLR_PIN11_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN11_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN11_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 10 : Set as input pin 10 */
+#define GPIO_DIRCLR_PIN10_Pos (10UL) /*!< Position of PIN10 field. */
+#define GPIO_DIRCLR_PIN10_Msk (0x1UL << GPIO_DIRCLR_PIN10_Pos) /*!< Bit mask of PIN10 field. */
+#define GPIO_DIRCLR_PIN10_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN10_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN10_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 9 : Set as input pin 9 */
+#define GPIO_DIRCLR_PIN9_Pos (9UL) /*!< Position of PIN9 field. */
+#define GPIO_DIRCLR_PIN9_Msk (0x1UL << GPIO_DIRCLR_PIN9_Pos) /*!< Bit mask of PIN9 field. */
+#define GPIO_DIRCLR_PIN9_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN9_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN9_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 8 : Set as input pin 8 */
+#define GPIO_DIRCLR_PIN8_Pos (8UL) /*!< Position of PIN8 field. */
+#define GPIO_DIRCLR_PIN8_Msk (0x1UL << GPIO_DIRCLR_PIN8_Pos) /*!< Bit mask of PIN8 field. */
+#define GPIO_DIRCLR_PIN8_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN8_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN8_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 7 : Set as input pin 7 */
+#define GPIO_DIRCLR_PIN7_Pos (7UL) /*!< Position of PIN7 field. */
+#define GPIO_DIRCLR_PIN7_Msk (0x1UL << GPIO_DIRCLR_PIN7_Pos) /*!< Bit mask of PIN7 field. */
+#define GPIO_DIRCLR_PIN7_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN7_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN7_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 6 : Set as input pin 6 */
+#define GPIO_DIRCLR_PIN6_Pos (6UL) /*!< Position of PIN6 field. */
+#define GPIO_DIRCLR_PIN6_Msk (0x1UL << GPIO_DIRCLR_PIN6_Pos) /*!< Bit mask of PIN6 field. */
+#define GPIO_DIRCLR_PIN6_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN6_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN6_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 5 : Set as input pin 5 */
+#define GPIO_DIRCLR_PIN5_Pos (5UL) /*!< Position of PIN5 field. */
+#define GPIO_DIRCLR_PIN5_Msk (0x1UL << GPIO_DIRCLR_PIN5_Pos) /*!< Bit mask of PIN5 field. */
+#define GPIO_DIRCLR_PIN5_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN5_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN5_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 4 : Set as input pin 4 */
+#define GPIO_DIRCLR_PIN4_Pos (4UL) /*!< Position of PIN4 field. */
+#define GPIO_DIRCLR_PIN4_Msk (0x1UL << GPIO_DIRCLR_PIN4_Pos) /*!< Bit mask of PIN4 field. */
+#define GPIO_DIRCLR_PIN4_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN4_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN4_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 3 : Set as input pin 3 */
+#define GPIO_DIRCLR_PIN3_Pos (3UL) /*!< Position of PIN3 field. */
+#define GPIO_DIRCLR_PIN3_Msk (0x1UL << GPIO_DIRCLR_PIN3_Pos) /*!< Bit mask of PIN3 field. */
+#define GPIO_DIRCLR_PIN3_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN3_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN3_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 2 : Set as input pin 2 */
+#define GPIO_DIRCLR_PIN2_Pos (2UL) /*!< Position of PIN2 field. */
+#define GPIO_DIRCLR_PIN2_Msk (0x1UL << GPIO_DIRCLR_PIN2_Pos) /*!< Bit mask of PIN2 field. */
+#define GPIO_DIRCLR_PIN2_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN2_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN2_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 1 : Set as input pin 1 */
+#define GPIO_DIRCLR_PIN1_Pos (1UL) /*!< Position of PIN1 field. */
+#define GPIO_DIRCLR_PIN1_Msk (0x1UL << GPIO_DIRCLR_PIN1_Pos) /*!< Bit mask of PIN1 field. */
+#define GPIO_DIRCLR_PIN1_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN1_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN1_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Bit 0 : Set as input pin 0 */
+#define GPIO_DIRCLR_PIN0_Pos (0UL) /*!< Position of PIN0 field. */
+#define GPIO_DIRCLR_PIN0_Msk (0x1UL << GPIO_DIRCLR_PIN0_Pos) /*!< Bit mask of PIN0 field. */
+#define GPIO_DIRCLR_PIN0_Input (0UL) /*!< Read: pin set as input */
+#define GPIO_DIRCLR_PIN0_Output (1UL) /*!< Read: pin set as output */
+#define GPIO_DIRCLR_PIN0_Clear (1UL) /*!< Write: writing a '1' sets pin to input; writing a '0' has no effect */
+
+/* Register: GPIO_LATCH */
+/* Description: Latch indicating which GPIO pins have met the criteria set in PIN_CNF[n].SENSE register */
+
+/* Bits 31..0 : Register holding a '1' for each GPIO pins which has met the criteria set in PIN_CNF[n].SENSE */
+#define GPIO_LATCH_LATCH_Pos (0UL) /*!< Position of LATCH field. */
+#define GPIO_LATCH_LATCH_Msk (0xFFFFFFFFUL << GPIO_LATCH_LATCH_Pos) /*!< Bit mask of LATCH field. */
+
+/* Register: GPIO_DETECTMODE */
+/* Description: Select between default DETECT signal behaviour and LDETECT mode */
+
+/* Bit 0 : Select between default DETECT signal behaviour and LDETECT mode */
+#define GPIO_DETECTMODE_DETECTMODE_Pos (0UL) /*!< Position of DETECTMODE field. */
+#define GPIO_DETECTMODE_DETECTMODE_Msk (0x1UL << GPIO_DETECTMODE_DETECTMODE_Pos) /*!< Bit mask of DETECTMODE field. */
+#define GPIO_DETECTMODE_DETECTMODE_Default (0UL) /*!< Use default behaviour */
+#define GPIO_DETECTMODE_DETECTMODE_LDETECT (1UL) /*!< Use LDETECT behaviour */
+
+/* Register: GPIO_PIN_CNF */
+/* Description: Description collection[0]:  Configuration of GPIO pins */
+
+/* Bits 17..16 : Pin sensing mechanism */
+#define GPIO_PIN_CNF_SENSE_Pos (16UL) /*!< Position of SENSE field. */
+#define GPIO_PIN_CNF_SENSE_Msk (0x3UL << GPIO_PIN_CNF_SENSE_Pos) /*!< Bit mask of SENSE field. */
+#define GPIO_PIN_CNF_SENSE_Disabled (0UL) /*!< Disabled */
+#define GPIO_PIN_CNF_SENSE_High (2UL) /*!< Sense for high level */
+#define GPIO_PIN_CNF_SENSE_Low (3UL) /*!< Sense for low level */
+
+/* Bits 10..8 : Drive configuration */
+#define GPIO_PIN_CNF_DRIVE_Pos (8UL) /*!< Position of DRIVE field. */
+#define GPIO_PIN_CNF_DRIVE_Msk (0x7UL << GPIO_PIN_CNF_DRIVE_Pos) /*!< Bit mask of DRIVE field. */
+#define GPIO_PIN_CNF_DRIVE_S0S1 (0UL) /*!< Standard '0', standard '1' */
+#define GPIO_PIN_CNF_DRIVE_H0S1 (1UL) /*!< High drive '0', standard '1' */
+#define GPIO_PIN_CNF_DRIVE_S0H1 (2UL) /*!< Standard '0', high drive '1' */
+#define GPIO_PIN_CNF_DRIVE_H0H1 (3UL) /*!< High drive '0', high 'drive '1'' */
+#define GPIO_PIN_CNF_DRIVE_D0S1 (4UL) /*!< Disconnect '0' standard '1' */
+#define GPIO_PIN_CNF_DRIVE_D0H1 (5UL) /*!< Disconnect '0', high drive '1' */
+#define GPIO_PIN_CNF_DRIVE_S0D1 (6UL) /*!< Standard '0'. disconnect '1' */
+#define GPIO_PIN_CNF_DRIVE_H0D1 (7UL) /*!< High drive '0', disconnect '1' */
+
+/* Bits 3..2 : Pull configuration */
+#define GPIO_PIN_CNF_PULL_Pos (2UL) /*!< Position of PULL field. */
+#define GPIO_PIN_CNF_PULL_Msk (0x3UL << GPIO_PIN_CNF_PULL_Pos) /*!< Bit mask of PULL field. */
+#define GPIO_PIN_CNF_PULL_Disabled (0UL) /*!< No pull */
+#define GPIO_PIN_CNF_PULL_Pulldown (1UL) /*!< Pull down on pin */
+#define GPIO_PIN_CNF_PULL_Pullup (3UL) /*!< Pull up on pin */
+
+/* Bit 1 : Connect or disconnect input buffer */
+#define GPIO_PIN_CNF_INPUT_Pos (1UL) /*!< Position of INPUT field. */
+#define GPIO_PIN_CNF_INPUT_Msk (0x1UL << GPIO_PIN_CNF_INPUT_Pos) /*!< Bit mask of INPUT field. */
+#define GPIO_PIN_CNF_INPUT_Connect (0UL) /*!< Connect input buffer */
+#define GPIO_PIN_CNF_INPUT_Disconnect (1UL) /*!< Disconnect input buffer */
+
+/* Bit 0 : Pin direction */
+#define GPIO_PIN_CNF_DIR_Pos (0UL) /*!< Position of DIR field. */
+#define GPIO_PIN_CNF_DIR_Msk (0x1UL << GPIO_PIN_CNF_DIR_Pos) /*!< Bit mask of DIR field. */
+#define GPIO_PIN_CNF_DIR_Input (0UL) /*!< Configure pin as an input pin */
+#define GPIO_PIN_CNF_DIR_Output (1UL) /*!< Configure pin as an output pin */
+
+
+/* Peripheral: PDM */
+/* Description: Pulse Density Modulation (Digital Microphone) Interface */
+
+/* Register: PDM_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 2 : Enable or disable interrupt for END event */
+#define PDM_INTEN_END_Pos (2UL) /*!< Position of END field. */
+#define PDM_INTEN_END_Msk (0x1UL << PDM_INTEN_END_Pos) /*!< Bit mask of END field. */
+#define PDM_INTEN_END_Disabled (0UL) /*!< Disable */
+#define PDM_INTEN_END_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for STOPPED event */
+#define PDM_INTEN_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define PDM_INTEN_STOPPED_Msk (0x1UL << PDM_INTEN_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define PDM_INTEN_STOPPED_Disabled (0UL) /*!< Disable */
+#define PDM_INTEN_STOPPED_Enabled (1UL) /*!< Enable */
+
+/* Bit 0 : Enable or disable interrupt for STARTED event */
+#define PDM_INTEN_STARTED_Pos (0UL) /*!< Position of STARTED field. */
+#define PDM_INTEN_STARTED_Msk (0x1UL << PDM_INTEN_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define PDM_INTEN_STARTED_Disabled (0UL) /*!< Disable */
+#define PDM_INTEN_STARTED_Enabled (1UL) /*!< Enable */
+
+/* Register: PDM_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 2 : Write '1' to Enable interrupt for END event */
+#define PDM_INTENSET_END_Pos (2UL) /*!< Position of END field. */
+#define PDM_INTENSET_END_Msk (0x1UL << PDM_INTENSET_END_Pos) /*!< Bit mask of END field. */
+#define PDM_INTENSET_END_Disabled (0UL) /*!< Read: Disabled */
+#define PDM_INTENSET_END_Enabled (1UL) /*!< Read: Enabled */
+#define PDM_INTENSET_END_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for STOPPED event */
+#define PDM_INTENSET_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define PDM_INTENSET_STOPPED_Msk (0x1UL << PDM_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define PDM_INTENSET_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define PDM_INTENSET_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define PDM_INTENSET_STOPPED_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for STARTED event */
+#define PDM_INTENSET_STARTED_Pos (0UL) /*!< Position of STARTED field. */
+#define PDM_INTENSET_STARTED_Msk (0x1UL << PDM_INTENSET_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define PDM_INTENSET_STARTED_Disabled (0UL) /*!< Read: Disabled */
+#define PDM_INTENSET_STARTED_Enabled (1UL) /*!< Read: Enabled */
+#define PDM_INTENSET_STARTED_Set (1UL) /*!< Enable */
+
+/* Register: PDM_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 2 : Write '1' to Disable interrupt for END event */
+#define PDM_INTENCLR_END_Pos (2UL) /*!< Position of END field. */
+#define PDM_INTENCLR_END_Msk (0x1UL << PDM_INTENCLR_END_Pos) /*!< Bit mask of END field. */
+#define PDM_INTENCLR_END_Disabled (0UL) /*!< Read: Disabled */
+#define PDM_INTENCLR_END_Enabled (1UL) /*!< Read: Enabled */
+#define PDM_INTENCLR_END_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for STOPPED event */
+#define PDM_INTENCLR_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define PDM_INTENCLR_STOPPED_Msk (0x1UL << PDM_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define PDM_INTENCLR_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define PDM_INTENCLR_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define PDM_INTENCLR_STOPPED_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for STARTED event */
+#define PDM_INTENCLR_STARTED_Pos (0UL) /*!< Position of STARTED field. */
+#define PDM_INTENCLR_STARTED_Msk (0x1UL << PDM_INTENCLR_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define PDM_INTENCLR_STARTED_Disabled (0UL) /*!< Read: Disabled */
+#define PDM_INTENCLR_STARTED_Enabled (1UL) /*!< Read: Enabled */
+#define PDM_INTENCLR_STARTED_Clear (1UL) /*!< Disable */
+
+/* Register: PDM_ENABLE */
+/* Description: PDM module enable register */
+
+/* Bit 0 : Enable or disable PDM module */
+#define PDM_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define PDM_ENABLE_ENABLE_Msk (0x1UL << PDM_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define PDM_ENABLE_ENABLE_Disabled (0UL) /*!< Disable */
+#define PDM_ENABLE_ENABLE_Enabled (1UL) /*!< Enable */
+
+/* Register: PDM_PDMCLKCTRL */
+/* Description: PDM clock generator control */
+
+/* Bits 31..0 : PDM_CLK frequency */
+#define PDM_PDMCLKCTRL_FREQ_Pos (0UL) /*!< Position of FREQ field. */
+#define PDM_PDMCLKCTRL_FREQ_Msk (0xFFFFFFFFUL << PDM_PDMCLKCTRL_FREQ_Pos) /*!< Bit mask of FREQ field. */
+#define PDM_PDMCLKCTRL_FREQ_1000K (0x08000000UL) /*!< PDM_CLK = 32 MHz / 32 = 1.000 MHz */
+#define PDM_PDMCLKCTRL_FREQ_Default (0x08400000UL) /*!< PDM_CLK = 32 MHz / 31 = 1.032 MHz */
+#define PDM_PDMCLKCTRL_FREQ_1067K (0x08800000UL) /*!< PDM_CLK = 32 MHz / 30 = 1.067 MHz */
+
+/* Register: PDM_MODE */
+/* Description: Defines the routing of the connected PDM microphones' signals */
+
+/* Bit 1 : Defines on which PDM_CLK edge Left (or mono) is sampled */
+#define PDM_MODE_EDGE_Pos (1UL) /*!< Position of EDGE field. */
+#define PDM_MODE_EDGE_Msk (0x1UL << PDM_MODE_EDGE_Pos) /*!< Bit mask of EDGE field. */
+#define PDM_MODE_EDGE_LeftFalling (0UL) /*!< Left (or mono) is sampled on falling edge of PDM_CLK */
+#define PDM_MODE_EDGE_LeftRising (1UL) /*!< Left (or mono) is sampled on rising edge of PDM_CLK */
+
+/* Bit 0 : Mono or stereo operation */
+#define PDM_MODE_OPERATION_Pos (0UL) /*!< Position of OPERATION field. */
+#define PDM_MODE_OPERATION_Msk (0x1UL << PDM_MODE_OPERATION_Pos) /*!< Bit mask of OPERATION field. */
+#define PDM_MODE_OPERATION_Stereo (0UL) /*!< Sample and store one pair (Left + Right) of 16bit samples per RAM word R=[31:16]; L=[15:0] */
+#define PDM_MODE_OPERATION_Mono (1UL) /*!< Sample and store two successive Left samples (16 bit each) per RAM word L1=[31:16]; L0=[15:0] */
+
+/* Register: PDM_GAINL */
+/* Description: Left output gain adjustment */
+
+/* Bits 6..0 : Left output gain adjustment, in 0.5 dB steps, around the default module gain (see electrical parameters) 0x00    -20 dB gain adjust 0x01  -19.5 dB gain adjust (...) 0x27   -0.5 dB gain adjust 0x28      0 dB gain adjust 0x29   +0.5 dB gain adjust (...) 0x4F  +19.5 dB gain adjust 0x50    +20 dB gain adjust */
+#define PDM_GAINL_GAINL_Pos (0UL) /*!< Position of GAINL field. */
+#define PDM_GAINL_GAINL_Msk (0x7FUL << PDM_GAINL_GAINL_Pos) /*!< Bit mask of GAINL field. */
+#define PDM_GAINL_GAINL_MinGain (0x00UL) /*!< -20dB gain adjustment (minimum) */
+#define PDM_GAINL_GAINL_DefaultGain (0x28UL) /*!< 0dB gain adjustment ('2500 RMS' requirement) */
+#define PDM_GAINL_GAINL_MaxGain (0x50UL) /*!< +20dB gain adjustment (maximum) */
+
+/* Register: PDM_GAINR */
+/* Description: Right output gain adjustment */
+
+/* Bits 7..0 : Right output gain adjustment, in 0.5 dB steps, around the default module gain (see electrical parameters) */
+#define PDM_GAINR_GAINR_Pos (0UL) /*!< Position of GAINR field. */
+#define PDM_GAINR_GAINR_Msk (0xFFUL << PDM_GAINR_GAINR_Pos) /*!< Bit mask of GAINR field. */
+#define PDM_GAINR_GAINR_MinGain (0x00UL) /*!< -20dB gain adjustment (minimum) */
+#define PDM_GAINR_GAINR_DefaultGain (0x28UL) /*!< 0dB gain adjustment ('2500 RMS' requirement) */
+#define PDM_GAINR_GAINR_MaxGain (0x50UL) /*!< +20dB gain adjustment (maximum) */
+
+/* Register: PDM_PSEL_CLK */
+/* Description: Pin number configuration for PDM CLK signal */
+
+/* Bit 31 : Connection */
+#define PDM_PSEL_CLK_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define PDM_PSEL_CLK_CONNECT_Msk (0x1UL << PDM_PSEL_CLK_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define PDM_PSEL_CLK_CONNECT_Connected (0UL) /*!< Connect */
+#define PDM_PSEL_CLK_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define PDM_PSEL_CLK_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define PDM_PSEL_CLK_PIN_Msk (0x1FUL << PDM_PSEL_CLK_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: PDM_PSEL_DIN */
+/* Description: Pin number configuration for PDM DIN signal */
+
+/* Bit 31 : Connection */
+#define PDM_PSEL_DIN_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define PDM_PSEL_DIN_CONNECT_Msk (0x1UL << PDM_PSEL_DIN_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define PDM_PSEL_DIN_CONNECT_Connected (0UL) /*!< Connect */
+#define PDM_PSEL_DIN_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define PDM_PSEL_DIN_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define PDM_PSEL_DIN_PIN_Msk (0x1FUL << PDM_PSEL_DIN_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: PDM_SAMPLE_PTR */
+/* Description: RAM address pointer to write samples to with EasyDMA */
+
+/* Bits 31..0 : Address to write PDM samples to over DMA */
+#define PDM_SAMPLE_PTR_SAMPLEPTR_Pos (0UL) /*!< Position of SAMPLEPTR field. */
+#define PDM_SAMPLE_PTR_SAMPLEPTR_Msk (0xFFFFFFFFUL << PDM_SAMPLE_PTR_SAMPLEPTR_Pos) /*!< Bit mask of SAMPLEPTR field. */
+
+/* Register: PDM_SAMPLE_MAXCNT */
+/* Description: Number of samples to allocate memory for in EasyDMA mode */
+
+/* Bits 14..0 : Length of DMA RAM allocation in number of samples */
+#define PDM_SAMPLE_MAXCNT_BUFFSIZE_Pos (0UL) /*!< Position of BUFFSIZE field. */
+#define PDM_SAMPLE_MAXCNT_BUFFSIZE_Msk (0x7FFFUL << PDM_SAMPLE_MAXCNT_BUFFSIZE_Pos) /*!< Bit mask of BUFFSIZE field. */
+
+
+/* Peripheral: POWER */
+/* Description: Power control */
+
+/* Register: POWER_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 6 : Write '1' to Enable interrupt for SLEEPEXIT event */
+#define POWER_INTENSET_SLEEPEXIT_Pos (6UL) /*!< Position of SLEEPEXIT field. */
+#define POWER_INTENSET_SLEEPEXIT_Msk (0x1UL << POWER_INTENSET_SLEEPEXIT_Pos) /*!< Bit mask of SLEEPEXIT field. */
+#define POWER_INTENSET_SLEEPEXIT_Disabled (0UL) /*!< Read: Disabled */
+#define POWER_INTENSET_SLEEPEXIT_Enabled (1UL) /*!< Read: Enabled */
+#define POWER_INTENSET_SLEEPEXIT_Set (1UL) /*!< Enable */
+
+/* Bit 5 : Write '1' to Enable interrupt for SLEEPENTER event */
+#define POWER_INTENSET_SLEEPENTER_Pos (5UL) /*!< Position of SLEEPENTER field. */
+#define POWER_INTENSET_SLEEPENTER_Msk (0x1UL << POWER_INTENSET_SLEEPENTER_Pos) /*!< Bit mask of SLEEPENTER field. */
+#define POWER_INTENSET_SLEEPENTER_Disabled (0UL) /*!< Read: Disabled */
+#define POWER_INTENSET_SLEEPENTER_Enabled (1UL) /*!< Read: Enabled */
+#define POWER_INTENSET_SLEEPENTER_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for POFWARN event */
+#define POWER_INTENSET_POFWARN_Pos (2UL) /*!< Position of POFWARN field. */
+#define POWER_INTENSET_POFWARN_Msk (0x1UL << POWER_INTENSET_POFWARN_Pos) /*!< Bit mask of POFWARN field. */
+#define POWER_INTENSET_POFWARN_Disabled (0UL) /*!< Read: Disabled */
+#define POWER_INTENSET_POFWARN_Enabled (1UL) /*!< Read: Enabled */
+#define POWER_INTENSET_POFWARN_Set (1UL) /*!< Enable */
+
+/* Register: POWER_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 6 : Write '1' to Disable interrupt for SLEEPEXIT event */
+#define POWER_INTENCLR_SLEEPEXIT_Pos (6UL) /*!< Position of SLEEPEXIT field. */
+#define POWER_INTENCLR_SLEEPEXIT_Msk (0x1UL << POWER_INTENCLR_SLEEPEXIT_Pos) /*!< Bit mask of SLEEPEXIT field. */
+#define POWER_INTENCLR_SLEEPEXIT_Disabled (0UL) /*!< Read: Disabled */
+#define POWER_INTENCLR_SLEEPEXIT_Enabled (1UL) /*!< Read: Enabled */
+#define POWER_INTENCLR_SLEEPEXIT_Clear (1UL) /*!< Disable */
+
+/* Bit 5 : Write '1' to Disable interrupt for SLEEPENTER event */
+#define POWER_INTENCLR_SLEEPENTER_Pos (5UL) /*!< Position of SLEEPENTER field. */
+#define POWER_INTENCLR_SLEEPENTER_Msk (0x1UL << POWER_INTENCLR_SLEEPENTER_Pos) /*!< Bit mask of SLEEPENTER field. */
+#define POWER_INTENCLR_SLEEPENTER_Disabled (0UL) /*!< Read: Disabled */
+#define POWER_INTENCLR_SLEEPENTER_Enabled (1UL) /*!< Read: Enabled */
+#define POWER_INTENCLR_SLEEPENTER_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for POFWARN event */
+#define POWER_INTENCLR_POFWARN_Pos (2UL) /*!< Position of POFWARN field. */
+#define POWER_INTENCLR_POFWARN_Msk (0x1UL << POWER_INTENCLR_POFWARN_Pos) /*!< Bit mask of POFWARN field. */
+#define POWER_INTENCLR_POFWARN_Disabled (0UL) /*!< Read: Disabled */
+#define POWER_INTENCLR_POFWARN_Enabled (1UL) /*!< Read: Enabled */
+#define POWER_INTENCLR_POFWARN_Clear (1UL) /*!< Disable */
+
+/* Register: POWER_RESETREAS */
+/* Description: Reset reason */
+
+/* Bit 19 : Reset due to wake up from System OFF mode by NFC field detect */
+#define POWER_RESETREAS_NFC_Pos (19UL) /*!< Position of NFC field. */
+#define POWER_RESETREAS_NFC_Msk (0x1UL << POWER_RESETREAS_NFC_Pos) /*!< Bit mask of NFC field. */
+#define POWER_RESETREAS_NFC_NotDetected (0UL) /*!< Not detected */
+#define POWER_RESETREAS_NFC_Detected (1UL) /*!< Detected */
+
+/* Bit 18 : Reset due to wake up from System OFF mode when wakeup is triggered from entering into debug interface mode */
+#define POWER_RESETREAS_DIF_Pos (18UL) /*!< Position of DIF field. */
+#define POWER_RESETREAS_DIF_Msk (0x1UL << POWER_RESETREAS_DIF_Pos) /*!< Bit mask of DIF field. */
+#define POWER_RESETREAS_DIF_NotDetected (0UL) /*!< Not detected */
+#define POWER_RESETREAS_DIF_Detected (1UL) /*!< Detected */
+
+/* Bit 17 : Reset due to wake up from System OFF mode when wakeup is triggered from ANADETECT signal from LPCOMP */
+#define POWER_RESETREAS_LPCOMP_Pos (17UL) /*!< Position of LPCOMP field. */
+#define POWER_RESETREAS_LPCOMP_Msk (0x1UL << POWER_RESETREAS_LPCOMP_Pos) /*!< Bit mask of LPCOMP field. */
+#define POWER_RESETREAS_LPCOMP_NotDetected (0UL) /*!< Not detected */
+#define POWER_RESETREAS_LPCOMP_Detected (1UL) /*!< Detected */
+
+/* Bit 16 : Reset due to wake up from System OFF mode when wakeup is triggered from DETECT signal from GPIO */
+#define POWER_RESETREAS_OFF_Pos (16UL) /*!< Position of OFF field. */
+#define POWER_RESETREAS_OFF_Msk (0x1UL << POWER_RESETREAS_OFF_Pos) /*!< Bit mask of OFF field. */
+#define POWER_RESETREAS_OFF_NotDetected (0UL) /*!< Not detected */
+#define POWER_RESETREAS_OFF_Detected (1UL) /*!< Detected */
+
+/* Bit 3 : Reset from CPU lock-up detected */
+#define POWER_RESETREAS_LOCKUP_Pos (3UL) /*!< Position of LOCKUP field. */
+#define POWER_RESETREAS_LOCKUP_Msk (0x1UL << POWER_RESETREAS_LOCKUP_Pos) /*!< Bit mask of LOCKUP field. */
+#define POWER_RESETREAS_LOCKUP_NotDetected (0UL) /*!< Not detected */
+#define POWER_RESETREAS_LOCKUP_Detected (1UL) /*!< Detected */
+
+/* Bit 2 : Reset from AIRCR.SYSRESETREQ detected */
+#define POWER_RESETREAS_SREQ_Pos (2UL) /*!< Position of SREQ field. */
+#define POWER_RESETREAS_SREQ_Msk (0x1UL << POWER_RESETREAS_SREQ_Pos) /*!< Bit mask of SREQ field. */
+#define POWER_RESETREAS_SREQ_NotDetected (0UL) /*!< Not detected */
+#define POWER_RESETREAS_SREQ_Detected (1UL) /*!< Detected */
+
+/* Bit 1 : Reset from watchdog detected */
+#define POWER_RESETREAS_DOG_Pos (1UL) /*!< Position of DOG field. */
+#define POWER_RESETREAS_DOG_Msk (0x1UL << POWER_RESETREAS_DOG_Pos) /*!< Bit mask of DOG field. */
+#define POWER_RESETREAS_DOG_NotDetected (0UL) /*!< Not detected */
+#define POWER_RESETREAS_DOG_Detected (1UL) /*!< Detected */
+
+/* Bit 0 : Reset from pin-reset detected */
+#define POWER_RESETREAS_RESETPIN_Pos (0UL) /*!< Position of RESETPIN field. */
+#define POWER_RESETREAS_RESETPIN_Msk (0x1UL << POWER_RESETREAS_RESETPIN_Pos) /*!< Bit mask of RESETPIN field. */
+#define POWER_RESETREAS_RESETPIN_NotDetected (0UL) /*!< Not detected */
+#define POWER_RESETREAS_RESETPIN_Detected (1UL) /*!< Detected */
+
+/* Register: POWER_RAMSTATUS */
+/* Description: Deprecated register -  RAM status register */
+
+/* Bit 3 : RAM block 3 is on or off/powering up */
+#define POWER_RAMSTATUS_RAMBLOCK3_Pos (3UL) /*!< Position of RAMBLOCK3 field. */
+#define POWER_RAMSTATUS_RAMBLOCK3_Msk (0x1UL << POWER_RAMSTATUS_RAMBLOCK3_Pos) /*!< Bit mask of RAMBLOCK3 field. */
+#define POWER_RAMSTATUS_RAMBLOCK3_Off (0UL) /*!< Off */
+#define POWER_RAMSTATUS_RAMBLOCK3_On (1UL) /*!< On */
+
+/* Bit 2 : RAM block 2 is on or off/powering up */
+#define POWER_RAMSTATUS_RAMBLOCK2_Pos (2UL) /*!< Position of RAMBLOCK2 field. */
+#define POWER_RAMSTATUS_RAMBLOCK2_Msk (0x1UL << POWER_RAMSTATUS_RAMBLOCK2_Pos) /*!< Bit mask of RAMBLOCK2 field. */
+#define POWER_RAMSTATUS_RAMBLOCK2_Off (0UL) /*!< Off */
+#define POWER_RAMSTATUS_RAMBLOCK2_On (1UL) /*!< On */
+
+/* Bit 1 : RAM block 1 is on or off/powering up */
+#define POWER_RAMSTATUS_RAMBLOCK1_Pos (1UL) /*!< Position of RAMBLOCK1 field. */
+#define POWER_RAMSTATUS_RAMBLOCK1_Msk (0x1UL << POWER_RAMSTATUS_RAMBLOCK1_Pos) /*!< Bit mask of RAMBLOCK1 field. */
+#define POWER_RAMSTATUS_RAMBLOCK1_Off (0UL) /*!< Off */
+#define POWER_RAMSTATUS_RAMBLOCK1_On (1UL) /*!< On */
+
+/* Bit 0 : RAM block 0 is on or off/powering up */
+#define POWER_RAMSTATUS_RAMBLOCK0_Pos (0UL) /*!< Position of RAMBLOCK0 field. */
+#define POWER_RAMSTATUS_RAMBLOCK0_Msk (0x1UL << POWER_RAMSTATUS_RAMBLOCK0_Pos) /*!< Bit mask of RAMBLOCK0 field. */
+#define POWER_RAMSTATUS_RAMBLOCK0_Off (0UL) /*!< Off */
+#define POWER_RAMSTATUS_RAMBLOCK0_On (1UL) /*!< On */
+
+/* Register: POWER_SYSTEMOFF */
+/* Description: System OFF register */
+
+/* Bit 0 : Enable System OFF mode */
+#define POWER_SYSTEMOFF_SYSTEMOFF_Pos (0UL) /*!< Position of SYSTEMOFF field. */
+#define POWER_SYSTEMOFF_SYSTEMOFF_Msk (0x1UL << POWER_SYSTEMOFF_SYSTEMOFF_Pos) /*!< Bit mask of SYSTEMOFF field. */
+#define POWER_SYSTEMOFF_SYSTEMOFF_Enter (1UL) /*!< Enable System OFF mode */
+
+/* Register: POWER_POFCON */
+/* Description: Power failure comparator configuration */
+
+/* Bits 4..1 : Power failure comparator threshold setting */
+#define POWER_POFCON_THRESHOLD_Pos (1UL) /*!< Position of THRESHOLD field. */
+#define POWER_POFCON_THRESHOLD_Msk (0xFUL << POWER_POFCON_THRESHOLD_Pos) /*!< Bit mask of THRESHOLD field. */
+#define POWER_POFCON_THRESHOLD_V19 (6UL) /*!< Set threshold to 1.9 V */
+#define POWER_POFCON_THRESHOLD_V20 (7UL) /*!< Set threshold to 2.0 V */
+#define POWER_POFCON_THRESHOLD_V21 (8UL) /*!< Set threshold to 2.1 V */
+#define POWER_POFCON_THRESHOLD_V22 (9UL) /*!< Set threshold to 2.2 V */
+#define POWER_POFCON_THRESHOLD_V23 (10UL) /*!< Set threshold to 2.3 V */
+#define POWER_POFCON_THRESHOLD_V24 (11UL) /*!< Set threshold to 2.4 V */
+#define POWER_POFCON_THRESHOLD_V27 (14UL) /*!< Set threshold to 2.7 V */
+#define POWER_POFCON_THRESHOLD_V28 (15UL) /*!< Set threshold to 2.8 V */
+
+/* Bit 0 : Enable or disable power failure comparator */
+#define POWER_POFCON_POF_Pos (0UL) /*!< Position of POF field. */
+#define POWER_POFCON_POF_Msk (0x1UL << POWER_POFCON_POF_Pos) /*!< Bit mask of POF field. */
+#define POWER_POFCON_POF_Disabled (0UL) /*!< Disable */
+#define POWER_POFCON_POF_Enabled (1UL) /*!< Enable */
+
+/* Register: POWER_GPREGRET */
+/* Description: General purpose retention register */
+
+/* Bits 7..0 : General purpose retention register */
+#define POWER_GPREGRET_GPREGRET_Pos (0UL) /*!< Position of GPREGRET field. */
+#define POWER_GPREGRET_GPREGRET_Msk (0xFFUL << POWER_GPREGRET_GPREGRET_Pos) /*!< Bit mask of GPREGRET field. */
+
+/* Register: POWER_GPREGRET2 */
+/* Description: General purpose retention register */
+
+/* Bits 7..0 : General purpose retention register */
+#define POWER_GPREGRET2_GPREGRET_Pos (0UL) /*!< Position of GPREGRET field. */
+#define POWER_GPREGRET2_GPREGRET_Msk (0xFFUL << POWER_GPREGRET2_GPREGRET_Pos) /*!< Bit mask of GPREGRET field. */
+
+/* Register: POWER_RAMON */
+/* Description: Deprecated register -  RAM on/off register (this register is retained) */
+
+/* Bit 17 : Keep retention on RAM block 1 when RAM block is switched off */
+#define POWER_RAMON_OFFRAM1_Pos (17UL) /*!< Position of OFFRAM1 field. */
+#define POWER_RAMON_OFFRAM1_Msk (0x1UL << POWER_RAMON_OFFRAM1_Pos) /*!< Bit mask of OFFRAM1 field. */
+#define POWER_RAMON_OFFRAM1_RAM1Off (0UL) /*!< Off */
+#define POWER_RAMON_OFFRAM1_RAM1On (1UL) /*!< On */
+
+/* Bit 16 : Keep retention on RAM block 0 when RAM block is switched off */
+#define POWER_RAMON_OFFRAM0_Pos (16UL) /*!< Position of OFFRAM0 field. */
+#define POWER_RAMON_OFFRAM0_Msk (0x1UL << POWER_RAMON_OFFRAM0_Pos) /*!< Bit mask of OFFRAM0 field. */
+#define POWER_RAMON_OFFRAM0_RAM0Off (0UL) /*!< Off */
+#define POWER_RAMON_OFFRAM0_RAM0On (1UL) /*!< On */
+
+/* Bit 1 : Keep RAM block 1 on or off in system ON Mode */
+#define POWER_RAMON_ONRAM1_Pos (1UL) /*!< Position of ONRAM1 field. */
+#define POWER_RAMON_ONRAM1_Msk (0x1UL << POWER_RAMON_ONRAM1_Pos) /*!< Bit mask of ONRAM1 field. */
+#define POWER_RAMON_ONRAM1_RAM1Off (0UL) /*!< Off */
+#define POWER_RAMON_ONRAM1_RAM1On (1UL) /*!< On */
+
+/* Bit 0 : Keep RAM block 0 on or off in system ON Mode */
+#define POWER_RAMON_ONRAM0_Pos (0UL) /*!< Position of ONRAM0 field. */
+#define POWER_RAMON_ONRAM0_Msk (0x1UL << POWER_RAMON_ONRAM0_Pos) /*!< Bit mask of ONRAM0 field. */
+#define POWER_RAMON_ONRAM0_RAM0Off (0UL) /*!< Off */
+#define POWER_RAMON_ONRAM0_RAM0On (1UL) /*!< On */
+
+/* Register: POWER_RAMONB */
+/* Description: Deprecated register -  RAM on/off register (this register is retained) */
+
+/* Bit 17 : Keep retention on RAM block 3 when RAM block is switched off */
+#define POWER_RAMONB_OFFRAM3_Pos (17UL) /*!< Position of OFFRAM3 field. */
+#define POWER_RAMONB_OFFRAM3_Msk (0x1UL << POWER_RAMONB_OFFRAM3_Pos) /*!< Bit mask of OFFRAM3 field. */
+#define POWER_RAMONB_OFFRAM3_RAM3Off (0UL) /*!< Off */
+#define POWER_RAMONB_OFFRAM3_RAM3On (1UL) /*!< On */
+
+/* Bit 16 : Keep retention on RAM block 2 when RAM block is switched off */
+#define POWER_RAMONB_OFFRAM2_Pos (16UL) /*!< Position of OFFRAM2 field. */
+#define POWER_RAMONB_OFFRAM2_Msk (0x1UL << POWER_RAMONB_OFFRAM2_Pos) /*!< Bit mask of OFFRAM2 field. */
+#define POWER_RAMONB_OFFRAM2_RAM2Off (0UL) /*!< Off */
+#define POWER_RAMONB_OFFRAM2_RAM2On (1UL) /*!< On */
+
+/* Bit 1 : Keep RAM block 3 on or off in system ON Mode */
+#define POWER_RAMONB_ONRAM3_Pos (1UL) /*!< Position of ONRAM3 field. */
+#define POWER_RAMONB_ONRAM3_Msk (0x1UL << POWER_RAMONB_ONRAM3_Pos) /*!< Bit mask of ONRAM3 field. */
+#define POWER_RAMONB_ONRAM3_RAM3Off (0UL) /*!< Off */
+#define POWER_RAMONB_ONRAM3_RAM3On (1UL) /*!< On */
+
+/* Bit 0 : Keep RAM block 2 on or off in system ON Mode */
+#define POWER_RAMONB_ONRAM2_Pos (0UL) /*!< Position of ONRAM2 field. */
+#define POWER_RAMONB_ONRAM2_Msk (0x1UL << POWER_RAMONB_ONRAM2_Pos) /*!< Bit mask of ONRAM2 field. */
+#define POWER_RAMONB_ONRAM2_RAM2Off (0UL) /*!< Off */
+#define POWER_RAMONB_ONRAM2_RAM2On (1UL) /*!< On */
+
+/* Register: POWER_DCDCEN */
+/* Description: DC/DC enable register */
+
+/* Bit 0 : Enable or disable DC/DC converter */
+#define POWER_DCDCEN_DCDCEN_Pos (0UL) /*!< Position of DCDCEN field. */
+#define POWER_DCDCEN_DCDCEN_Msk (0x1UL << POWER_DCDCEN_DCDCEN_Pos) /*!< Bit mask of DCDCEN field. */
+#define POWER_DCDCEN_DCDCEN_Disabled (0UL) /*!< Disable */
+#define POWER_DCDCEN_DCDCEN_Enabled (1UL) /*!< Enable */
+
+/* Register: POWER_RAM_POWER */
+/* Description: Description cluster[0]:  RAM0 power control register */
+
+/* Bit 17 : Keep retention on RAM section S1 when RAM section is switched off */
+#define POWER_RAM_POWER_S1RETENTION_Pos (17UL) /*!< Position of S1RETENTION field. */
+#define POWER_RAM_POWER_S1RETENTION_Msk (0x1UL << POWER_RAM_POWER_S1RETENTION_Pos) /*!< Bit mask of S1RETENTION field. */
+#define POWER_RAM_POWER_S1RETENTION_Off (0UL) /*!< Off */
+#define POWER_RAM_POWER_S1RETENTION_On (1UL) /*!< On */
+
+/* Bit 16 : Keep retention on RAM section S0 when RAM section is switched off */
+#define POWER_RAM_POWER_S0RETENTION_Pos (16UL) /*!< Position of S0RETENTION field. */
+#define POWER_RAM_POWER_S0RETENTION_Msk (0x1UL << POWER_RAM_POWER_S0RETENTION_Pos) /*!< Bit mask of S0RETENTION field. */
+#define POWER_RAM_POWER_S0RETENTION_Off (0UL) /*!< Off */
+#define POWER_RAM_POWER_S0RETENTION_On (1UL) /*!< On */
+
+/* Bit 1 : Keep RAM section S1 of RAMm on or off in System ON mode */
+#define POWER_RAM_POWER_S1POWER_Pos (1UL) /*!< Position of S1POWER field. */
+#define POWER_RAM_POWER_S1POWER_Msk (0x1UL << POWER_RAM_POWER_S1POWER_Pos) /*!< Bit mask of S1POWER field. */
+#define POWER_RAM_POWER_S1POWER_Off (0UL) /*!< Off */
+#define POWER_RAM_POWER_S1POWER_On (1UL) /*!< On */
+
+/* Bit 0 : Keep RAM section S0 of RAMm on or off in System ON mode */
+#define POWER_RAM_POWER_S0POWER_Pos (0UL) /*!< Position of S0POWER field. */
+#define POWER_RAM_POWER_S0POWER_Msk (0x1UL << POWER_RAM_POWER_S0POWER_Pos) /*!< Bit mask of S0POWER field. */
+#define POWER_RAM_POWER_S0POWER_Off (0UL) /*!< Off */
+#define POWER_RAM_POWER_S0POWER_On (1UL) /*!< On */
+
+/* Register: POWER_RAM_POWERSET */
+/* Description: Description cluster[0]:  RAM0 power control set register */
+
+/* Bit 17 : Keep retention on RAM section S1 when RAM section is switched off */
+#define POWER_RAM_POWERSET_S1RETENTION_Pos (17UL) /*!< Position of S1RETENTION field. */
+#define POWER_RAM_POWERSET_S1RETENTION_Msk (0x1UL << POWER_RAM_POWERSET_S1RETENTION_Pos) /*!< Bit mask of S1RETENTION field. */
+#define POWER_RAM_POWERSET_S1RETENTION_On (1UL) /*!< On */
+
+/* Bit 16 : Keep retention on RAM section S0 when RAM section is switched off */
+#define POWER_RAM_POWERSET_S0RETENTION_Pos (16UL) /*!< Position of S0RETENTION field. */
+#define POWER_RAM_POWERSET_S0RETENTION_Msk (0x1UL << POWER_RAM_POWERSET_S0RETENTION_Pos) /*!< Bit mask of S0RETENTION field. */
+#define POWER_RAM_POWERSET_S0RETENTION_On (1UL) /*!< On */
+
+/* Bit 1 : Keep RAM section S1 of RAMm on or off in System ON mode */
+#define POWER_RAM_POWERSET_S1POWER_Pos (1UL) /*!< Position of S1POWER field. */
+#define POWER_RAM_POWERSET_S1POWER_Msk (0x1UL << POWER_RAM_POWERSET_S1POWER_Pos) /*!< Bit mask of S1POWER field. */
+#define POWER_RAM_POWERSET_S1POWER_On (1UL) /*!< On */
+
+/* Bit 0 : Keep RAM section S0 of RAMm on or off in System ON mode */
+#define POWER_RAM_POWERSET_S0POWER_Pos (0UL) /*!< Position of S0POWER field. */
+#define POWER_RAM_POWERSET_S0POWER_Msk (0x1UL << POWER_RAM_POWERSET_S0POWER_Pos) /*!< Bit mask of S0POWER field. */
+#define POWER_RAM_POWERSET_S0POWER_On (1UL) /*!< On */
+
+/* Register: POWER_RAM_POWERCLR */
+/* Description: Description cluster[0]:  RAM0 power control clear register */
+
+/* Bit 17 : Keep retention on RAM section S1 when RAM section is switched off */
+#define POWER_RAM_POWERCLR_S1RETENTION_Pos (17UL) /*!< Position of S1RETENTION field. */
+#define POWER_RAM_POWERCLR_S1RETENTION_Msk (0x1UL << POWER_RAM_POWERCLR_S1RETENTION_Pos) /*!< Bit mask of S1RETENTION field. */
+#define POWER_RAM_POWERCLR_S1RETENTION_Off (1UL) /*!< Off */
+
+/* Bit 16 : Keep retention on RAM section S0 when RAM section is switched off */
+#define POWER_RAM_POWERCLR_S0RETENTION_Pos (16UL) /*!< Position of S0RETENTION field. */
+#define POWER_RAM_POWERCLR_S0RETENTION_Msk (0x1UL << POWER_RAM_POWERCLR_S0RETENTION_Pos) /*!< Bit mask of S0RETENTION field. */
+#define POWER_RAM_POWERCLR_S0RETENTION_Off (1UL) /*!< Off */
+
+/* Bit 1 : Keep RAM section S1 of RAMm on or off in System ON mode */
+#define POWER_RAM_POWERCLR_S1POWER_Pos (1UL) /*!< Position of S1POWER field. */
+#define POWER_RAM_POWERCLR_S1POWER_Msk (0x1UL << POWER_RAM_POWERCLR_S1POWER_Pos) /*!< Bit mask of S1POWER field. */
+#define POWER_RAM_POWERCLR_S1POWER_Off (1UL) /*!< Off */
+
+/* Bit 0 : Keep RAM section S0 of RAMm on or off in System ON mode */
+#define POWER_RAM_POWERCLR_S0POWER_Pos (0UL) /*!< Position of S0POWER field. */
+#define POWER_RAM_POWERCLR_S0POWER_Msk (0x1UL << POWER_RAM_POWERCLR_S0POWER_Pos) /*!< Bit mask of S0POWER field. */
+#define POWER_RAM_POWERCLR_S0POWER_Off (1UL) /*!< Off */
+
+
+/* Peripheral: PPI */
+/* Description: Programmable Peripheral Interconnect */
+
+/* Register: PPI_CHEN */
+/* Description: Channel enable register */
+
+/* Bit 31 : Enable or disable channel 31 */
+#define PPI_CHEN_CH31_Pos (31UL) /*!< Position of CH31 field. */
+#define PPI_CHEN_CH31_Msk (0x1UL << PPI_CHEN_CH31_Pos) /*!< Bit mask of CH31 field. */
+#define PPI_CHEN_CH31_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH31_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 30 : Enable or disable channel 30 */
+#define PPI_CHEN_CH30_Pos (30UL) /*!< Position of CH30 field. */
+#define PPI_CHEN_CH30_Msk (0x1UL << PPI_CHEN_CH30_Pos) /*!< Bit mask of CH30 field. */
+#define PPI_CHEN_CH30_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH30_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 29 : Enable or disable channel 29 */
+#define PPI_CHEN_CH29_Pos (29UL) /*!< Position of CH29 field. */
+#define PPI_CHEN_CH29_Msk (0x1UL << PPI_CHEN_CH29_Pos) /*!< Bit mask of CH29 field. */
+#define PPI_CHEN_CH29_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH29_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 28 : Enable or disable channel 28 */
+#define PPI_CHEN_CH28_Pos (28UL) /*!< Position of CH28 field. */
+#define PPI_CHEN_CH28_Msk (0x1UL << PPI_CHEN_CH28_Pos) /*!< Bit mask of CH28 field. */
+#define PPI_CHEN_CH28_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH28_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 27 : Enable or disable channel 27 */
+#define PPI_CHEN_CH27_Pos (27UL) /*!< Position of CH27 field. */
+#define PPI_CHEN_CH27_Msk (0x1UL << PPI_CHEN_CH27_Pos) /*!< Bit mask of CH27 field. */
+#define PPI_CHEN_CH27_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH27_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 26 : Enable or disable channel 26 */
+#define PPI_CHEN_CH26_Pos (26UL) /*!< Position of CH26 field. */
+#define PPI_CHEN_CH26_Msk (0x1UL << PPI_CHEN_CH26_Pos) /*!< Bit mask of CH26 field. */
+#define PPI_CHEN_CH26_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH26_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 25 : Enable or disable channel 25 */
+#define PPI_CHEN_CH25_Pos (25UL) /*!< Position of CH25 field. */
+#define PPI_CHEN_CH25_Msk (0x1UL << PPI_CHEN_CH25_Pos) /*!< Bit mask of CH25 field. */
+#define PPI_CHEN_CH25_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH25_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 24 : Enable or disable channel 24 */
+#define PPI_CHEN_CH24_Pos (24UL) /*!< Position of CH24 field. */
+#define PPI_CHEN_CH24_Msk (0x1UL << PPI_CHEN_CH24_Pos) /*!< Bit mask of CH24 field. */
+#define PPI_CHEN_CH24_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH24_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 23 : Enable or disable channel 23 */
+#define PPI_CHEN_CH23_Pos (23UL) /*!< Position of CH23 field. */
+#define PPI_CHEN_CH23_Msk (0x1UL << PPI_CHEN_CH23_Pos) /*!< Bit mask of CH23 field. */
+#define PPI_CHEN_CH23_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH23_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 22 : Enable or disable channel 22 */
+#define PPI_CHEN_CH22_Pos (22UL) /*!< Position of CH22 field. */
+#define PPI_CHEN_CH22_Msk (0x1UL << PPI_CHEN_CH22_Pos) /*!< Bit mask of CH22 field. */
+#define PPI_CHEN_CH22_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH22_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 21 : Enable or disable channel 21 */
+#define PPI_CHEN_CH21_Pos (21UL) /*!< Position of CH21 field. */
+#define PPI_CHEN_CH21_Msk (0x1UL << PPI_CHEN_CH21_Pos) /*!< Bit mask of CH21 field. */
+#define PPI_CHEN_CH21_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH21_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 20 : Enable or disable channel 20 */
+#define PPI_CHEN_CH20_Pos (20UL) /*!< Position of CH20 field. */
+#define PPI_CHEN_CH20_Msk (0x1UL << PPI_CHEN_CH20_Pos) /*!< Bit mask of CH20 field. */
+#define PPI_CHEN_CH20_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH20_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 19 : Enable or disable channel 19 */
+#define PPI_CHEN_CH19_Pos (19UL) /*!< Position of CH19 field. */
+#define PPI_CHEN_CH19_Msk (0x1UL << PPI_CHEN_CH19_Pos) /*!< Bit mask of CH19 field. */
+#define PPI_CHEN_CH19_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH19_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 18 : Enable or disable channel 18 */
+#define PPI_CHEN_CH18_Pos (18UL) /*!< Position of CH18 field. */
+#define PPI_CHEN_CH18_Msk (0x1UL << PPI_CHEN_CH18_Pos) /*!< Bit mask of CH18 field. */
+#define PPI_CHEN_CH18_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH18_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 17 : Enable or disable channel 17 */
+#define PPI_CHEN_CH17_Pos (17UL) /*!< Position of CH17 field. */
+#define PPI_CHEN_CH17_Msk (0x1UL << PPI_CHEN_CH17_Pos) /*!< Bit mask of CH17 field. */
+#define PPI_CHEN_CH17_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH17_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 16 : Enable or disable channel 16 */
+#define PPI_CHEN_CH16_Pos (16UL) /*!< Position of CH16 field. */
+#define PPI_CHEN_CH16_Msk (0x1UL << PPI_CHEN_CH16_Pos) /*!< Bit mask of CH16 field. */
+#define PPI_CHEN_CH16_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH16_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 15 : Enable or disable channel 15 */
+#define PPI_CHEN_CH15_Pos (15UL) /*!< Position of CH15 field. */
+#define PPI_CHEN_CH15_Msk (0x1UL << PPI_CHEN_CH15_Pos) /*!< Bit mask of CH15 field. */
+#define PPI_CHEN_CH15_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH15_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 14 : Enable or disable channel 14 */
+#define PPI_CHEN_CH14_Pos (14UL) /*!< Position of CH14 field. */
+#define PPI_CHEN_CH14_Msk (0x1UL << PPI_CHEN_CH14_Pos) /*!< Bit mask of CH14 field. */
+#define PPI_CHEN_CH14_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH14_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 13 : Enable or disable channel 13 */
+#define PPI_CHEN_CH13_Pos (13UL) /*!< Position of CH13 field. */
+#define PPI_CHEN_CH13_Msk (0x1UL << PPI_CHEN_CH13_Pos) /*!< Bit mask of CH13 field. */
+#define PPI_CHEN_CH13_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH13_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 12 : Enable or disable channel 12 */
+#define PPI_CHEN_CH12_Pos (12UL) /*!< Position of CH12 field. */
+#define PPI_CHEN_CH12_Msk (0x1UL << PPI_CHEN_CH12_Pos) /*!< Bit mask of CH12 field. */
+#define PPI_CHEN_CH12_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH12_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 11 : Enable or disable channel 11 */
+#define PPI_CHEN_CH11_Pos (11UL) /*!< Position of CH11 field. */
+#define PPI_CHEN_CH11_Msk (0x1UL << PPI_CHEN_CH11_Pos) /*!< Bit mask of CH11 field. */
+#define PPI_CHEN_CH11_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH11_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 10 : Enable or disable channel 10 */
+#define PPI_CHEN_CH10_Pos (10UL) /*!< Position of CH10 field. */
+#define PPI_CHEN_CH10_Msk (0x1UL << PPI_CHEN_CH10_Pos) /*!< Bit mask of CH10 field. */
+#define PPI_CHEN_CH10_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH10_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 9 : Enable or disable channel 9 */
+#define PPI_CHEN_CH9_Pos (9UL) /*!< Position of CH9 field. */
+#define PPI_CHEN_CH9_Msk (0x1UL << PPI_CHEN_CH9_Pos) /*!< Bit mask of CH9 field. */
+#define PPI_CHEN_CH9_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH9_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 8 : Enable or disable channel 8 */
+#define PPI_CHEN_CH8_Pos (8UL) /*!< Position of CH8 field. */
+#define PPI_CHEN_CH8_Msk (0x1UL << PPI_CHEN_CH8_Pos) /*!< Bit mask of CH8 field. */
+#define PPI_CHEN_CH8_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH8_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 7 : Enable or disable channel 7 */
+#define PPI_CHEN_CH7_Pos (7UL) /*!< Position of CH7 field. */
+#define PPI_CHEN_CH7_Msk (0x1UL << PPI_CHEN_CH7_Pos) /*!< Bit mask of CH7 field. */
+#define PPI_CHEN_CH7_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH7_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 6 : Enable or disable channel 6 */
+#define PPI_CHEN_CH6_Pos (6UL) /*!< Position of CH6 field. */
+#define PPI_CHEN_CH6_Msk (0x1UL << PPI_CHEN_CH6_Pos) /*!< Bit mask of CH6 field. */
+#define PPI_CHEN_CH6_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH6_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 5 : Enable or disable channel 5 */
+#define PPI_CHEN_CH5_Pos (5UL) /*!< Position of CH5 field. */
+#define PPI_CHEN_CH5_Msk (0x1UL << PPI_CHEN_CH5_Pos) /*!< Bit mask of CH5 field. */
+#define PPI_CHEN_CH5_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH5_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 4 : Enable or disable channel 4 */
+#define PPI_CHEN_CH4_Pos (4UL) /*!< Position of CH4 field. */
+#define PPI_CHEN_CH4_Msk (0x1UL << PPI_CHEN_CH4_Pos) /*!< Bit mask of CH4 field. */
+#define PPI_CHEN_CH4_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH4_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 3 : Enable or disable channel 3 */
+#define PPI_CHEN_CH3_Pos (3UL) /*!< Position of CH3 field. */
+#define PPI_CHEN_CH3_Msk (0x1UL << PPI_CHEN_CH3_Pos) /*!< Bit mask of CH3 field. */
+#define PPI_CHEN_CH3_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH3_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 2 : Enable or disable channel 2 */
+#define PPI_CHEN_CH2_Pos (2UL) /*!< Position of CH2 field. */
+#define PPI_CHEN_CH2_Msk (0x1UL << PPI_CHEN_CH2_Pos) /*!< Bit mask of CH2 field. */
+#define PPI_CHEN_CH2_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH2_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 1 : Enable or disable channel 1 */
+#define PPI_CHEN_CH1_Pos (1UL) /*!< Position of CH1 field. */
+#define PPI_CHEN_CH1_Msk (0x1UL << PPI_CHEN_CH1_Pos) /*!< Bit mask of CH1 field. */
+#define PPI_CHEN_CH1_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH1_Enabled (1UL) /*!< Enable channel */
+
+/* Bit 0 : Enable or disable channel 0 */
+#define PPI_CHEN_CH0_Pos (0UL) /*!< Position of CH0 field. */
+#define PPI_CHEN_CH0_Msk (0x1UL << PPI_CHEN_CH0_Pos) /*!< Bit mask of CH0 field. */
+#define PPI_CHEN_CH0_Disabled (0UL) /*!< Disable channel */
+#define PPI_CHEN_CH0_Enabled (1UL) /*!< Enable channel */
+
+/* Register: PPI_CHENSET */
+/* Description: Channel enable set register */
+
+/* Bit 31 : Channel 31 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH31_Pos (31UL) /*!< Position of CH31 field. */
+#define PPI_CHENSET_CH31_Msk (0x1UL << PPI_CHENSET_CH31_Pos) /*!< Bit mask of CH31 field. */
+#define PPI_CHENSET_CH31_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH31_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH31_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 30 : Channel 30 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH30_Pos (30UL) /*!< Position of CH30 field. */
+#define PPI_CHENSET_CH30_Msk (0x1UL << PPI_CHENSET_CH30_Pos) /*!< Bit mask of CH30 field. */
+#define PPI_CHENSET_CH30_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH30_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH30_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 29 : Channel 29 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH29_Pos (29UL) /*!< Position of CH29 field. */
+#define PPI_CHENSET_CH29_Msk (0x1UL << PPI_CHENSET_CH29_Pos) /*!< Bit mask of CH29 field. */
+#define PPI_CHENSET_CH29_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH29_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH29_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 28 : Channel 28 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH28_Pos (28UL) /*!< Position of CH28 field. */
+#define PPI_CHENSET_CH28_Msk (0x1UL << PPI_CHENSET_CH28_Pos) /*!< Bit mask of CH28 field. */
+#define PPI_CHENSET_CH28_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH28_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH28_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 27 : Channel 27 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH27_Pos (27UL) /*!< Position of CH27 field. */
+#define PPI_CHENSET_CH27_Msk (0x1UL << PPI_CHENSET_CH27_Pos) /*!< Bit mask of CH27 field. */
+#define PPI_CHENSET_CH27_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH27_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH27_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 26 : Channel 26 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH26_Pos (26UL) /*!< Position of CH26 field. */
+#define PPI_CHENSET_CH26_Msk (0x1UL << PPI_CHENSET_CH26_Pos) /*!< Bit mask of CH26 field. */
+#define PPI_CHENSET_CH26_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH26_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH26_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 25 : Channel 25 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH25_Pos (25UL) /*!< Position of CH25 field. */
+#define PPI_CHENSET_CH25_Msk (0x1UL << PPI_CHENSET_CH25_Pos) /*!< Bit mask of CH25 field. */
+#define PPI_CHENSET_CH25_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH25_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH25_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 24 : Channel 24 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH24_Pos (24UL) /*!< Position of CH24 field. */
+#define PPI_CHENSET_CH24_Msk (0x1UL << PPI_CHENSET_CH24_Pos) /*!< Bit mask of CH24 field. */
+#define PPI_CHENSET_CH24_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH24_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH24_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 23 : Channel 23 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH23_Pos (23UL) /*!< Position of CH23 field. */
+#define PPI_CHENSET_CH23_Msk (0x1UL << PPI_CHENSET_CH23_Pos) /*!< Bit mask of CH23 field. */
+#define PPI_CHENSET_CH23_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH23_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH23_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 22 : Channel 22 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH22_Pos (22UL) /*!< Position of CH22 field. */
+#define PPI_CHENSET_CH22_Msk (0x1UL << PPI_CHENSET_CH22_Pos) /*!< Bit mask of CH22 field. */
+#define PPI_CHENSET_CH22_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH22_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH22_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 21 : Channel 21 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH21_Pos (21UL) /*!< Position of CH21 field. */
+#define PPI_CHENSET_CH21_Msk (0x1UL << PPI_CHENSET_CH21_Pos) /*!< Bit mask of CH21 field. */
+#define PPI_CHENSET_CH21_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH21_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH21_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 20 : Channel 20 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH20_Pos (20UL) /*!< Position of CH20 field. */
+#define PPI_CHENSET_CH20_Msk (0x1UL << PPI_CHENSET_CH20_Pos) /*!< Bit mask of CH20 field. */
+#define PPI_CHENSET_CH20_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH20_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH20_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 19 : Channel 19 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH19_Pos (19UL) /*!< Position of CH19 field. */
+#define PPI_CHENSET_CH19_Msk (0x1UL << PPI_CHENSET_CH19_Pos) /*!< Bit mask of CH19 field. */
+#define PPI_CHENSET_CH19_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH19_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH19_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 18 : Channel 18 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH18_Pos (18UL) /*!< Position of CH18 field. */
+#define PPI_CHENSET_CH18_Msk (0x1UL << PPI_CHENSET_CH18_Pos) /*!< Bit mask of CH18 field. */
+#define PPI_CHENSET_CH18_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH18_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH18_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 17 : Channel 17 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH17_Pos (17UL) /*!< Position of CH17 field. */
+#define PPI_CHENSET_CH17_Msk (0x1UL << PPI_CHENSET_CH17_Pos) /*!< Bit mask of CH17 field. */
+#define PPI_CHENSET_CH17_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH17_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH17_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 16 : Channel 16 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH16_Pos (16UL) /*!< Position of CH16 field. */
+#define PPI_CHENSET_CH16_Msk (0x1UL << PPI_CHENSET_CH16_Pos) /*!< Bit mask of CH16 field. */
+#define PPI_CHENSET_CH16_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH16_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH16_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 15 : Channel 15 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH15_Pos (15UL) /*!< Position of CH15 field. */
+#define PPI_CHENSET_CH15_Msk (0x1UL << PPI_CHENSET_CH15_Pos) /*!< Bit mask of CH15 field. */
+#define PPI_CHENSET_CH15_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH15_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH15_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 14 : Channel 14 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH14_Pos (14UL) /*!< Position of CH14 field. */
+#define PPI_CHENSET_CH14_Msk (0x1UL << PPI_CHENSET_CH14_Pos) /*!< Bit mask of CH14 field. */
+#define PPI_CHENSET_CH14_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH14_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH14_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 13 : Channel 13 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH13_Pos (13UL) /*!< Position of CH13 field. */
+#define PPI_CHENSET_CH13_Msk (0x1UL << PPI_CHENSET_CH13_Pos) /*!< Bit mask of CH13 field. */
+#define PPI_CHENSET_CH13_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH13_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH13_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 12 : Channel 12 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH12_Pos (12UL) /*!< Position of CH12 field. */
+#define PPI_CHENSET_CH12_Msk (0x1UL << PPI_CHENSET_CH12_Pos) /*!< Bit mask of CH12 field. */
+#define PPI_CHENSET_CH12_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH12_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH12_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 11 : Channel 11 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH11_Pos (11UL) /*!< Position of CH11 field. */
+#define PPI_CHENSET_CH11_Msk (0x1UL << PPI_CHENSET_CH11_Pos) /*!< Bit mask of CH11 field. */
+#define PPI_CHENSET_CH11_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH11_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH11_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 10 : Channel 10 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH10_Pos (10UL) /*!< Position of CH10 field. */
+#define PPI_CHENSET_CH10_Msk (0x1UL << PPI_CHENSET_CH10_Pos) /*!< Bit mask of CH10 field. */
+#define PPI_CHENSET_CH10_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH10_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH10_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 9 : Channel 9 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH9_Pos (9UL) /*!< Position of CH9 field. */
+#define PPI_CHENSET_CH9_Msk (0x1UL << PPI_CHENSET_CH9_Pos) /*!< Bit mask of CH9 field. */
+#define PPI_CHENSET_CH9_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH9_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH9_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 8 : Channel 8 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH8_Pos (8UL) /*!< Position of CH8 field. */
+#define PPI_CHENSET_CH8_Msk (0x1UL << PPI_CHENSET_CH8_Pos) /*!< Bit mask of CH8 field. */
+#define PPI_CHENSET_CH8_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH8_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH8_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 7 : Channel 7 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH7_Pos (7UL) /*!< Position of CH7 field. */
+#define PPI_CHENSET_CH7_Msk (0x1UL << PPI_CHENSET_CH7_Pos) /*!< Bit mask of CH7 field. */
+#define PPI_CHENSET_CH7_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH7_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH7_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 6 : Channel 6 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH6_Pos (6UL) /*!< Position of CH6 field. */
+#define PPI_CHENSET_CH6_Msk (0x1UL << PPI_CHENSET_CH6_Pos) /*!< Bit mask of CH6 field. */
+#define PPI_CHENSET_CH6_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH6_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH6_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 5 : Channel 5 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH5_Pos (5UL) /*!< Position of CH5 field. */
+#define PPI_CHENSET_CH5_Msk (0x1UL << PPI_CHENSET_CH5_Pos) /*!< Bit mask of CH5 field. */
+#define PPI_CHENSET_CH5_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH5_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH5_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 4 : Channel 4 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH4_Pos (4UL) /*!< Position of CH4 field. */
+#define PPI_CHENSET_CH4_Msk (0x1UL << PPI_CHENSET_CH4_Pos) /*!< Bit mask of CH4 field. */
+#define PPI_CHENSET_CH4_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH4_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH4_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 3 : Channel 3 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH3_Pos (3UL) /*!< Position of CH3 field. */
+#define PPI_CHENSET_CH3_Msk (0x1UL << PPI_CHENSET_CH3_Pos) /*!< Bit mask of CH3 field. */
+#define PPI_CHENSET_CH3_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH3_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH3_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 2 : Channel 2 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH2_Pos (2UL) /*!< Position of CH2 field. */
+#define PPI_CHENSET_CH2_Msk (0x1UL << PPI_CHENSET_CH2_Pos) /*!< Bit mask of CH2 field. */
+#define PPI_CHENSET_CH2_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH2_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH2_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 1 : Channel 1 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH1_Pos (1UL) /*!< Position of CH1 field. */
+#define PPI_CHENSET_CH1_Msk (0x1UL << PPI_CHENSET_CH1_Pos) /*!< Bit mask of CH1 field. */
+#define PPI_CHENSET_CH1_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH1_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH1_Set (1UL) /*!< Write: Enable channel */
+
+/* Bit 0 : Channel 0 enable set register.  Writing '0' has no effect */
+#define PPI_CHENSET_CH0_Pos (0UL) /*!< Position of CH0 field. */
+#define PPI_CHENSET_CH0_Msk (0x1UL << PPI_CHENSET_CH0_Pos) /*!< Bit mask of CH0 field. */
+#define PPI_CHENSET_CH0_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENSET_CH0_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENSET_CH0_Set (1UL) /*!< Write: Enable channel */
+
+/* Register: PPI_CHENCLR */
+/* Description: Channel enable clear register */
+
+/* Bit 31 : Channel 31 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH31_Pos (31UL) /*!< Position of CH31 field. */
+#define PPI_CHENCLR_CH31_Msk (0x1UL << PPI_CHENCLR_CH31_Pos) /*!< Bit mask of CH31 field. */
+#define PPI_CHENCLR_CH31_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH31_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH31_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 30 : Channel 30 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH30_Pos (30UL) /*!< Position of CH30 field. */
+#define PPI_CHENCLR_CH30_Msk (0x1UL << PPI_CHENCLR_CH30_Pos) /*!< Bit mask of CH30 field. */
+#define PPI_CHENCLR_CH30_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH30_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH30_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 29 : Channel 29 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH29_Pos (29UL) /*!< Position of CH29 field. */
+#define PPI_CHENCLR_CH29_Msk (0x1UL << PPI_CHENCLR_CH29_Pos) /*!< Bit mask of CH29 field. */
+#define PPI_CHENCLR_CH29_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH29_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH29_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 28 : Channel 28 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH28_Pos (28UL) /*!< Position of CH28 field. */
+#define PPI_CHENCLR_CH28_Msk (0x1UL << PPI_CHENCLR_CH28_Pos) /*!< Bit mask of CH28 field. */
+#define PPI_CHENCLR_CH28_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH28_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH28_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 27 : Channel 27 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH27_Pos (27UL) /*!< Position of CH27 field. */
+#define PPI_CHENCLR_CH27_Msk (0x1UL << PPI_CHENCLR_CH27_Pos) /*!< Bit mask of CH27 field. */
+#define PPI_CHENCLR_CH27_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH27_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH27_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 26 : Channel 26 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH26_Pos (26UL) /*!< Position of CH26 field. */
+#define PPI_CHENCLR_CH26_Msk (0x1UL << PPI_CHENCLR_CH26_Pos) /*!< Bit mask of CH26 field. */
+#define PPI_CHENCLR_CH26_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH26_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH26_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 25 : Channel 25 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH25_Pos (25UL) /*!< Position of CH25 field. */
+#define PPI_CHENCLR_CH25_Msk (0x1UL << PPI_CHENCLR_CH25_Pos) /*!< Bit mask of CH25 field. */
+#define PPI_CHENCLR_CH25_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH25_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH25_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 24 : Channel 24 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH24_Pos (24UL) /*!< Position of CH24 field. */
+#define PPI_CHENCLR_CH24_Msk (0x1UL << PPI_CHENCLR_CH24_Pos) /*!< Bit mask of CH24 field. */
+#define PPI_CHENCLR_CH24_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH24_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH24_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 23 : Channel 23 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH23_Pos (23UL) /*!< Position of CH23 field. */
+#define PPI_CHENCLR_CH23_Msk (0x1UL << PPI_CHENCLR_CH23_Pos) /*!< Bit mask of CH23 field. */
+#define PPI_CHENCLR_CH23_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH23_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH23_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 22 : Channel 22 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH22_Pos (22UL) /*!< Position of CH22 field. */
+#define PPI_CHENCLR_CH22_Msk (0x1UL << PPI_CHENCLR_CH22_Pos) /*!< Bit mask of CH22 field. */
+#define PPI_CHENCLR_CH22_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH22_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH22_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 21 : Channel 21 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH21_Pos (21UL) /*!< Position of CH21 field. */
+#define PPI_CHENCLR_CH21_Msk (0x1UL << PPI_CHENCLR_CH21_Pos) /*!< Bit mask of CH21 field. */
+#define PPI_CHENCLR_CH21_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH21_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH21_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 20 : Channel 20 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH20_Pos (20UL) /*!< Position of CH20 field. */
+#define PPI_CHENCLR_CH20_Msk (0x1UL << PPI_CHENCLR_CH20_Pos) /*!< Bit mask of CH20 field. */
+#define PPI_CHENCLR_CH20_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH20_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH20_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 19 : Channel 19 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH19_Pos (19UL) /*!< Position of CH19 field. */
+#define PPI_CHENCLR_CH19_Msk (0x1UL << PPI_CHENCLR_CH19_Pos) /*!< Bit mask of CH19 field. */
+#define PPI_CHENCLR_CH19_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH19_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH19_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 18 : Channel 18 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH18_Pos (18UL) /*!< Position of CH18 field. */
+#define PPI_CHENCLR_CH18_Msk (0x1UL << PPI_CHENCLR_CH18_Pos) /*!< Bit mask of CH18 field. */
+#define PPI_CHENCLR_CH18_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH18_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH18_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 17 : Channel 17 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH17_Pos (17UL) /*!< Position of CH17 field. */
+#define PPI_CHENCLR_CH17_Msk (0x1UL << PPI_CHENCLR_CH17_Pos) /*!< Bit mask of CH17 field. */
+#define PPI_CHENCLR_CH17_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH17_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH17_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 16 : Channel 16 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH16_Pos (16UL) /*!< Position of CH16 field. */
+#define PPI_CHENCLR_CH16_Msk (0x1UL << PPI_CHENCLR_CH16_Pos) /*!< Bit mask of CH16 field. */
+#define PPI_CHENCLR_CH16_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH16_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH16_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 15 : Channel 15 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH15_Pos (15UL) /*!< Position of CH15 field. */
+#define PPI_CHENCLR_CH15_Msk (0x1UL << PPI_CHENCLR_CH15_Pos) /*!< Bit mask of CH15 field. */
+#define PPI_CHENCLR_CH15_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH15_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH15_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 14 : Channel 14 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH14_Pos (14UL) /*!< Position of CH14 field. */
+#define PPI_CHENCLR_CH14_Msk (0x1UL << PPI_CHENCLR_CH14_Pos) /*!< Bit mask of CH14 field. */
+#define PPI_CHENCLR_CH14_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH14_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH14_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 13 : Channel 13 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH13_Pos (13UL) /*!< Position of CH13 field. */
+#define PPI_CHENCLR_CH13_Msk (0x1UL << PPI_CHENCLR_CH13_Pos) /*!< Bit mask of CH13 field. */
+#define PPI_CHENCLR_CH13_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH13_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH13_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 12 : Channel 12 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH12_Pos (12UL) /*!< Position of CH12 field. */
+#define PPI_CHENCLR_CH12_Msk (0x1UL << PPI_CHENCLR_CH12_Pos) /*!< Bit mask of CH12 field. */
+#define PPI_CHENCLR_CH12_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH12_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH12_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 11 : Channel 11 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH11_Pos (11UL) /*!< Position of CH11 field. */
+#define PPI_CHENCLR_CH11_Msk (0x1UL << PPI_CHENCLR_CH11_Pos) /*!< Bit mask of CH11 field. */
+#define PPI_CHENCLR_CH11_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH11_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH11_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 10 : Channel 10 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH10_Pos (10UL) /*!< Position of CH10 field. */
+#define PPI_CHENCLR_CH10_Msk (0x1UL << PPI_CHENCLR_CH10_Pos) /*!< Bit mask of CH10 field. */
+#define PPI_CHENCLR_CH10_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH10_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH10_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 9 : Channel 9 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH9_Pos (9UL) /*!< Position of CH9 field. */
+#define PPI_CHENCLR_CH9_Msk (0x1UL << PPI_CHENCLR_CH9_Pos) /*!< Bit mask of CH9 field. */
+#define PPI_CHENCLR_CH9_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH9_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH9_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 8 : Channel 8 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH8_Pos (8UL) /*!< Position of CH8 field. */
+#define PPI_CHENCLR_CH8_Msk (0x1UL << PPI_CHENCLR_CH8_Pos) /*!< Bit mask of CH8 field. */
+#define PPI_CHENCLR_CH8_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH8_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH8_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 7 : Channel 7 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH7_Pos (7UL) /*!< Position of CH7 field. */
+#define PPI_CHENCLR_CH7_Msk (0x1UL << PPI_CHENCLR_CH7_Pos) /*!< Bit mask of CH7 field. */
+#define PPI_CHENCLR_CH7_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH7_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH7_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 6 : Channel 6 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH6_Pos (6UL) /*!< Position of CH6 field. */
+#define PPI_CHENCLR_CH6_Msk (0x1UL << PPI_CHENCLR_CH6_Pos) /*!< Bit mask of CH6 field. */
+#define PPI_CHENCLR_CH6_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH6_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH6_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 5 : Channel 5 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH5_Pos (5UL) /*!< Position of CH5 field. */
+#define PPI_CHENCLR_CH5_Msk (0x1UL << PPI_CHENCLR_CH5_Pos) /*!< Bit mask of CH5 field. */
+#define PPI_CHENCLR_CH5_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH5_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH5_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 4 : Channel 4 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH4_Pos (4UL) /*!< Position of CH4 field. */
+#define PPI_CHENCLR_CH4_Msk (0x1UL << PPI_CHENCLR_CH4_Pos) /*!< Bit mask of CH4 field. */
+#define PPI_CHENCLR_CH4_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH4_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH4_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 3 : Channel 3 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH3_Pos (3UL) /*!< Position of CH3 field. */
+#define PPI_CHENCLR_CH3_Msk (0x1UL << PPI_CHENCLR_CH3_Pos) /*!< Bit mask of CH3 field. */
+#define PPI_CHENCLR_CH3_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH3_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH3_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 2 : Channel 2 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH2_Pos (2UL) /*!< Position of CH2 field. */
+#define PPI_CHENCLR_CH2_Msk (0x1UL << PPI_CHENCLR_CH2_Pos) /*!< Bit mask of CH2 field. */
+#define PPI_CHENCLR_CH2_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH2_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH2_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 1 : Channel 1 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH1_Pos (1UL) /*!< Position of CH1 field. */
+#define PPI_CHENCLR_CH1_Msk (0x1UL << PPI_CHENCLR_CH1_Pos) /*!< Bit mask of CH1 field. */
+#define PPI_CHENCLR_CH1_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH1_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH1_Clear (1UL) /*!< Write: disable channel */
+
+/* Bit 0 : Channel 0 enable clear register.  Writing '0' has no effect */
+#define PPI_CHENCLR_CH0_Pos (0UL) /*!< Position of CH0 field. */
+#define PPI_CHENCLR_CH0_Msk (0x1UL << PPI_CHENCLR_CH0_Pos) /*!< Bit mask of CH0 field. */
+#define PPI_CHENCLR_CH0_Disabled (0UL) /*!< Read: channel disabled */
+#define PPI_CHENCLR_CH0_Enabled (1UL) /*!< Read: channel enabled */
+#define PPI_CHENCLR_CH0_Clear (1UL) /*!< Write: disable channel */
+
+/* Register: PPI_CH_EEP */
+/* Description: Description cluster[0]:  Channel 0 event end-point */
+
+/* Bits 31..0 : Pointer to event register. Accepts only addresses to registers from the Event group. */
+#define PPI_CH_EEP_EEP_Pos (0UL) /*!< Position of EEP field. */
+#define PPI_CH_EEP_EEP_Msk (0xFFFFFFFFUL << PPI_CH_EEP_EEP_Pos) /*!< Bit mask of EEP field. */
+
+/* Register: PPI_CH_TEP */
+/* Description: Description cluster[0]:  Channel 0 task end-point */
+
+/* Bits 31..0 : Pointer to task register. Accepts only addresses to registers from the Task group. */
+#define PPI_CH_TEP_TEP_Pos (0UL) /*!< Position of TEP field. */
+#define PPI_CH_TEP_TEP_Msk (0xFFFFFFFFUL << PPI_CH_TEP_TEP_Pos) /*!< Bit mask of TEP field. */
+
+/* Register: PPI_CHG */
+/* Description: Description collection[0]:  Channel group 0 */
+
+/* Bit 31 : Include or exclude channel 31 */
+#define PPI_CHG_CH31_Pos (31UL) /*!< Position of CH31 field. */
+#define PPI_CHG_CH31_Msk (0x1UL << PPI_CHG_CH31_Pos) /*!< Bit mask of CH31 field. */
+#define PPI_CHG_CH31_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH31_Included (1UL) /*!< Include */
+
+/* Bit 30 : Include or exclude channel 30 */
+#define PPI_CHG_CH30_Pos (30UL) /*!< Position of CH30 field. */
+#define PPI_CHG_CH30_Msk (0x1UL << PPI_CHG_CH30_Pos) /*!< Bit mask of CH30 field. */
+#define PPI_CHG_CH30_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH30_Included (1UL) /*!< Include */
+
+/* Bit 29 : Include or exclude channel 29 */
+#define PPI_CHG_CH29_Pos (29UL) /*!< Position of CH29 field. */
+#define PPI_CHG_CH29_Msk (0x1UL << PPI_CHG_CH29_Pos) /*!< Bit mask of CH29 field. */
+#define PPI_CHG_CH29_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH29_Included (1UL) /*!< Include */
+
+/* Bit 28 : Include or exclude channel 28 */
+#define PPI_CHG_CH28_Pos (28UL) /*!< Position of CH28 field. */
+#define PPI_CHG_CH28_Msk (0x1UL << PPI_CHG_CH28_Pos) /*!< Bit mask of CH28 field. */
+#define PPI_CHG_CH28_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH28_Included (1UL) /*!< Include */
+
+/* Bit 27 : Include or exclude channel 27 */
+#define PPI_CHG_CH27_Pos (27UL) /*!< Position of CH27 field. */
+#define PPI_CHG_CH27_Msk (0x1UL << PPI_CHG_CH27_Pos) /*!< Bit mask of CH27 field. */
+#define PPI_CHG_CH27_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH27_Included (1UL) /*!< Include */
+
+/* Bit 26 : Include or exclude channel 26 */
+#define PPI_CHG_CH26_Pos (26UL) /*!< Position of CH26 field. */
+#define PPI_CHG_CH26_Msk (0x1UL << PPI_CHG_CH26_Pos) /*!< Bit mask of CH26 field. */
+#define PPI_CHG_CH26_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH26_Included (1UL) /*!< Include */
+
+/* Bit 25 : Include or exclude channel 25 */
+#define PPI_CHG_CH25_Pos (25UL) /*!< Position of CH25 field. */
+#define PPI_CHG_CH25_Msk (0x1UL << PPI_CHG_CH25_Pos) /*!< Bit mask of CH25 field. */
+#define PPI_CHG_CH25_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH25_Included (1UL) /*!< Include */
+
+/* Bit 24 : Include or exclude channel 24 */
+#define PPI_CHG_CH24_Pos (24UL) /*!< Position of CH24 field. */
+#define PPI_CHG_CH24_Msk (0x1UL << PPI_CHG_CH24_Pos) /*!< Bit mask of CH24 field. */
+#define PPI_CHG_CH24_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH24_Included (1UL) /*!< Include */
+
+/* Bit 23 : Include or exclude channel 23 */
+#define PPI_CHG_CH23_Pos (23UL) /*!< Position of CH23 field. */
+#define PPI_CHG_CH23_Msk (0x1UL << PPI_CHG_CH23_Pos) /*!< Bit mask of CH23 field. */
+#define PPI_CHG_CH23_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH23_Included (1UL) /*!< Include */
+
+/* Bit 22 : Include or exclude channel 22 */
+#define PPI_CHG_CH22_Pos (22UL) /*!< Position of CH22 field. */
+#define PPI_CHG_CH22_Msk (0x1UL << PPI_CHG_CH22_Pos) /*!< Bit mask of CH22 field. */
+#define PPI_CHG_CH22_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH22_Included (1UL) /*!< Include */
+
+/* Bit 21 : Include or exclude channel 21 */
+#define PPI_CHG_CH21_Pos (21UL) /*!< Position of CH21 field. */
+#define PPI_CHG_CH21_Msk (0x1UL << PPI_CHG_CH21_Pos) /*!< Bit mask of CH21 field. */
+#define PPI_CHG_CH21_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH21_Included (1UL) /*!< Include */
+
+/* Bit 20 : Include or exclude channel 20 */
+#define PPI_CHG_CH20_Pos (20UL) /*!< Position of CH20 field. */
+#define PPI_CHG_CH20_Msk (0x1UL << PPI_CHG_CH20_Pos) /*!< Bit mask of CH20 field. */
+#define PPI_CHG_CH20_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH20_Included (1UL) /*!< Include */
+
+/* Bit 19 : Include or exclude channel 19 */
+#define PPI_CHG_CH19_Pos (19UL) /*!< Position of CH19 field. */
+#define PPI_CHG_CH19_Msk (0x1UL << PPI_CHG_CH19_Pos) /*!< Bit mask of CH19 field. */
+#define PPI_CHG_CH19_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH19_Included (1UL) /*!< Include */
+
+/* Bit 18 : Include or exclude channel 18 */
+#define PPI_CHG_CH18_Pos (18UL) /*!< Position of CH18 field. */
+#define PPI_CHG_CH18_Msk (0x1UL << PPI_CHG_CH18_Pos) /*!< Bit mask of CH18 field. */
+#define PPI_CHG_CH18_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH18_Included (1UL) /*!< Include */
+
+/* Bit 17 : Include or exclude channel 17 */
+#define PPI_CHG_CH17_Pos (17UL) /*!< Position of CH17 field. */
+#define PPI_CHG_CH17_Msk (0x1UL << PPI_CHG_CH17_Pos) /*!< Bit mask of CH17 field. */
+#define PPI_CHG_CH17_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH17_Included (1UL) /*!< Include */
+
+/* Bit 16 : Include or exclude channel 16 */
+#define PPI_CHG_CH16_Pos (16UL) /*!< Position of CH16 field. */
+#define PPI_CHG_CH16_Msk (0x1UL << PPI_CHG_CH16_Pos) /*!< Bit mask of CH16 field. */
+#define PPI_CHG_CH16_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH16_Included (1UL) /*!< Include */
+
+/* Bit 15 : Include or exclude channel 15 */
+#define PPI_CHG_CH15_Pos (15UL) /*!< Position of CH15 field. */
+#define PPI_CHG_CH15_Msk (0x1UL << PPI_CHG_CH15_Pos) /*!< Bit mask of CH15 field. */
+#define PPI_CHG_CH15_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH15_Included (1UL) /*!< Include */
+
+/* Bit 14 : Include or exclude channel 14 */
+#define PPI_CHG_CH14_Pos (14UL) /*!< Position of CH14 field. */
+#define PPI_CHG_CH14_Msk (0x1UL << PPI_CHG_CH14_Pos) /*!< Bit mask of CH14 field. */
+#define PPI_CHG_CH14_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH14_Included (1UL) /*!< Include */
+
+/* Bit 13 : Include or exclude channel 13 */
+#define PPI_CHG_CH13_Pos (13UL) /*!< Position of CH13 field. */
+#define PPI_CHG_CH13_Msk (0x1UL << PPI_CHG_CH13_Pos) /*!< Bit mask of CH13 field. */
+#define PPI_CHG_CH13_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH13_Included (1UL) /*!< Include */
+
+/* Bit 12 : Include or exclude channel 12 */
+#define PPI_CHG_CH12_Pos (12UL) /*!< Position of CH12 field. */
+#define PPI_CHG_CH12_Msk (0x1UL << PPI_CHG_CH12_Pos) /*!< Bit mask of CH12 field. */
+#define PPI_CHG_CH12_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH12_Included (1UL) /*!< Include */
+
+/* Bit 11 : Include or exclude channel 11 */
+#define PPI_CHG_CH11_Pos (11UL) /*!< Position of CH11 field. */
+#define PPI_CHG_CH11_Msk (0x1UL << PPI_CHG_CH11_Pos) /*!< Bit mask of CH11 field. */
+#define PPI_CHG_CH11_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH11_Included (1UL) /*!< Include */
+
+/* Bit 10 : Include or exclude channel 10 */
+#define PPI_CHG_CH10_Pos (10UL) /*!< Position of CH10 field. */
+#define PPI_CHG_CH10_Msk (0x1UL << PPI_CHG_CH10_Pos) /*!< Bit mask of CH10 field. */
+#define PPI_CHG_CH10_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH10_Included (1UL) /*!< Include */
+
+/* Bit 9 : Include or exclude channel 9 */
+#define PPI_CHG_CH9_Pos (9UL) /*!< Position of CH9 field. */
+#define PPI_CHG_CH9_Msk (0x1UL << PPI_CHG_CH9_Pos) /*!< Bit mask of CH9 field. */
+#define PPI_CHG_CH9_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH9_Included (1UL) /*!< Include */
+
+/* Bit 8 : Include or exclude channel 8 */
+#define PPI_CHG_CH8_Pos (8UL) /*!< Position of CH8 field. */
+#define PPI_CHG_CH8_Msk (0x1UL << PPI_CHG_CH8_Pos) /*!< Bit mask of CH8 field. */
+#define PPI_CHG_CH8_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH8_Included (1UL) /*!< Include */
+
+/* Bit 7 : Include or exclude channel 7 */
+#define PPI_CHG_CH7_Pos (7UL) /*!< Position of CH7 field. */
+#define PPI_CHG_CH7_Msk (0x1UL << PPI_CHG_CH7_Pos) /*!< Bit mask of CH7 field. */
+#define PPI_CHG_CH7_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH7_Included (1UL) /*!< Include */
+
+/* Bit 6 : Include or exclude channel 6 */
+#define PPI_CHG_CH6_Pos (6UL) /*!< Position of CH6 field. */
+#define PPI_CHG_CH6_Msk (0x1UL << PPI_CHG_CH6_Pos) /*!< Bit mask of CH6 field. */
+#define PPI_CHG_CH6_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH6_Included (1UL) /*!< Include */
+
+/* Bit 5 : Include or exclude channel 5 */
+#define PPI_CHG_CH5_Pos (5UL) /*!< Position of CH5 field. */
+#define PPI_CHG_CH5_Msk (0x1UL << PPI_CHG_CH5_Pos) /*!< Bit mask of CH5 field. */
+#define PPI_CHG_CH5_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH5_Included (1UL) /*!< Include */
+
+/* Bit 4 : Include or exclude channel 4 */
+#define PPI_CHG_CH4_Pos (4UL) /*!< Position of CH4 field. */
+#define PPI_CHG_CH4_Msk (0x1UL << PPI_CHG_CH4_Pos) /*!< Bit mask of CH4 field. */
+#define PPI_CHG_CH4_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH4_Included (1UL) /*!< Include */
+
+/* Bit 3 : Include or exclude channel 3 */
+#define PPI_CHG_CH3_Pos (3UL) /*!< Position of CH3 field. */
+#define PPI_CHG_CH3_Msk (0x1UL << PPI_CHG_CH3_Pos) /*!< Bit mask of CH3 field. */
+#define PPI_CHG_CH3_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH3_Included (1UL) /*!< Include */
+
+/* Bit 2 : Include or exclude channel 2 */
+#define PPI_CHG_CH2_Pos (2UL) /*!< Position of CH2 field. */
+#define PPI_CHG_CH2_Msk (0x1UL << PPI_CHG_CH2_Pos) /*!< Bit mask of CH2 field. */
+#define PPI_CHG_CH2_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH2_Included (1UL) /*!< Include */
+
+/* Bit 1 : Include or exclude channel 1 */
+#define PPI_CHG_CH1_Pos (1UL) /*!< Position of CH1 field. */
+#define PPI_CHG_CH1_Msk (0x1UL << PPI_CHG_CH1_Pos) /*!< Bit mask of CH1 field. */
+#define PPI_CHG_CH1_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH1_Included (1UL) /*!< Include */
+
+/* Bit 0 : Include or exclude channel 0 */
+#define PPI_CHG_CH0_Pos (0UL) /*!< Position of CH0 field. */
+#define PPI_CHG_CH0_Msk (0x1UL << PPI_CHG_CH0_Pos) /*!< Bit mask of CH0 field. */
+#define PPI_CHG_CH0_Excluded (0UL) /*!< Exclude */
+#define PPI_CHG_CH0_Included (1UL) /*!< Include */
+
+/* Register: PPI_FORK_TEP */
+/* Description: Description cluster[0]:  Channel 0 task end-point */
+
+/* Bits 31..0 : Pointer to task register */
+#define PPI_FORK_TEP_TEP_Pos (0UL) /*!< Position of TEP field. */
+#define PPI_FORK_TEP_TEP_Msk (0xFFFFFFFFUL << PPI_FORK_TEP_TEP_Pos) /*!< Bit mask of TEP field. */
+
+
+/* Peripheral: PWM */
+/* Description: Pulse Width Modulation Unit 0 */
+
+/* Register: PWM_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 4 : Shortcut between LOOPSDONE event and STOP task */
+#define PWM_SHORTS_LOOPSDONE_STOP_Pos (4UL) /*!< Position of LOOPSDONE_STOP field. */
+#define PWM_SHORTS_LOOPSDONE_STOP_Msk (0x1UL << PWM_SHORTS_LOOPSDONE_STOP_Pos) /*!< Bit mask of LOOPSDONE_STOP field. */
+#define PWM_SHORTS_LOOPSDONE_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define PWM_SHORTS_LOOPSDONE_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 3 : Shortcut between LOOPSDONE event and SEQSTART[1] task */
+#define PWM_SHORTS_LOOPSDONE_SEQSTART1_Pos (3UL) /*!< Position of LOOPSDONE_SEQSTART1 field. */
+#define PWM_SHORTS_LOOPSDONE_SEQSTART1_Msk (0x1UL << PWM_SHORTS_LOOPSDONE_SEQSTART1_Pos) /*!< Bit mask of LOOPSDONE_SEQSTART1 field. */
+#define PWM_SHORTS_LOOPSDONE_SEQSTART1_Disabled (0UL) /*!< Disable shortcut */
+#define PWM_SHORTS_LOOPSDONE_SEQSTART1_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 2 : Shortcut between LOOPSDONE event and SEQSTART[0] task */
+#define PWM_SHORTS_LOOPSDONE_SEQSTART0_Pos (2UL) /*!< Position of LOOPSDONE_SEQSTART0 field. */
+#define PWM_SHORTS_LOOPSDONE_SEQSTART0_Msk (0x1UL << PWM_SHORTS_LOOPSDONE_SEQSTART0_Pos) /*!< Bit mask of LOOPSDONE_SEQSTART0 field. */
+#define PWM_SHORTS_LOOPSDONE_SEQSTART0_Disabled (0UL) /*!< Disable shortcut */
+#define PWM_SHORTS_LOOPSDONE_SEQSTART0_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 1 : Shortcut between SEQEND[1] event and STOP task */
+#define PWM_SHORTS_SEQEND1_STOP_Pos (1UL) /*!< Position of SEQEND1_STOP field. */
+#define PWM_SHORTS_SEQEND1_STOP_Msk (0x1UL << PWM_SHORTS_SEQEND1_STOP_Pos) /*!< Bit mask of SEQEND1_STOP field. */
+#define PWM_SHORTS_SEQEND1_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define PWM_SHORTS_SEQEND1_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 0 : Shortcut between SEQEND[0] event and STOP task */
+#define PWM_SHORTS_SEQEND0_STOP_Pos (0UL) /*!< Position of SEQEND0_STOP field. */
+#define PWM_SHORTS_SEQEND0_STOP_Msk (0x1UL << PWM_SHORTS_SEQEND0_STOP_Pos) /*!< Bit mask of SEQEND0_STOP field. */
+#define PWM_SHORTS_SEQEND0_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define PWM_SHORTS_SEQEND0_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: PWM_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 7 : Enable or disable interrupt for LOOPSDONE event */
+#define PWM_INTEN_LOOPSDONE_Pos (7UL) /*!< Position of LOOPSDONE field. */
+#define PWM_INTEN_LOOPSDONE_Msk (0x1UL << PWM_INTEN_LOOPSDONE_Pos) /*!< Bit mask of LOOPSDONE field. */
+#define PWM_INTEN_LOOPSDONE_Disabled (0UL) /*!< Disable */
+#define PWM_INTEN_LOOPSDONE_Enabled (1UL) /*!< Enable */
+
+/* Bit 6 : Enable or disable interrupt for PWMPERIODEND event */
+#define PWM_INTEN_PWMPERIODEND_Pos (6UL) /*!< Position of PWMPERIODEND field. */
+#define PWM_INTEN_PWMPERIODEND_Msk (0x1UL << PWM_INTEN_PWMPERIODEND_Pos) /*!< Bit mask of PWMPERIODEND field. */
+#define PWM_INTEN_PWMPERIODEND_Disabled (0UL) /*!< Disable */
+#define PWM_INTEN_PWMPERIODEND_Enabled (1UL) /*!< Enable */
+
+/* Bit 5 : Enable or disable interrupt for SEQEND[1] event */
+#define PWM_INTEN_SEQEND1_Pos (5UL) /*!< Position of SEQEND1 field. */
+#define PWM_INTEN_SEQEND1_Msk (0x1UL << PWM_INTEN_SEQEND1_Pos) /*!< Bit mask of SEQEND1 field. */
+#define PWM_INTEN_SEQEND1_Disabled (0UL) /*!< Disable */
+#define PWM_INTEN_SEQEND1_Enabled (1UL) /*!< Enable */
+
+/* Bit 4 : Enable or disable interrupt for SEQEND[0] event */
+#define PWM_INTEN_SEQEND0_Pos (4UL) /*!< Position of SEQEND0 field. */
+#define PWM_INTEN_SEQEND0_Msk (0x1UL << PWM_INTEN_SEQEND0_Pos) /*!< Bit mask of SEQEND0 field. */
+#define PWM_INTEN_SEQEND0_Disabled (0UL) /*!< Disable */
+#define PWM_INTEN_SEQEND0_Enabled (1UL) /*!< Enable */
+
+/* Bit 3 : Enable or disable interrupt for SEQSTARTED[1] event */
+#define PWM_INTEN_SEQSTARTED1_Pos (3UL) /*!< Position of SEQSTARTED1 field. */
+#define PWM_INTEN_SEQSTARTED1_Msk (0x1UL << PWM_INTEN_SEQSTARTED1_Pos) /*!< Bit mask of SEQSTARTED1 field. */
+#define PWM_INTEN_SEQSTARTED1_Disabled (0UL) /*!< Disable */
+#define PWM_INTEN_SEQSTARTED1_Enabled (1UL) /*!< Enable */
+
+/* Bit 2 : Enable or disable interrupt for SEQSTARTED[0] event */
+#define PWM_INTEN_SEQSTARTED0_Pos (2UL) /*!< Position of SEQSTARTED0 field. */
+#define PWM_INTEN_SEQSTARTED0_Msk (0x1UL << PWM_INTEN_SEQSTARTED0_Pos) /*!< Bit mask of SEQSTARTED0 field. */
+#define PWM_INTEN_SEQSTARTED0_Disabled (0UL) /*!< Disable */
+#define PWM_INTEN_SEQSTARTED0_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for STOPPED event */
+#define PWM_INTEN_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define PWM_INTEN_STOPPED_Msk (0x1UL << PWM_INTEN_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define PWM_INTEN_STOPPED_Disabled (0UL) /*!< Disable */
+#define PWM_INTEN_STOPPED_Enabled (1UL) /*!< Enable */
+
+/* Register: PWM_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 7 : Write '1' to Enable interrupt for LOOPSDONE event */
+#define PWM_INTENSET_LOOPSDONE_Pos (7UL) /*!< Position of LOOPSDONE field. */
+#define PWM_INTENSET_LOOPSDONE_Msk (0x1UL << PWM_INTENSET_LOOPSDONE_Pos) /*!< Bit mask of LOOPSDONE field. */
+#define PWM_INTENSET_LOOPSDONE_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENSET_LOOPSDONE_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENSET_LOOPSDONE_Set (1UL) /*!< Enable */
+
+/* Bit 6 : Write '1' to Enable interrupt for PWMPERIODEND event */
+#define PWM_INTENSET_PWMPERIODEND_Pos (6UL) /*!< Position of PWMPERIODEND field. */
+#define PWM_INTENSET_PWMPERIODEND_Msk (0x1UL << PWM_INTENSET_PWMPERIODEND_Pos) /*!< Bit mask of PWMPERIODEND field. */
+#define PWM_INTENSET_PWMPERIODEND_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENSET_PWMPERIODEND_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENSET_PWMPERIODEND_Set (1UL) /*!< Enable */
+
+/* Bit 5 : Write '1' to Enable interrupt for SEQEND[1] event */
+#define PWM_INTENSET_SEQEND1_Pos (5UL) /*!< Position of SEQEND1 field. */
+#define PWM_INTENSET_SEQEND1_Msk (0x1UL << PWM_INTENSET_SEQEND1_Pos) /*!< Bit mask of SEQEND1 field. */
+#define PWM_INTENSET_SEQEND1_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENSET_SEQEND1_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENSET_SEQEND1_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable interrupt for SEQEND[0] event */
+#define PWM_INTENSET_SEQEND0_Pos (4UL) /*!< Position of SEQEND0 field. */
+#define PWM_INTENSET_SEQEND0_Msk (0x1UL << PWM_INTENSET_SEQEND0_Pos) /*!< Bit mask of SEQEND0 field. */
+#define PWM_INTENSET_SEQEND0_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENSET_SEQEND0_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENSET_SEQEND0_Set (1UL) /*!< Enable */
+
+/* Bit 3 : Write '1' to Enable interrupt for SEQSTARTED[1] event */
+#define PWM_INTENSET_SEQSTARTED1_Pos (3UL) /*!< Position of SEQSTARTED1 field. */
+#define PWM_INTENSET_SEQSTARTED1_Msk (0x1UL << PWM_INTENSET_SEQSTARTED1_Pos) /*!< Bit mask of SEQSTARTED1 field. */
+#define PWM_INTENSET_SEQSTARTED1_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENSET_SEQSTARTED1_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENSET_SEQSTARTED1_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for SEQSTARTED[0] event */
+#define PWM_INTENSET_SEQSTARTED0_Pos (2UL) /*!< Position of SEQSTARTED0 field. */
+#define PWM_INTENSET_SEQSTARTED0_Msk (0x1UL << PWM_INTENSET_SEQSTARTED0_Pos) /*!< Bit mask of SEQSTARTED0 field. */
+#define PWM_INTENSET_SEQSTARTED0_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENSET_SEQSTARTED0_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENSET_SEQSTARTED0_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for STOPPED event */
+#define PWM_INTENSET_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define PWM_INTENSET_STOPPED_Msk (0x1UL << PWM_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define PWM_INTENSET_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENSET_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENSET_STOPPED_Set (1UL) /*!< Enable */
+
+/* Register: PWM_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 7 : Write '1' to Disable interrupt for LOOPSDONE event */
+#define PWM_INTENCLR_LOOPSDONE_Pos (7UL) /*!< Position of LOOPSDONE field. */
+#define PWM_INTENCLR_LOOPSDONE_Msk (0x1UL << PWM_INTENCLR_LOOPSDONE_Pos) /*!< Bit mask of LOOPSDONE field. */
+#define PWM_INTENCLR_LOOPSDONE_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENCLR_LOOPSDONE_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENCLR_LOOPSDONE_Clear (1UL) /*!< Disable */
+
+/* Bit 6 : Write '1' to Disable interrupt for PWMPERIODEND event */
+#define PWM_INTENCLR_PWMPERIODEND_Pos (6UL) /*!< Position of PWMPERIODEND field. */
+#define PWM_INTENCLR_PWMPERIODEND_Msk (0x1UL << PWM_INTENCLR_PWMPERIODEND_Pos) /*!< Bit mask of PWMPERIODEND field. */
+#define PWM_INTENCLR_PWMPERIODEND_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENCLR_PWMPERIODEND_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENCLR_PWMPERIODEND_Clear (1UL) /*!< Disable */
+
+/* Bit 5 : Write '1' to Disable interrupt for SEQEND[1] event */
+#define PWM_INTENCLR_SEQEND1_Pos (5UL) /*!< Position of SEQEND1 field. */
+#define PWM_INTENCLR_SEQEND1_Msk (0x1UL << PWM_INTENCLR_SEQEND1_Pos) /*!< Bit mask of SEQEND1 field. */
+#define PWM_INTENCLR_SEQEND1_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENCLR_SEQEND1_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENCLR_SEQEND1_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable interrupt for SEQEND[0] event */
+#define PWM_INTENCLR_SEQEND0_Pos (4UL) /*!< Position of SEQEND0 field. */
+#define PWM_INTENCLR_SEQEND0_Msk (0x1UL << PWM_INTENCLR_SEQEND0_Pos) /*!< Bit mask of SEQEND0 field. */
+#define PWM_INTENCLR_SEQEND0_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENCLR_SEQEND0_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENCLR_SEQEND0_Clear (1UL) /*!< Disable */
+
+/* Bit 3 : Write '1' to Disable interrupt for SEQSTARTED[1] event */
+#define PWM_INTENCLR_SEQSTARTED1_Pos (3UL) /*!< Position of SEQSTARTED1 field. */
+#define PWM_INTENCLR_SEQSTARTED1_Msk (0x1UL << PWM_INTENCLR_SEQSTARTED1_Pos) /*!< Bit mask of SEQSTARTED1 field. */
+#define PWM_INTENCLR_SEQSTARTED1_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENCLR_SEQSTARTED1_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENCLR_SEQSTARTED1_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for SEQSTARTED[0] event */
+#define PWM_INTENCLR_SEQSTARTED0_Pos (2UL) /*!< Position of SEQSTARTED0 field. */
+#define PWM_INTENCLR_SEQSTARTED0_Msk (0x1UL << PWM_INTENCLR_SEQSTARTED0_Pos) /*!< Bit mask of SEQSTARTED0 field. */
+#define PWM_INTENCLR_SEQSTARTED0_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENCLR_SEQSTARTED0_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENCLR_SEQSTARTED0_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for STOPPED event */
+#define PWM_INTENCLR_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define PWM_INTENCLR_STOPPED_Msk (0x1UL << PWM_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define PWM_INTENCLR_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define PWM_INTENCLR_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define PWM_INTENCLR_STOPPED_Clear (1UL) /*!< Disable */
+
+/* Register: PWM_ENABLE */
+/* Description: PWM module enable register */
+
+/* Bit 0 : Enable or disable PWM module */
+#define PWM_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define PWM_ENABLE_ENABLE_Msk (0x1UL << PWM_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define PWM_ENABLE_ENABLE_Disabled (0UL) /*!< Disabled */
+#define PWM_ENABLE_ENABLE_Enabled (1UL) /*!< Enable */
+
+/* Register: PWM_MODE */
+/* Description: Selects operating mode of the wave counter */
+
+/* Bit 0 : Selects up or up and down as wave counter mode */
+#define PWM_MODE_UPDOWN_Pos (0UL) /*!< Position of UPDOWN field. */
+#define PWM_MODE_UPDOWN_Msk (0x1UL << PWM_MODE_UPDOWN_Pos) /*!< Bit mask of UPDOWN field. */
+#define PWM_MODE_UPDOWN_Up (0UL) /*!< Up counter - edge aligned PWM duty-cycle */
+#define PWM_MODE_UPDOWN_UpAndDown (1UL) /*!< Up and down counter - center aligned PWM duty cycle */
+
+/* Register: PWM_COUNTERTOP */
+/* Description: Value up to which the pulse generator counter counts */
+
+/* Bits 14..0 : Value up to which the pulse generator counter counts. This register is ignored when DECODER.MODE=WaveForm and only values from RAM will be used. */
+#define PWM_COUNTERTOP_COUNTERTOP_Pos (0UL) /*!< Position of COUNTERTOP field. */
+#define PWM_COUNTERTOP_COUNTERTOP_Msk (0x7FFFUL << PWM_COUNTERTOP_COUNTERTOP_Pos) /*!< Bit mask of COUNTERTOP field. */
+
+/* Register: PWM_PRESCALER */
+/* Description: Configuration for PWM_CLK */
+
+/* Bits 2..0 : Pre-scaler of PWM_CLK */
+#define PWM_PRESCALER_PRESCALER_Pos (0UL) /*!< Position of PRESCALER field. */
+#define PWM_PRESCALER_PRESCALER_Msk (0x7UL << PWM_PRESCALER_PRESCALER_Pos) /*!< Bit mask of PRESCALER field. */
+#define PWM_PRESCALER_PRESCALER_DIV_1 (0UL) /*!< Divide by   1 (16MHz) */
+#define PWM_PRESCALER_PRESCALER_DIV_2 (1UL) /*!< Divide by   2 ( 8MHz) */
+#define PWM_PRESCALER_PRESCALER_DIV_4 (2UL) /*!< Divide by   4 ( 4MHz) */
+#define PWM_PRESCALER_PRESCALER_DIV_8 (3UL) /*!< Divide by   8 ( 2MHz) */
+#define PWM_PRESCALER_PRESCALER_DIV_16 (4UL) /*!< Divide by  16 ( 1MHz) */
+#define PWM_PRESCALER_PRESCALER_DIV_32 (5UL) /*!< Divide by  32 ( 500kHz) */
+#define PWM_PRESCALER_PRESCALER_DIV_64 (6UL) /*!< Divide by  64 ( 250kHz) */
+#define PWM_PRESCALER_PRESCALER_DIV_128 (7UL) /*!< Divide by 128 ( 125kHz) */
+
+/* Register: PWM_DECODER */
+/* Description: Configuration of the decoder */
+
+/* Bit 8 : Selects source for advancing the active sequence */
+#define PWM_DECODER_MODE_Pos (8UL) /*!< Position of MODE field. */
+#define PWM_DECODER_MODE_Msk (0x1UL << PWM_DECODER_MODE_Pos) /*!< Bit mask of MODE field. */
+#define PWM_DECODER_MODE_RefreshCount (0UL) /*!< SEQ[n].REFRESH is used to determine loading internal compare registers */
+#define PWM_DECODER_MODE_NextStep (1UL) /*!< NEXTSTEP task causes a new value to be loaded to internal compare registers */
+
+/* Bits 2..0 : How a sequence is read from RAM and spread to the compare register */
+#define PWM_DECODER_LOAD_Pos (0UL) /*!< Position of LOAD field. */
+#define PWM_DECODER_LOAD_Msk (0x7UL << PWM_DECODER_LOAD_Pos) /*!< Bit mask of LOAD field. */
+#define PWM_DECODER_LOAD_Common (0UL) /*!< 1st half word (16-bit) used in all PWM channels 0..3 */
+#define PWM_DECODER_LOAD_Grouped (1UL) /*!< 1st half word (16-bit) used in channel 0..1; 2nd word in channel 2..3 */
+#define PWM_DECODER_LOAD_Individual (2UL) /*!< 1st half word (16-bit) in ch.0; 2nd in ch.1; ...; 4th in ch.3 */
+#define PWM_DECODER_LOAD_WaveForm (3UL) /*!< 1st half word (16-bit) in ch.0; 2nd in ch.1; ...; 4th in COUNTERTOP */
+
+/* Register: PWM_LOOP */
+/* Description: Amount of playback of a loop */
+
+/* Bits 15..0 : Amount of playback of pattern cycles */
+#define PWM_LOOP_CNT_Pos (0UL) /*!< Position of CNT field. */
+#define PWM_LOOP_CNT_Msk (0xFFFFUL << PWM_LOOP_CNT_Pos) /*!< Bit mask of CNT field. */
+#define PWM_LOOP_CNT_Disabled (0UL) /*!< Looping disabled (stop at the end of the sequence) */
+
+/* Register: PWM_SEQ_PTR */
+/* Description: Description cluster[0]:  Beginning address in Data RAM of sequence A */
+
+/* Bits 31..0 : Beginning address in Data RAM of sequence A */
+#define PWM_SEQ_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define PWM_SEQ_PTR_PTR_Msk (0xFFFFFFFFUL << PWM_SEQ_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: PWM_SEQ_CNT */
+/* Description: Description cluster[0]:  Amount of values (duty cycles) in sequence A */
+
+/* Bits 14..0 : Amount of values (duty cycles) in sequence A */
+#define PWM_SEQ_CNT_CNT_Pos (0UL) /*!< Position of CNT field. */
+#define PWM_SEQ_CNT_CNT_Msk (0x7FFFUL << PWM_SEQ_CNT_CNT_Pos) /*!< Bit mask of CNT field. */
+#define PWM_SEQ_CNT_CNT_Disabled (0UL) /*!< Sequence is disabled, and shall not be started as it is empty */
+
+/* Register: PWM_SEQ_REFRESH */
+/* Description: Description cluster[0]:  Amount of additional PWM periods between samples loaded to compare register (load every CNT+1 PWM periods) */
+
+/* Bits 23..0 : Amount of additional PWM periods between samples loaded to compare register (load every CNT+1 PWM periods) */
+#define PWM_SEQ_REFRESH_CNT_Pos (0UL) /*!< Position of CNT field. */
+#define PWM_SEQ_REFRESH_CNT_Msk (0xFFFFFFUL << PWM_SEQ_REFRESH_CNT_Pos) /*!< Bit mask of CNT field. */
+#define PWM_SEQ_REFRESH_CNT_Continuous (0UL) /*!< Update every PWM period */
+
+/* Register: PWM_SEQ_ENDDELAY */
+/* Description: Description cluster[0]:  Time added after the sequence */
+
+/* Bits 23..0 : Time added after the sequence in PWM periods */
+#define PWM_SEQ_ENDDELAY_CNT_Pos (0UL) /*!< Position of CNT field. */
+#define PWM_SEQ_ENDDELAY_CNT_Msk (0xFFFFFFUL << PWM_SEQ_ENDDELAY_CNT_Pos) /*!< Bit mask of CNT field. */
+
+/* Register: PWM_PSEL_OUT */
+/* Description: Description collection[0]:  Output pin select for PWM channel 0 */
+
+/* Bit 31 : Connection */
+#define PWM_PSEL_OUT_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define PWM_PSEL_OUT_CONNECT_Msk (0x1UL << PWM_PSEL_OUT_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define PWM_PSEL_OUT_CONNECT_Connected (0UL) /*!< Connect */
+#define PWM_PSEL_OUT_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define PWM_PSEL_OUT_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define PWM_PSEL_OUT_PIN_Msk (0x1FUL << PWM_PSEL_OUT_PIN_Pos) /*!< Bit mask of PIN field. */
+
+
+/* Peripheral: QDEC */
+/* Description: Quadrature Decoder */
+
+/* Register: QDEC_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 6 : Shortcut between SAMPLERDY event and READCLRACC task */
+#define QDEC_SHORTS_SAMPLERDY_READCLRACC_Pos (6UL) /*!< Position of SAMPLERDY_READCLRACC field. */
+#define QDEC_SHORTS_SAMPLERDY_READCLRACC_Msk (0x1UL << QDEC_SHORTS_SAMPLERDY_READCLRACC_Pos) /*!< Bit mask of SAMPLERDY_READCLRACC field. */
+#define QDEC_SHORTS_SAMPLERDY_READCLRACC_Disabled (0UL) /*!< Disable shortcut */
+#define QDEC_SHORTS_SAMPLERDY_READCLRACC_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 5 : Shortcut between DBLRDY event and STOP task */
+#define QDEC_SHORTS_DBLRDY_STOP_Pos (5UL) /*!< Position of DBLRDY_STOP field. */
+#define QDEC_SHORTS_DBLRDY_STOP_Msk (0x1UL << QDEC_SHORTS_DBLRDY_STOP_Pos) /*!< Bit mask of DBLRDY_STOP field. */
+#define QDEC_SHORTS_DBLRDY_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define QDEC_SHORTS_DBLRDY_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 4 : Shortcut between DBLRDY event and RDCLRDBL task */
+#define QDEC_SHORTS_DBLRDY_RDCLRDBL_Pos (4UL) /*!< Position of DBLRDY_RDCLRDBL field. */
+#define QDEC_SHORTS_DBLRDY_RDCLRDBL_Msk (0x1UL << QDEC_SHORTS_DBLRDY_RDCLRDBL_Pos) /*!< Bit mask of DBLRDY_RDCLRDBL field. */
+#define QDEC_SHORTS_DBLRDY_RDCLRDBL_Disabled (0UL) /*!< Disable shortcut */
+#define QDEC_SHORTS_DBLRDY_RDCLRDBL_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 3 : Shortcut between REPORTRDY event and STOP task */
+#define QDEC_SHORTS_REPORTRDY_STOP_Pos (3UL) /*!< Position of REPORTRDY_STOP field. */
+#define QDEC_SHORTS_REPORTRDY_STOP_Msk (0x1UL << QDEC_SHORTS_REPORTRDY_STOP_Pos) /*!< Bit mask of REPORTRDY_STOP field. */
+#define QDEC_SHORTS_REPORTRDY_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define QDEC_SHORTS_REPORTRDY_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 2 : Shortcut between REPORTRDY event and RDCLRACC task */
+#define QDEC_SHORTS_REPORTRDY_RDCLRACC_Pos (2UL) /*!< Position of REPORTRDY_RDCLRACC field. */
+#define QDEC_SHORTS_REPORTRDY_RDCLRACC_Msk (0x1UL << QDEC_SHORTS_REPORTRDY_RDCLRACC_Pos) /*!< Bit mask of REPORTRDY_RDCLRACC field. */
+#define QDEC_SHORTS_REPORTRDY_RDCLRACC_Disabled (0UL) /*!< Disable shortcut */
+#define QDEC_SHORTS_REPORTRDY_RDCLRACC_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 1 : Shortcut between SAMPLERDY event and STOP task */
+#define QDEC_SHORTS_SAMPLERDY_STOP_Pos (1UL) /*!< Position of SAMPLERDY_STOP field. */
+#define QDEC_SHORTS_SAMPLERDY_STOP_Msk (0x1UL << QDEC_SHORTS_SAMPLERDY_STOP_Pos) /*!< Bit mask of SAMPLERDY_STOP field. */
+#define QDEC_SHORTS_SAMPLERDY_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define QDEC_SHORTS_SAMPLERDY_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 0 : Shortcut between REPORTRDY event and READCLRACC task */
+#define QDEC_SHORTS_REPORTRDY_READCLRACC_Pos (0UL) /*!< Position of REPORTRDY_READCLRACC field. */
+#define QDEC_SHORTS_REPORTRDY_READCLRACC_Msk (0x1UL << QDEC_SHORTS_REPORTRDY_READCLRACC_Pos) /*!< Bit mask of REPORTRDY_READCLRACC field. */
+#define QDEC_SHORTS_REPORTRDY_READCLRACC_Disabled (0UL) /*!< Disable shortcut */
+#define QDEC_SHORTS_REPORTRDY_READCLRACC_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: QDEC_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 4 : Write '1' to Enable interrupt for STOPPED event */
+#define QDEC_INTENSET_STOPPED_Pos (4UL) /*!< Position of STOPPED field. */
+#define QDEC_INTENSET_STOPPED_Msk (0x1UL << QDEC_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define QDEC_INTENSET_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define QDEC_INTENSET_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define QDEC_INTENSET_STOPPED_Set (1UL) /*!< Enable */
+
+/* Bit 3 : Write '1' to Enable interrupt for DBLRDY event */
+#define QDEC_INTENSET_DBLRDY_Pos (3UL) /*!< Position of DBLRDY field. */
+#define QDEC_INTENSET_DBLRDY_Msk (0x1UL << QDEC_INTENSET_DBLRDY_Pos) /*!< Bit mask of DBLRDY field. */
+#define QDEC_INTENSET_DBLRDY_Disabled (0UL) /*!< Read: Disabled */
+#define QDEC_INTENSET_DBLRDY_Enabled (1UL) /*!< Read: Enabled */
+#define QDEC_INTENSET_DBLRDY_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for ACCOF event */
+#define QDEC_INTENSET_ACCOF_Pos (2UL) /*!< Position of ACCOF field. */
+#define QDEC_INTENSET_ACCOF_Msk (0x1UL << QDEC_INTENSET_ACCOF_Pos) /*!< Bit mask of ACCOF field. */
+#define QDEC_INTENSET_ACCOF_Disabled (0UL) /*!< Read: Disabled */
+#define QDEC_INTENSET_ACCOF_Enabled (1UL) /*!< Read: Enabled */
+#define QDEC_INTENSET_ACCOF_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for REPORTRDY event */
+#define QDEC_INTENSET_REPORTRDY_Pos (1UL) /*!< Position of REPORTRDY field. */
+#define QDEC_INTENSET_REPORTRDY_Msk (0x1UL << QDEC_INTENSET_REPORTRDY_Pos) /*!< Bit mask of REPORTRDY field. */
+#define QDEC_INTENSET_REPORTRDY_Disabled (0UL) /*!< Read: Disabled */
+#define QDEC_INTENSET_REPORTRDY_Enabled (1UL) /*!< Read: Enabled */
+#define QDEC_INTENSET_REPORTRDY_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for SAMPLERDY event */
+#define QDEC_INTENSET_SAMPLERDY_Pos (0UL) /*!< Position of SAMPLERDY field. */
+#define QDEC_INTENSET_SAMPLERDY_Msk (0x1UL << QDEC_INTENSET_SAMPLERDY_Pos) /*!< Bit mask of SAMPLERDY field. */
+#define QDEC_INTENSET_SAMPLERDY_Disabled (0UL) /*!< Read: Disabled */
+#define QDEC_INTENSET_SAMPLERDY_Enabled (1UL) /*!< Read: Enabled */
+#define QDEC_INTENSET_SAMPLERDY_Set (1UL) /*!< Enable */
+
+/* Register: QDEC_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 4 : Write '1' to Disable interrupt for STOPPED event */
+#define QDEC_INTENCLR_STOPPED_Pos (4UL) /*!< Position of STOPPED field. */
+#define QDEC_INTENCLR_STOPPED_Msk (0x1UL << QDEC_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define QDEC_INTENCLR_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define QDEC_INTENCLR_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define QDEC_INTENCLR_STOPPED_Clear (1UL) /*!< Disable */
+
+/* Bit 3 : Write '1' to Disable interrupt for DBLRDY event */
+#define QDEC_INTENCLR_DBLRDY_Pos (3UL) /*!< Position of DBLRDY field. */
+#define QDEC_INTENCLR_DBLRDY_Msk (0x1UL << QDEC_INTENCLR_DBLRDY_Pos) /*!< Bit mask of DBLRDY field. */
+#define QDEC_INTENCLR_DBLRDY_Disabled (0UL) /*!< Read: Disabled */
+#define QDEC_INTENCLR_DBLRDY_Enabled (1UL) /*!< Read: Enabled */
+#define QDEC_INTENCLR_DBLRDY_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for ACCOF event */
+#define QDEC_INTENCLR_ACCOF_Pos (2UL) /*!< Position of ACCOF field. */
+#define QDEC_INTENCLR_ACCOF_Msk (0x1UL << QDEC_INTENCLR_ACCOF_Pos) /*!< Bit mask of ACCOF field. */
+#define QDEC_INTENCLR_ACCOF_Disabled (0UL) /*!< Read: Disabled */
+#define QDEC_INTENCLR_ACCOF_Enabled (1UL) /*!< Read: Enabled */
+#define QDEC_INTENCLR_ACCOF_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for REPORTRDY event */
+#define QDEC_INTENCLR_REPORTRDY_Pos (1UL) /*!< Position of REPORTRDY field. */
+#define QDEC_INTENCLR_REPORTRDY_Msk (0x1UL << QDEC_INTENCLR_REPORTRDY_Pos) /*!< Bit mask of REPORTRDY field. */
+#define QDEC_INTENCLR_REPORTRDY_Disabled (0UL) /*!< Read: Disabled */
+#define QDEC_INTENCLR_REPORTRDY_Enabled (1UL) /*!< Read: Enabled */
+#define QDEC_INTENCLR_REPORTRDY_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for SAMPLERDY event */
+#define QDEC_INTENCLR_SAMPLERDY_Pos (0UL) /*!< Position of SAMPLERDY field. */
+#define QDEC_INTENCLR_SAMPLERDY_Msk (0x1UL << QDEC_INTENCLR_SAMPLERDY_Pos) /*!< Bit mask of SAMPLERDY field. */
+#define QDEC_INTENCLR_SAMPLERDY_Disabled (0UL) /*!< Read: Disabled */
+#define QDEC_INTENCLR_SAMPLERDY_Enabled (1UL) /*!< Read: Enabled */
+#define QDEC_INTENCLR_SAMPLERDY_Clear (1UL) /*!< Disable */
+
+/* Register: QDEC_ENABLE */
+/* Description: Enable the quadrature decoder */
+
+/* Bit 0 : Enable or disable the quadrature decoder */
+#define QDEC_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define QDEC_ENABLE_ENABLE_Msk (0x1UL << QDEC_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define QDEC_ENABLE_ENABLE_Disabled (0UL) /*!< Disable */
+#define QDEC_ENABLE_ENABLE_Enabled (1UL) /*!< Enable */
+
+/* Register: QDEC_LEDPOL */
+/* Description: LED output pin polarity */
+
+/* Bit 0 : LED output pin polarity */
+#define QDEC_LEDPOL_LEDPOL_Pos (0UL) /*!< Position of LEDPOL field. */
+#define QDEC_LEDPOL_LEDPOL_Msk (0x1UL << QDEC_LEDPOL_LEDPOL_Pos) /*!< Bit mask of LEDPOL field. */
+#define QDEC_LEDPOL_LEDPOL_ActiveLow (0UL) /*!< Led active on output pin low */
+#define QDEC_LEDPOL_LEDPOL_ActiveHigh (1UL) /*!< Led active on output pin high */
+
+/* Register: QDEC_SAMPLEPER */
+/* Description: Sample period */
+
+/* Bits 3..0 : Sample period. The SAMPLE register will be updated for every new sample */
+#define QDEC_SAMPLEPER_SAMPLEPER_Pos (0UL) /*!< Position of SAMPLEPER field. */
+#define QDEC_SAMPLEPER_SAMPLEPER_Msk (0xFUL << QDEC_SAMPLEPER_SAMPLEPER_Pos) /*!< Bit mask of SAMPLEPER field. */
+#define QDEC_SAMPLEPER_SAMPLEPER_128us (0UL) /*!< 128 us */
+#define QDEC_SAMPLEPER_SAMPLEPER_256us (1UL) /*!< 256 us */
+#define QDEC_SAMPLEPER_SAMPLEPER_512us (2UL) /*!< 512 us */
+#define QDEC_SAMPLEPER_SAMPLEPER_1024us (3UL) /*!< 1024 us */
+#define QDEC_SAMPLEPER_SAMPLEPER_2048us (4UL) /*!< 2048 us */
+#define QDEC_SAMPLEPER_SAMPLEPER_4096us (5UL) /*!< 4096 us */
+#define QDEC_SAMPLEPER_SAMPLEPER_8192us (6UL) /*!< 8192 us */
+#define QDEC_SAMPLEPER_SAMPLEPER_16384us (7UL) /*!< 16384 us */
+#define QDEC_SAMPLEPER_SAMPLEPER_32ms (8UL) /*!< 32768 us */
+#define QDEC_SAMPLEPER_SAMPLEPER_65ms (9UL) /*!< 65536 us */
+#define QDEC_SAMPLEPER_SAMPLEPER_131ms (10UL) /*!< 131072 us */
+
+/* Register: QDEC_SAMPLE */
+/* Description: Motion sample value */
+
+/* Bits 31..0 : Last motion sample */
+#define QDEC_SAMPLE_SAMPLE_Pos (0UL) /*!< Position of SAMPLE field. */
+#define QDEC_SAMPLE_SAMPLE_Msk (0xFFFFFFFFUL << QDEC_SAMPLE_SAMPLE_Pos) /*!< Bit mask of SAMPLE field. */
+
+/* Register: QDEC_REPORTPER */
+/* Description: Number of samples to be taken before REPORTRDY and DBLRDY events can be generated */
+
+/* Bits 3..0 : Specifies the number of samples to be accumulated in the ACC register before the REPORTRDY and DBLRDY events can be generated */
+#define QDEC_REPORTPER_REPORTPER_Pos (0UL) /*!< Position of REPORTPER field. */
+#define QDEC_REPORTPER_REPORTPER_Msk (0xFUL << QDEC_REPORTPER_REPORTPER_Pos) /*!< Bit mask of REPORTPER field. */
+#define QDEC_REPORTPER_REPORTPER_10Smpl (0UL) /*!< 10 samples / report */
+#define QDEC_REPORTPER_REPORTPER_40Smpl (1UL) /*!< 40 samples / report */
+#define QDEC_REPORTPER_REPORTPER_80Smpl (2UL) /*!< 80 samples / report */
+#define QDEC_REPORTPER_REPORTPER_120Smpl (3UL) /*!< 120 samples / report */
+#define QDEC_REPORTPER_REPORTPER_160Smpl (4UL) /*!< 160 samples / report */
+#define QDEC_REPORTPER_REPORTPER_200Smpl (5UL) /*!< 200 samples / report */
+#define QDEC_REPORTPER_REPORTPER_240Smpl (6UL) /*!< 240 samples / report */
+#define QDEC_REPORTPER_REPORTPER_280Smpl (7UL) /*!< 280 samples / report */
+#define QDEC_REPORTPER_REPORTPER_1Smpl (8UL) /*!< 1 sample / report */
+
+/* Register: QDEC_ACC */
+/* Description: Register accumulating the valid transitions */
+
+/* Bits 31..0 : Register accumulating all valid samples (not double transition) read from the SAMPLE register */
+#define QDEC_ACC_ACC_Pos (0UL) /*!< Position of ACC field. */
+#define QDEC_ACC_ACC_Msk (0xFFFFFFFFUL << QDEC_ACC_ACC_Pos) /*!< Bit mask of ACC field. */
+
+/* Register: QDEC_ACCREAD */
+/* Description: Snapshot of the ACC register, updated by the READCLRACC or RDCLRACC task */
+
+/* Bits 31..0 : Snapshot of the ACC register. */
+#define QDEC_ACCREAD_ACCREAD_Pos (0UL) /*!< Position of ACCREAD field. */
+#define QDEC_ACCREAD_ACCREAD_Msk (0xFFFFFFFFUL << QDEC_ACCREAD_ACCREAD_Pos) /*!< Bit mask of ACCREAD field. */
+
+/* Register: QDEC_PSEL_LED */
+/* Description: Pin select for LED signal */
+
+/* Bit 31 : Connection */
+#define QDEC_PSEL_LED_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define QDEC_PSEL_LED_CONNECT_Msk (0x1UL << QDEC_PSEL_LED_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define QDEC_PSEL_LED_CONNECT_Connected (0UL) /*!< Connect */
+#define QDEC_PSEL_LED_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define QDEC_PSEL_LED_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define QDEC_PSEL_LED_PIN_Msk (0x1FUL << QDEC_PSEL_LED_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: QDEC_PSEL_A */
+/* Description: Pin select for A signal */
+
+/* Bit 31 : Connection */
+#define QDEC_PSEL_A_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define QDEC_PSEL_A_CONNECT_Msk (0x1UL << QDEC_PSEL_A_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define QDEC_PSEL_A_CONNECT_Connected (0UL) /*!< Connect */
+#define QDEC_PSEL_A_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define QDEC_PSEL_A_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define QDEC_PSEL_A_PIN_Msk (0x1FUL << QDEC_PSEL_A_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: QDEC_PSEL_B */
+/* Description: Pin select for B signal */
+
+/* Bit 31 : Connection */
+#define QDEC_PSEL_B_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define QDEC_PSEL_B_CONNECT_Msk (0x1UL << QDEC_PSEL_B_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define QDEC_PSEL_B_CONNECT_Connected (0UL) /*!< Connect */
+#define QDEC_PSEL_B_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define QDEC_PSEL_B_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define QDEC_PSEL_B_PIN_Msk (0x1FUL << QDEC_PSEL_B_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: QDEC_DBFEN */
+/* Description: Enable input debounce filters */
+
+/* Bit 0 : Enable input debounce filters */
+#define QDEC_DBFEN_DBFEN_Pos (0UL) /*!< Position of DBFEN field. */
+#define QDEC_DBFEN_DBFEN_Msk (0x1UL << QDEC_DBFEN_DBFEN_Pos) /*!< Bit mask of DBFEN field. */
+#define QDEC_DBFEN_DBFEN_Disabled (0UL) /*!< Debounce input filters disabled */
+#define QDEC_DBFEN_DBFEN_Enabled (1UL) /*!< Debounce input filters enabled */
+
+/* Register: QDEC_LEDPRE */
+/* Description: Time period the LED is switched ON prior to sampling */
+
+/* Bits 8..0 : Period in us the LED is switched on prior to sampling */
+#define QDEC_LEDPRE_LEDPRE_Pos (0UL) /*!< Position of LEDPRE field. */
+#define QDEC_LEDPRE_LEDPRE_Msk (0x1FFUL << QDEC_LEDPRE_LEDPRE_Pos) /*!< Bit mask of LEDPRE field. */
+
+/* Register: QDEC_ACCDBL */
+/* Description: Register accumulating the number of detected double transitions */
+
+/* Bits 3..0 : Register accumulating the number of detected double or illegal transitions. ( SAMPLE = 2 ). */
+#define QDEC_ACCDBL_ACCDBL_Pos (0UL) /*!< Position of ACCDBL field. */
+#define QDEC_ACCDBL_ACCDBL_Msk (0xFUL << QDEC_ACCDBL_ACCDBL_Pos) /*!< Bit mask of ACCDBL field. */
+
+/* Register: QDEC_ACCDBLREAD */
+/* Description: Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task */
+
+/* Bits 3..0 : Snapshot of the ACCDBL register. This field is updated when the READCLRACC or RDCLRDBL task is triggered. */
+#define QDEC_ACCDBLREAD_ACCDBLREAD_Pos (0UL) /*!< Position of ACCDBLREAD field. */
+#define QDEC_ACCDBLREAD_ACCDBLREAD_Msk (0xFUL << QDEC_ACCDBLREAD_ACCDBLREAD_Pos) /*!< Bit mask of ACCDBLREAD field. */
+
+
+/* Peripheral: RADIO */
+/* Description: 2.4 GHz Radio */
+
+/* Register: RADIO_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 8 : Shortcut between DISABLED event and RSSISTOP task */
+#define RADIO_SHORTS_DISABLED_RSSISTOP_Pos (8UL) /*!< Position of DISABLED_RSSISTOP field. */
+#define RADIO_SHORTS_DISABLED_RSSISTOP_Msk (0x1UL << RADIO_SHORTS_DISABLED_RSSISTOP_Pos) /*!< Bit mask of DISABLED_RSSISTOP field. */
+#define RADIO_SHORTS_DISABLED_RSSISTOP_Disabled (0UL) /*!< Disable shortcut */
+#define RADIO_SHORTS_DISABLED_RSSISTOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 6 : Shortcut between ADDRESS event and BCSTART task */
+#define RADIO_SHORTS_ADDRESS_BCSTART_Pos (6UL) /*!< Position of ADDRESS_BCSTART field. */
+#define RADIO_SHORTS_ADDRESS_BCSTART_Msk (0x1UL << RADIO_SHORTS_ADDRESS_BCSTART_Pos) /*!< Bit mask of ADDRESS_BCSTART field. */
+#define RADIO_SHORTS_ADDRESS_BCSTART_Disabled (0UL) /*!< Disable shortcut */
+#define RADIO_SHORTS_ADDRESS_BCSTART_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 5 : Shortcut between END event and START task */
+#define RADIO_SHORTS_END_START_Pos (5UL) /*!< Position of END_START field. */
+#define RADIO_SHORTS_END_START_Msk (0x1UL << RADIO_SHORTS_END_START_Pos) /*!< Bit mask of END_START field. */
+#define RADIO_SHORTS_END_START_Disabled (0UL) /*!< Disable shortcut */
+#define RADIO_SHORTS_END_START_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 4 : Shortcut between ADDRESS event and RSSISTART task */
+#define RADIO_SHORTS_ADDRESS_RSSISTART_Pos (4UL) /*!< Position of ADDRESS_RSSISTART field. */
+#define RADIO_SHORTS_ADDRESS_RSSISTART_Msk (0x1UL << RADIO_SHORTS_ADDRESS_RSSISTART_Pos) /*!< Bit mask of ADDRESS_RSSISTART field. */
+#define RADIO_SHORTS_ADDRESS_RSSISTART_Disabled (0UL) /*!< Disable shortcut */
+#define RADIO_SHORTS_ADDRESS_RSSISTART_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 3 : Shortcut between DISABLED event and RXEN task */
+#define RADIO_SHORTS_DISABLED_RXEN_Pos (3UL) /*!< Position of DISABLED_RXEN field. */
+#define RADIO_SHORTS_DISABLED_RXEN_Msk (0x1UL << RADIO_SHORTS_DISABLED_RXEN_Pos) /*!< Bit mask of DISABLED_RXEN field. */
+#define RADIO_SHORTS_DISABLED_RXEN_Disabled (0UL) /*!< Disable shortcut */
+#define RADIO_SHORTS_DISABLED_RXEN_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 2 : Shortcut between DISABLED event and TXEN task */
+#define RADIO_SHORTS_DISABLED_TXEN_Pos (2UL) /*!< Position of DISABLED_TXEN field. */
+#define RADIO_SHORTS_DISABLED_TXEN_Msk (0x1UL << RADIO_SHORTS_DISABLED_TXEN_Pos) /*!< Bit mask of DISABLED_TXEN field. */
+#define RADIO_SHORTS_DISABLED_TXEN_Disabled (0UL) /*!< Disable shortcut */
+#define RADIO_SHORTS_DISABLED_TXEN_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 1 : Shortcut between END event and DISABLE task */
+#define RADIO_SHORTS_END_DISABLE_Pos (1UL) /*!< Position of END_DISABLE field. */
+#define RADIO_SHORTS_END_DISABLE_Msk (0x1UL << RADIO_SHORTS_END_DISABLE_Pos) /*!< Bit mask of END_DISABLE field. */
+#define RADIO_SHORTS_END_DISABLE_Disabled (0UL) /*!< Disable shortcut */
+#define RADIO_SHORTS_END_DISABLE_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 0 : Shortcut between READY event and START task */
+#define RADIO_SHORTS_READY_START_Pos (0UL) /*!< Position of READY_START field. */
+#define RADIO_SHORTS_READY_START_Msk (0x1UL << RADIO_SHORTS_READY_START_Pos) /*!< Bit mask of READY_START field. */
+#define RADIO_SHORTS_READY_START_Disabled (0UL) /*!< Disable shortcut */
+#define RADIO_SHORTS_READY_START_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: RADIO_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 13 : Write '1' to Enable interrupt for CRCERROR event */
+#define RADIO_INTENSET_CRCERROR_Pos (13UL) /*!< Position of CRCERROR field. */
+#define RADIO_INTENSET_CRCERROR_Msk (0x1UL << RADIO_INTENSET_CRCERROR_Pos) /*!< Bit mask of CRCERROR field. */
+#define RADIO_INTENSET_CRCERROR_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_CRCERROR_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_CRCERROR_Set (1UL) /*!< Enable */
+
+/* Bit 12 : Write '1' to Enable interrupt for CRCOK event */
+#define RADIO_INTENSET_CRCOK_Pos (12UL) /*!< Position of CRCOK field. */
+#define RADIO_INTENSET_CRCOK_Msk (0x1UL << RADIO_INTENSET_CRCOK_Pos) /*!< Bit mask of CRCOK field. */
+#define RADIO_INTENSET_CRCOK_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_CRCOK_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_CRCOK_Set (1UL) /*!< Enable */
+
+/* Bit 10 : Write '1' to Enable interrupt for BCMATCH event */
+#define RADIO_INTENSET_BCMATCH_Pos (10UL) /*!< Position of BCMATCH field. */
+#define RADIO_INTENSET_BCMATCH_Msk (0x1UL << RADIO_INTENSET_BCMATCH_Pos) /*!< Bit mask of BCMATCH field. */
+#define RADIO_INTENSET_BCMATCH_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_BCMATCH_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_BCMATCH_Set (1UL) /*!< Enable */
+
+/* Bit 7 : Write '1' to Enable interrupt for RSSIEND event */
+#define RADIO_INTENSET_RSSIEND_Pos (7UL) /*!< Position of RSSIEND field. */
+#define RADIO_INTENSET_RSSIEND_Msk (0x1UL << RADIO_INTENSET_RSSIEND_Pos) /*!< Bit mask of RSSIEND field. */
+#define RADIO_INTENSET_RSSIEND_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_RSSIEND_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_RSSIEND_Set (1UL) /*!< Enable */
+
+/* Bit 6 : Write '1' to Enable interrupt for DEVMISS event */
+#define RADIO_INTENSET_DEVMISS_Pos (6UL) /*!< Position of DEVMISS field. */
+#define RADIO_INTENSET_DEVMISS_Msk (0x1UL << RADIO_INTENSET_DEVMISS_Pos) /*!< Bit mask of DEVMISS field. */
+#define RADIO_INTENSET_DEVMISS_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_DEVMISS_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_DEVMISS_Set (1UL) /*!< Enable */
+
+/* Bit 5 : Write '1' to Enable interrupt for DEVMATCH event */
+#define RADIO_INTENSET_DEVMATCH_Pos (5UL) /*!< Position of DEVMATCH field. */
+#define RADIO_INTENSET_DEVMATCH_Msk (0x1UL << RADIO_INTENSET_DEVMATCH_Pos) /*!< Bit mask of DEVMATCH field. */
+#define RADIO_INTENSET_DEVMATCH_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_DEVMATCH_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_DEVMATCH_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable interrupt for DISABLED event */
+#define RADIO_INTENSET_DISABLED_Pos (4UL) /*!< Position of DISABLED field. */
+#define RADIO_INTENSET_DISABLED_Msk (0x1UL << RADIO_INTENSET_DISABLED_Pos) /*!< Bit mask of DISABLED field. */
+#define RADIO_INTENSET_DISABLED_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_DISABLED_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_DISABLED_Set (1UL) /*!< Enable */
+
+/* Bit 3 : Write '1' to Enable interrupt for END event */
+#define RADIO_INTENSET_END_Pos (3UL) /*!< Position of END field. */
+#define RADIO_INTENSET_END_Msk (0x1UL << RADIO_INTENSET_END_Pos) /*!< Bit mask of END field. */
+#define RADIO_INTENSET_END_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_END_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_END_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for PAYLOAD event */
+#define RADIO_INTENSET_PAYLOAD_Pos (2UL) /*!< Position of PAYLOAD field. */
+#define RADIO_INTENSET_PAYLOAD_Msk (0x1UL << RADIO_INTENSET_PAYLOAD_Pos) /*!< Bit mask of PAYLOAD field. */
+#define RADIO_INTENSET_PAYLOAD_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_PAYLOAD_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_PAYLOAD_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for ADDRESS event */
+#define RADIO_INTENSET_ADDRESS_Pos (1UL) /*!< Position of ADDRESS field. */
+#define RADIO_INTENSET_ADDRESS_Msk (0x1UL << RADIO_INTENSET_ADDRESS_Pos) /*!< Bit mask of ADDRESS field. */
+#define RADIO_INTENSET_ADDRESS_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_ADDRESS_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_ADDRESS_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for READY event */
+#define RADIO_INTENSET_READY_Pos (0UL) /*!< Position of READY field. */
+#define RADIO_INTENSET_READY_Msk (0x1UL << RADIO_INTENSET_READY_Pos) /*!< Bit mask of READY field. */
+#define RADIO_INTENSET_READY_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENSET_READY_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENSET_READY_Set (1UL) /*!< Enable */
+
+/* Register: RADIO_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 13 : Write '1' to Disable interrupt for CRCERROR event */
+#define RADIO_INTENCLR_CRCERROR_Pos (13UL) /*!< Position of CRCERROR field. */
+#define RADIO_INTENCLR_CRCERROR_Msk (0x1UL << RADIO_INTENCLR_CRCERROR_Pos) /*!< Bit mask of CRCERROR field. */
+#define RADIO_INTENCLR_CRCERROR_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_CRCERROR_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_CRCERROR_Clear (1UL) /*!< Disable */
+
+/* Bit 12 : Write '1' to Disable interrupt for CRCOK event */
+#define RADIO_INTENCLR_CRCOK_Pos (12UL) /*!< Position of CRCOK field. */
+#define RADIO_INTENCLR_CRCOK_Msk (0x1UL << RADIO_INTENCLR_CRCOK_Pos) /*!< Bit mask of CRCOK field. */
+#define RADIO_INTENCLR_CRCOK_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_CRCOK_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_CRCOK_Clear (1UL) /*!< Disable */
+
+/* Bit 10 : Write '1' to Disable interrupt for BCMATCH event */
+#define RADIO_INTENCLR_BCMATCH_Pos (10UL) /*!< Position of BCMATCH field. */
+#define RADIO_INTENCLR_BCMATCH_Msk (0x1UL << RADIO_INTENCLR_BCMATCH_Pos) /*!< Bit mask of BCMATCH field. */
+#define RADIO_INTENCLR_BCMATCH_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_BCMATCH_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_BCMATCH_Clear (1UL) /*!< Disable */
+
+/* Bit 7 : Write '1' to Disable interrupt for RSSIEND event */
+#define RADIO_INTENCLR_RSSIEND_Pos (7UL) /*!< Position of RSSIEND field. */
+#define RADIO_INTENCLR_RSSIEND_Msk (0x1UL << RADIO_INTENCLR_RSSIEND_Pos) /*!< Bit mask of RSSIEND field. */
+#define RADIO_INTENCLR_RSSIEND_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_RSSIEND_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_RSSIEND_Clear (1UL) /*!< Disable */
+
+/* Bit 6 : Write '1' to Disable interrupt for DEVMISS event */
+#define RADIO_INTENCLR_DEVMISS_Pos (6UL) /*!< Position of DEVMISS field. */
+#define RADIO_INTENCLR_DEVMISS_Msk (0x1UL << RADIO_INTENCLR_DEVMISS_Pos) /*!< Bit mask of DEVMISS field. */
+#define RADIO_INTENCLR_DEVMISS_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_DEVMISS_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_DEVMISS_Clear (1UL) /*!< Disable */
+
+/* Bit 5 : Write '1' to Disable interrupt for DEVMATCH event */
+#define RADIO_INTENCLR_DEVMATCH_Pos (5UL) /*!< Position of DEVMATCH field. */
+#define RADIO_INTENCLR_DEVMATCH_Msk (0x1UL << RADIO_INTENCLR_DEVMATCH_Pos) /*!< Bit mask of DEVMATCH field. */
+#define RADIO_INTENCLR_DEVMATCH_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_DEVMATCH_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_DEVMATCH_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable interrupt for DISABLED event */
+#define RADIO_INTENCLR_DISABLED_Pos (4UL) /*!< Position of DISABLED field. */
+#define RADIO_INTENCLR_DISABLED_Msk (0x1UL << RADIO_INTENCLR_DISABLED_Pos) /*!< Bit mask of DISABLED field. */
+#define RADIO_INTENCLR_DISABLED_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_DISABLED_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_DISABLED_Clear (1UL) /*!< Disable */
+
+/* Bit 3 : Write '1' to Disable interrupt for END event */
+#define RADIO_INTENCLR_END_Pos (3UL) /*!< Position of END field. */
+#define RADIO_INTENCLR_END_Msk (0x1UL << RADIO_INTENCLR_END_Pos) /*!< Bit mask of END field. */
+#define RADIO_INTENCLR_END_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_END_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_END_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for PAYLOAD event */
+#define RADIO_INTENCLR_PAYLOAD_Pos (2UL) /*!< Position of PAYLOAD field. */
+#define RADIO_INTENCLR_PAYLOAD_Msk (0x1UL << RADIO_INTENCLR_PAYLOAD_Pos) /*!< Bit mask of PAYLOAD field. */
+#define RADIO_INTENCLR_PAYLOAD_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_PAYLOAD_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_PAYLOAD_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for ADDRESS event */
+#define RADIO_INTENCLR_ADDRESS_Pos (1UL) /*!< Position of ADDRESS field. */
+#define RADIO_INTENCLR_ADDRESS_Msk (0x1UL << RADIO_INTENCLR_ADDRESS_Pos) /*!< Bit mask of ADDRESS field. */
+#define RADIO_INTENCLR_ADDRESS_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_ADDRESS_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_ADDRESS_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for READY event */
+#define RADIO_INTENCLR_READY_Pos (0UL) /*!< Position of READY field. */
+#define RADIO_INTENCLR_READY_Msk (0x1UL << RADIO_INTENCLR_READY_Pos) /*!< Bit mask of READY field. */
+#define RADIO_INTENCLR_READY_Disabled (0UL) /*!< Read: Disabled */
+#define RADIO_INTENCLR_READY_Enabled (1UL) /*!< Read: Enabled */
+#define RADIO_INTENCLR_READY_Clear (1UL) /*!< Disable */
+
+/* Register: RADIO_CRCSTATUS */
+/* Description: CRC status */
+
+/* Bit 0 : CRC status of packet received */
+#define RADIO_CRCSTATUS_CRCSTATUS_Pos (0UL) /*!< Position of CRCSTATUS field. */
+#define RADIO_CRCSTATUS_CRCSTATUS_Msk (0x1UL << RADIO_CRCSTATUS_CRCSTATUS_Pos) /*!< Bit mask of CRCSTATUS field. */
+#define RADIO_CRCSTATUS_CRCSTATUS_CRCError (0UL) /*!< Packet received with CRC error */
+#define RADIO_CRCSTATUS_CRCSTATUS_CRCOk (1UL) /*!< Packet received with CRC ok */
+
+/* Register: RADIO_RXMATCH */
+/* Description: Received address */
+
+/* Bits 2..0 : Received address */
+#define RADIO_RXMATCH_RXMATCH_Pos (0UL) /*!< Position of RXMATCH field. */
+#define RADIO_RXMATCH_RXMATCH_Msk (0x7UL << RADIO_RXMATCH_RXMATCH_Pos) /*!< Bit mask of RXMATCH field. */
+
+/* Register: RADIO_RXCRC */
+/* Description: CRC field of previously received packet */
+
+/* Bits 23..0 : CRC field of previously received packet */
+#define RADIO_RXCRC_RXCRC_Pos (0UL) /*!< Position of RXCRC field. */
+#define RADIO_RXCRC_RXCRC_Msk (0xFFFFFFUL << RADIO_RXCRC_RXCRC_Pos) /*!< Bit mask of RXCRC field. */
+
+/* Register: RADIO_DAI */
+/* Description: Device address match index */
+
+/* Bits 2..0 : Device address match index */
+#define RADIO_DAI_DAI_Pos (0UL) /*!< Position of DAI field. */
+#define RADIO_DAI_DAI_Msk (0x7UL << RADIO_DAI_DAI_Pos) /*!< Bit mask of DAI field. */
+
+/* Register: RADIO_PACKETPTR */
+/* Description: Packet pointer */
+
+/* Bits 31..0 : Packet pointer */
+#define RADIO_PACKETPTR_PACKETPTR_Pos (0UL) /*!< Position of PACKETPTR field. */
+#define RADIO_PACKETPTR_PACKETPTR_Msk (0xFFFFFFFFUL << RADIO_PACKETPTR_PACKETPTR_Pos) /*!< Bit mask of PACKETPTR field. */
+
+/* Register: RADIO_FREQUENCY */
+/* Description: Frequency */
+
+/* Bits 6..0 : Radio channel frequency */
+#define RADIO_FREQUENCY_FREQUENCY_Pos (0UL) /*!< Position of FREQUENCY field. */
+#define RADIO_FREQUENCY_FREQUENCY_Msk (0x7FUL << RADIO_FREQUENCY_FREQUENCY_Pos) /*!< Bit mask of FREQUENCY field. */
+
+/* Register: RADIO_TXPOWER */
+/* Description: Output power */
+
+/* Bits 7..0 : RADIO output power. */
+#define RADIO_TXPOWER_TXPOWER_Pos (0UL) /*!< Position of TXPOWER field. */
+#define RADIO_TXPOWER_TXPOWER_Msk (0xFFUL << RADIO_TXPOWER_TXPOWER_Pos) /*!< Bit mask of TXPOWER field. */
+#define RADIO_TXPOWER_TXPOWER_0dBm (0x00UL) /*!< 0 dBm */
+#define RADIO_TXPOWER_TXPOWER_Pos3dBm (0x03UL) /*!< +3 dBm */
+#define RADIO_TXPOWER_TXPOWER_Pos4dBm (0x04UL) /*!< +4 dBm */
+#define RADIO_TXPOWER_TXPOWER_Neg30dBm (0xD8UL) /*!< Deprecated enumerator -  -40 dBm */
+#define RADIO_TXPOWER_TXPOWER_Neg40dBm (0xD8UL) /*!< -40 dBm */
+#define RADIO_TXPOWER_TXPOWER_Neg20dBm (0xECUL) /*!< -20 dBm */
+#define RADIO_TXPOWER_TXPOWER_Neg16dBm (0xF0UL) /*!< -16 dBm */
+#define RADIO_TXPOWER_TXPOWER_Neg12dBm (0xF4UL) /*!< -12 dBm */
+#define RADIO_TXPOWER_TXPOWER_Neg8dBm (0xF8UL) /*!< -8 dBm */
+#define RADIO_TXPOWER_TXPOWER_Neg4dBm (0xFCUL) /*!< -4 dBm */
+
+/* Register: RADIO_MODE */
+/* Description: Data rate and modulation */
+
+/* Bits 3..0 : Radio data rate and modulation setting. The radio supports Frequency-shift Keying (FSK) modulation. */
+#define RADIO_MODE_MODE_Pos (0UL) /*!< Position of MODE field. */
+#define RADIO_MODE_MODE_Msk (0xFUL << RADIO_MODE_MODE_Pos) /*!< Bit mask of MODE field. */
+#define RADIO_MODE_MODE_Nrf_1Mbit (0UL) /*!< 1 Mbit/s Nordic proprietary radio mode */
+#define RADIO_MODE_MODE_Nrf_2Mbit (1UL) /*!< 2 Mbit/s Nordic proprietary radio mode */
+#define RADIO_MODE_MODE_Nrf_250Kbit (2UL) /*!< Deprecated enumerator -  250 kbit/s Nordic proprietary radio mode */
+#define RADIO_MODE_MODE_Ble_1Mbit (3UL) /*!< 1 Mbit/s Bluetooth Low Energy */
+
+/* Register: RADIO_PCNF0 */
+/* Description: Packet configuration register 0 */
+
+/* Bit 24 : Length of preamble on air. Decision point: TASKS_START task */
+#define RADIO_PCNF0_PLEN_Pos (24UL) /*!< Position of PLEN field. */
+#define RADIO_PCNF0_PLEN_Msk (0x1UL << RADIO_PCNF0_PLEN_Pos) /*!< Bit mask of PLEN field. */
+#define RADIO_PCNF0_PLEN_8bit (0UL) /*!< 8-bit preamble */
+#define RADIO_PCNF0_PLEN_16bit (1UL) /*!< 16-bit preamble */
+
+/* Bit 20 : Include or exclude S1 field in RAM */
+#define RADIO_PCNF0_S1INCL_Pos (20UL) /*!< Position of S1INCL field. */
+#define RADIO_PCNF0_S1INCL_Msk (0x1UL << RADIO_PCNF0_S1INCL_Pos) /*!< Bit mask of S1INCL field. */
+#define RADIO_PCNF0_S1INCL_Automatic (0UL) /*!< Include S1 field in RAM only if S1LEN &gt; 0 */
+#define RADIO_PCNF0_S1INCL_Include (1UL) /*!< Always include S1 field in RAM independent of S1LEN */
+
+/* Bits 19..16 : Length on air of S1 field in number of bits. */
+#define RADIO_PCNF0_S1LEN_Pos (16UL) /*!< Position of S1LEN field. */
+#define RADIO_PCNF0_S1LEN_Msk (0xFUL << RADIO_PCNF0_S1LEN_Pos) /*!< Bit mask of S1LEN field. */
+
+/* Bit 8 : Length on air of S0 field in number of bytes. */
+#define RADIO_PCNF0_S0LEN_Pos (8UL) /*!< Position of S0LEN field. */
+#define RADIO_PCNF0_S0LEN_Msk (0x1UL << RADIO_PCNF0_S0LEN_Pos) /*!< Bit mask of S0LEN field. */
+
+/* Bits 3..0 : Length on air of LENGTH field in number of bits. */
+#define RADIO_PCNF0_LFLEN_Pos (0UL) /*!< Position of LFLEN field. */
+#define RADIO_PCNF0_LFLEN_Msk (0xFUL << RADIO_PCNF0_LFLEN_Pos) /*!< Bit mask of LFLEN field. */
+
+/* Register: RADIO_PCNF1 */
+/* Description: Packet configuration register 1 */
+
+/* Bit 25 : Enable or disable packet whitening */
+#define RADIO_PCNF1_WHITEEN_Pos (25UL) /*!< Position of WHITEEN field. */
+#define RADIO_PCNF1_WHITEEN_Msk (0x1UL << RADIO_PCNF1_WHITEEN_Pos) /*!< Bit mask of WHITEEN field. */
+#define RADIO_PCNF1_WHITEEN_Disabled (0UL) /*!< Disable */
+#define RADIO_PCNF1_WHITEEN_Enabled (1UL) /*!< Enable */
+
+/* Bit 24 : On air endianness of packet, this applies to the S0, LENGTH, S1 and the PAYLOAD fields. */
+#define RADIO_PCNF1_ENDIAN_Pos (24UL) /*!< Position of ENDIAN field. */
+#define RADIO_PCNF1_ENDIAN_Msk (0x1UL << RADIO_PCNF1_ENDIAN_Pos) /*!< Bit mask of ENDIAN field. */
+#define RADIO_PCNF1_ENDIAN_Little (0UL) /*!< Least Significant bit on air first */
+#define RADIO_PCNF1_ENDIAN_Big (1UL) /*!< Most significant bit on air first */
+
+/* Bits 18..16 : Base address length in number of bytes */
+#define RADIO_PCNF1_BALEN_Pos (16UL) /*!< Position of BALEN field. */
+#define RADIO_PCNF1_BALEN_Msk (0x7UL << RADIO_PCNF1_BALEN_Pos) /*!< Bit mask of BALEN field. */
+
+/* Bits 15..8 : Static length in number of bytes */
+#define RADIO_PCNF1_STATLEN_Pos (8UL) /*!< Position of STATLEN field. */
+#define RADIO_PCNF1_STATLEN_Msk (0xFFUL << RADIO_PCNF1_STATLEN_Pos) /*!< Bit mask of STATLEN field. */
+
+/* Bits 7..0 : Maximum length of packet payload. If the packet payload is larger than MAXLEN, the radio will truncate the payload to MAXLEN. */
+#define RADIO_PCNF1_MAXLEN_Pos (0UL) /*!< Position of MAXLEN field. */
+#define RADIO_PCNF1_MAXLEN_Msk (0xFFUL << RADIO_PCNF1_MAXLEN_Pos) /*!< Bit mask of MAXLEN field. */
+
+/* Register: RADIO_BASE0 */
+/* Description: Base address 0 */
+
+/* Bits 31..0 : Base address 0 */
+#define RADIO_BASE0_BASE0_Pos (0UL) /*!< Position of BASE0 field. */
+#define RADIO_BASE0_BASE0_Msk (0xFFFFFFFFUL << RADIO_BASE0_BASE0_Pos) /*!< Bit mask of BASE0 field. */
+
+/* Register: RADIO_BASE1 */
+/* Description: Base address 1 */
+
+/* Bits 31..0 : Base address 1 */
+#define RADIO_BASE1_BASE1_Pos (0UL) /*!< Position of BASE1 field. */
+#define RADIO_BASE1_BASE1_Msk (0xFFFFFFFFUL << RADIO_BASE1_BASE1_Pos) /*!< Bit mask of BASE1 field. */
+
+/* Register: RADIO_PREFIX0 */
+/* Description: Prefixes bytes for logical addresses 0-3 */
+
+/* Bits 31..24 : Address prefix 3. */
+#define RADIO_PREFIX0_AP3_Pos (24UL) /*!< Position of AP3 field. */
+#define RADIO_PREFIX0_AP3_Msk (0xFFUL << RADIO_PREFIX0_AP3_Pos) /*!< Bit mask of AP3 field. */
+
+/* Bits 23..16 : Address prefix 2. */
+#define RADIO_PREFIX0_AP2_Pos (16UL) /*!< Position of AP2 field. */
+#define RADIO_PREFIX0_AP2_Msk (0xFFUL << RADIO_PREFIX0_AP2_Pos) /*!< Bit mask of AP2 field. */
+
+/* Bits 15..8 : Address prefix 1. */
+#define RADIO_PREFIX0_AP1_Pos (8UL) /*!< Position of AP1 field. */
+#define RADIO_PREFIX0_AP1_Msk (0xFFUL << RADIO_PREFIX0_AP1_Pos) /*!< Bit mask of AP1 field. */
+
+/* Bits 7..0 : Address prefix 0. */
+#define RADIO_PREFIX0_AP0_Pos (0UL) /*!< Position of AP0 field. */
+#define RADIO_PREFIX0_AP0_Msk (0xFFUL << RADIO_PREFIX0_AP0_Pos) /*!< Bit mask of AP0 field. */
+
+/* Register: RADIO_PREFIX1 */
+/* Description: Prefixes bytes for logical addresses 4-7 */
+
+/* Bits 31..24 : Address prefix 7. */
+#define RADIO_PREFIX1_AP7_Pos (24UL) /*!< Position of AP7 field. */
+#define RADIO_PREFIX1_AP7_Msk (0xFFUL << RADIO_PREFIX1_AP7_Pos) /*!< Bit mask of AP7 field. */
+
+/* Bits 23..16 : Address prefix 6. */
+#define RADIO_PREFIX1_AP6_Pos (16UL) /*!< Position of AP6 field. */
+#define RADIO_PREFIX1_AP6_Msk (0xFFUL << RADIO_PREFIX1_AP6_Pos) /*!< Bit mask of AP6 field. */
+
+/* Bits 15..8 : Address prefix 5. */
+#define RADIO_PREFIX1_AP5_Pos (8UL) /*!< Position of AP5 field. */
+#define RADIO_PREFIX1_AP5_Msk (0xFFUL << RADIO_PREFIX1_AP5_Pos) /*!< Bit mask of AP5 field. */
+
+/* Bits 7..0 : Address prefix 4. */
+#define RADIO_PREFIX1_AP4_Pos (0UL) /*!< Position of AP4 field. */
+#define RADIO_PREFIX1_AP4_Msk (0xFFUL << RADIO_PREFIX1_AP4_Pos) /*!< Bit mask of AP4 field. */
+
+/* Register: RADIO_TXADDRESS */
+/* Description: Transmit address select */
+
+/* Bits 2..0 : Transmit address select */
+#define RADIO_TXADDRESS_TXADDRESS_Pos (0UL) /*!< Position of TXADDRESS field. */
+#define RADIO_TXADDRESS_TXADDRESS_Msk (0x7UL << RADIO_TXADDRESS_TXADDRESS_Pos) /*!< Bit mask of TXADDRESS field. */
+
+/* Register: RADIO_RXADDRESSES */
+/* Description: Receive address select */
+
+/* Bit 7 : Enable or disable reception on logical address 7. */
+#define RADIO_RXADDRESSES_ADDR7_Pos (7UL) /*!< Position of ADDR7 field. */
+#define RADIO_RXADDRESSES_ADDR7_Msk (0x1UL << RADIO_RXADDRESSES_ADDR7_Pos) /*!< Bit mask of ADDR7 field. */
+#define RADIO_RXADDRESSES_ADDR7_Disabled (0UL) /*!< Disable */
+#define RADIO_RXADDRESSES_ADDR7_Enabled (1UL) /*!< Enable */
+
+/* Bit 6 : Enable or disable reception on logical address 6. */
+#define RADIO_RXADDRESSES_ADDR6_Pos (6UL) /*!< Position of ADDR6 field. */
+#define RADIO_RXADDRESSES_ADDR6_Msk (0x1UL << RADIO_RXADDRESSES_ADDR6_Pos) /*!< Bit mask of ADDR6 field. */
+#define RADIO_RXADDRESSES_ADDR6_Disabled (0UL) /*!< Disable */
+#define RADIO_RXADDRESSES_ADDR6_Enabled (1UL) /*!< Enable */
+
+/* Bit 5 : Enable or disable reception on logical address 5. */
+#define RADIO_RXADDRESSES_ADDR5_Pos (5UL) /*!< Position of ADDR5 field. */
+#define RADIO_RXADDRESSES_ADDR5_Msk (0x1UL << RADIO_RXADDRESSES_ADDR5_Pos) /*!< Bit mask of ADDR5 field. */
+#define RADIO_RXADDRESSES_ADDR5_Disabled (0UL) /*!< Disable */
+#define RADIO_RXADDRESSES_ADDR5_Enabled (1UL) /*!< Enable */
+
+/* Bit 4 : Enable or disable reception on logical address 4. */
+#define RADIO_RXADDRESSES_ADDR4_Pos (4UL) /*!< Position of ADDR4 field. */
+#define RADIO_RXADDRESSES_ADDR4_Msk (0x1UL << RADIO_RXADDRESSES_ADDR4_Pos) /*!< Bit mask of ADDR4 field. */
+#define RADIO_RXADDRESSES_ADDR4_Disabled (0UL) /*!< Disable */
+#define RADIO_RXADDRESSES_ADDR4_Enabled (1UL) /*!< Enable */
+
+/* Bit 3 : Enable or disable reception on logical address 3. */
+#define RADIO_RXADDRESSES_ADDR3_Pos (3UL) /*!< Position of ADDR3 field. */
+#define RADIO_RXADDRESSES_ADDR3_Msk (0x1UL << RADIO_RXADDRESSES_ADDR3_Pos) /*!< Bit mask of ADDR3 field. */
+#define RADIO_RXADDRESSES_ADDR3_Disabled (0UL) /*!< Disable */
+#define RADIO_RXADDRESSES_ADDR3_Enabled (1UL) /*!< Enable */
+
+/* Bit 2 : Enable or disable reception on logical address 2. */
+#define RADIO_RXADDRESSES_ADDR2_Pos (2UL) /*!< Position of ADDR2 field. */
+#define RADIO_RXADDRESSES_ADDR2_Msk (0x1UL << RADIO_RXADDRESSES_ADDR2_Pos) /*!< Bit mask of ADDR2 field. */
+#define RADIO_RXADDRESSES_ADDR2_Disabled (0UL) /*!< Disable */
+#define RADIO_RXADDRESSES_ADDR2_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable reception on logical address 1. */
+#define RADIO_RXADDRESSES_ADDR1_Pos (1UL) /*!< Position of ADDR1 field. */
+#define RADIO_RXADDRESSES_ADDR1_Msk (0x1UL << RADIO_RXADDRESSES_ADDR1_Pos) /*!< Bit mask of ADDR1 field. */
+#define RADIO_RXADDRESSES_ADDR1_Disabled (0UL) /*!< Disable */
+#define RADIO_RXADDRESSES_ADDR1_Enabled (1UL) /*!< Enable */
+
+/* Bit 0 : Enable or disable reception on logical address 0. */
+#define RADIO_RXADDRESSES_ADDR0_Pos (0UL) /*!< Position of ADDR0 field. */
+#define RADIO_RXADDRESSES_ADDR0_Msk (0x1UL << RADIO_RXADDRESSES_ADDR0_Pos) /*!< Bit mask of ADDR0 field. */
+#define RADIO_RXADDRESSES_ADDR0_Disabled (0UL) /*!< Disable */
+#define RADIO_RXADDRESSES_ADDR0_Enabled (1UL) /*!< Enable */
+
+/* Register: RADIO_CRCCNF */
+/* Description: CRC configuration */
+
+/* Bit 8 : Include or exclude packet address field out of CRC calculation. */
+#define RADIO_CRCCNF_SKIPADDR_Pos (8UL) /*!< Position of SKIPADDR field. */
+#define RADIO_CRCCNF_SKIPADDR_Msk (0x1UL << RADIO_CRCCNF_SKIPADDR_Pos) /*!< Bit mask of SKIPADDR field. */
+#define RADIO_CRCCNF_SKIPADDR_Include (0UL) /*!< CRC calculation includes address field */
+#define RADIO_CRCCNF_SKIPADDR_Skip (1UL) /*!< CRC calculation does not include address field. The CRC calculation will start at the first byte after the address. */
+
+/* Bits 1..0 : CRC length in number of bytes. */
+#define RADIO_CRCCNF_LEN_Pos (0UL) /*!< Position of LEN field. */
+#define RADIO_CRCCNF_LEN_Msk (0x3UL << RADIO_CRCCNF_LEN_Pos) /*!< Bit mask of LEN field. */
+#define RADIO_CRCCNF_LEN_Disabled (0UL) /*!< CRC length is zero and CRC calculation is disabled */
+#define RADIO_CRCCNF_LEN_One (1UL) /*!< CRC length is one byte and CRC calculation is enabled */
+#define RADIO_CRCCNF_LEN_Two (2UL) /*!< CRC length is two bytes and CRC calculation is enabled */
+#define RADIO_CRCCNF_LEN_Three (3UL) /*!< CRC length is three bytes and CRC calculation is enabled */
+
+/* Register: RADIO_CRCPOLY */
+/* Description: CRC polynomial */
+
+/* Bits 23..0 : CRC polynomial */
+#define RADIO_CRCPOLY_CRCPOLY_Pos (0UL) /*!< Position of CRCPOLY field. */
+#define RADIO_CRCPOLY_CRCPOLY_Msk (0xFFFFFFUL << RADIO_CRCPOLY_CRCPOLY_Pos) /*!< Bit mask of CRCPOLY field. */
+
+/* Register: RADIO_CRCINIT */
+/* Description: CRC initial value */
+
+/* Bits 23..0 : CRC initial value */
+#define RADIO_CRCINIT_CRCINIT_Pos (0UL) /*!< Position of CRCINIT field. */
+#define RADIO_CRCINIT_CRCINIT_Msk (0xFFFFFFUL << RADIO_CRCINIT_CRCINIT_Pos) /*!< Bit mask of CRCINIT field. */
+
+/* Register: RADIO_TIFS */
+/* Description: Inter Frame Spacing in us */
+
+/* Bits 7..0 : Inter Frame Spacing in us */
+#define RADIO_TIFS_TIFS_Pos (0UL) /*!< Position of TIFS field. */
+#define RADIO_TIFS_TIFS_Msk (0xFFUL << RADIO_TIFS_TIFS_Pos) /*!< Bit mask of TIFS field. */
+
+/* Register: RADIO_RSSISAMPLE */
+/* Description: RSSI sample */
+
+/* Bits 6..0 : RSSI sample */
+#define RADIO_RSSISAMPLE_RSSISAMPLE_Pos (0UL) /*!< Position of RSSISAMPLE field. */
+#define RADIO_RSSISAMPLE_RSSISAMPLE_Msk (0x7FUL << RADIO_RSSISAMPLE_RSSISAMPLE_Pos) /*!< Bit mask of RSSISAMPLE field. */
+
+/* Register: RADIO_STATE */
+/* Description: Current radio state */
+
+/* Bits 3..0 : Current radio state */
+#define RADIO_STATE_STATE_Pos (0UL) /*!< Position of STATE field. */
+#define RADIO_STATE_STATE_Msk (0xFUL << RADIO_STATE_STATE_Pos) /*!< Bit mask of STATE field. */
+#define RADIO_STATE_STATE_Disabled (0UL) /*!< RADIO is in the Disabled state */
+#define RADIO_STATE_STATE_RxRu (1UL) /*!< RADIO is in the RXRU state */
+#define RADIO_STATE_STATE_RxIdle (2UL) /*!< RADIO is in the RXIDLE state */
+#define RADIO_STATE_STATE_Rx (3UL) /*!< RADIO is in the RX state */
+#define RADIO_STATE_STATE_RxDisable (4UL) /*!< RADIO is in the RXDISABLED state */
+#define RADIO_STATE_STATE_TxRu (9UL) /*!< RADIO is in the TXRU state */
+#define RADIO_STATE_STATE_TxIdle (10UL) /*!< RADIO is in the TXIDLE state */
+#define RADIO_STATE_STATE_Tx (11UL) /*!< RADIO is in the TX state */
+#define RADIO_STATE_STATE_TxDisable (12UL) /*!< RADIO is in the TXDISABLED state */
+
+/* Register: RADIO_DATAWHITEIV */
+/* Description: Data whitening initial value */
+
+/* Bits 6..0 : Data whitening initial value. Bit 6 is hard-wired to '1', writing '0' to it has no effect, and it will always be read back and used by the device as '1'. */
+#define RADIO_DATAWHITEIV_DATAWHITEIV_Pos (0UL) /*!< Position of DATAWHITEIV field. */
+#define RADIO_DATAWHITEIV_DATAWHITEIV_Msk (0x7FUL << RADIO_DATAWHITEIV_DATAWHITEIV_Pos) /*!< Bit mask of DATAWHITEIV field. */
+
+/* Register: RADIO_BCC */
+/* Description: Bit counter compare */
+
+/* Bits 31..0 : Bit counter compare */
+#define RADIO_BCC_BCC_Pos (0UL) /*!< Position of BCC field. */
+#define RADIO_BCC_BCC_Msk (0xFFFFFFFFUL << RADIO_BCC_BCC_Pos) /*!< Bit mask of BCC field. */
+
+/* Register: RADIO_DAB */
+/* Description: Description collection[0]:  Device address base segment 0 */
+
+/* Bits 31..0 : Device address base segment 0 */
+#define RADIO_DAB_DAB_Pos (0UL) /*!< Position of DAB field. */
+#define RADIO_DAB_DAB_Msk (0xFFFFFFFFUL << RADIO_DAB_DAB_Pos) /*!< Bit mask of DAB field. */
+
+/* Register: RADIO_DAP */
+/* Description: Description collection[0]:  Device address prefix 0 */
+
+/* Bits 15..0 : Device address prefix 0 */
+#define RADIO_DAP_DAP_Pos (0UL) /*!< Position of DAP field. */
+#define RADIO_DAP_DAP_Msk (0xFFFFUL << RADIO_DAP_DAP_Pos) /*!< Bit mask of DAP field. */
+
+/* Register: RADIO_DACNF */
+/* Description: Device address match configuration */
+
+/* Bit 15 : TxAdd for device address 7 */
+#define RADIO_DACNF_TXADD7_Pos (15UL) /*!< Position of TXADD7 field. */
+#define RADIO_DACNF_TXADD7_Msk (0x1UL << RADIO_DACNF_TXADD7_Pos) /*!< Bit mask of TXADD7 field. */
+
+/* Bit 14 : TxAdd for device address 6 */
+#define RADIO_DACNF_TXADD6_Pos (14UL) /*!< Position of TXADD6 field. */
+#define RADIO_DACNF_TXADD6_Msk (0x1UL << RADIO_DACNF_TXADD6_Pos) /*!< Bit mask of TXADD6 field. */
+
+/* Bit 13 : TxAdd for device address 5 */
+#define RADIO_DACNF_TXADD5_Pos (13UL) /*!< Position of TXADD5 field. */
+#define RADIO_DACNF_TXADD5_Msk (0x1UL << RADIO_DACNF_TXADD5_Pos) /*!< Bit mask of TXADD5 field. */
+
+/* Bit 12 : TxAdd for device address 4 */
+#define RADIO_DACNF_TXADD4_Pos (12UL) /*!< Position of TXADD4 field. */
+#define RADIO_DACNF_TXADD4_Msk (0x1UL << RADIO_DACNF_TXADD4_Pos) /*!< Bit mask of TXADD4 field. */
+
+/* Bit 11 : TxAdd for device address 3 */
+#define RADIO_DACNF_TXADD3_Pos (11UL) /*!< Position of TXADD3 field. */
+#define RADIO_DACNF_TXADD3_Msk (0x1UL << RADIO_DACNF_TXADD3_Pos) /*!< Bit mask of TXADD3 field. */
+
+/* Bit 10 : TxAdd for device address 2 */
+#define RADIO_DACNF_TXADD2_Pos (10UL) /*!< Position of TXADD2 field. */
+#define RADIO_DACNF_TXADD2_Msk (0x1UL << RADIO_DACNF_TXADD2_Pos) /*!< Bit mask of TXADD2 field. */
+
+/* Bit 9 : TxAdd for device address 1 */
+#define RADIO_DACNF_TXADD1_Pos (9UL) /*!< Position of TXADD1 field. */
+#define RADIO_DACNF_TXADD1_Msk (0x1UL << RADIO_DACNF_TXADD1_Pos) /*!< Bit mask of TXADD1 field. */
+
+/* Bit 8 : TxAdd for device address 0 */
+#define RADIO_DACNF_TXADD0_Pos (8UL) /*!< Position of TXADD0 field. */
+#define RADIO_DACNF_TXADD0_Msk (0x1UL << RADIO_DACNF_TXADD0_Pos) /*!< Bit mask of TXADD0 field. */
+
+/* Bit 7 : Enable or disable device address matching using device address 7 */
+#define RADIO_DACNF_ENA7_Pos (7UL) /*!< Position of ENA7 field. */
+#define RADIO_DACNF_ENA7_Msk (0x1UL << RADIO_DACNF_ENA7_Pos) /*!< Bit mask of ENA7 field. */
+#define RADIO_DACNF_ENA7_Disabled (0UL) /*!< Disabled */
+#define RADIO_DACNF_ENA7_Enabled (1UL) /*!< Enabled */
+
+/* Bit 6 : Enable or disable device address matching using device address 6 */
+#define RADIO_DACNF_ENA6_Pos (6UL) /*!< Position of ENA6 field. */
+#define RADIO_DACNF_ENA6_Msk (0x1UL << RADIO_DACNF_ENA6_Pos) /*!< Bit mask of ENA6 field. */
+#define RADIO_DACNF_ENA6_Disabled (0UL) /*!< Disabled */
+#define RADIO_DACNF_ENA6_Enabled (1UL) /*!< Enabled */
+
+/* Bit 5 : Enable or disable device address matching using device address 5 */
+#define RADIO_DACNF_ENA5_Pos (5UL) /*!< Position of ENA5 field. */
+#define RADIO_DACNF_ENA5_Msk (0x1UL << RADIO_DACNF_ENA5_Pos) /*!< Bit mask of ENA5 field. */
+#define RADIO_DACNF_ENA5_Disabled (0UL) /*!< Disabled */
+#define RADIO_DACNF_ENA5_Enabled (1UL) /*!< Enabled */
+
+/* Bit 4 : Enable or disable device address matching using device address 4 */
+#define RADIO_DACNF_ENA4_Pos (4UL) /*!< Position of ENA4 field. */
+#define RADIO_DACNF_ENA4_Msk (0x1UL << RADIO_DACNF_ENA4_Pos) /*!< Bit mask of ENA4 field. */
+#define RADIO_DACNF_ENA4_Disabled (0UL) /*!< Disabled */
+#define RADIO_DACNF_ENA4_Enabled (1UL) /*!< Enabled */
+
+/* Bit 3 : Enable or disable device address matching using device address 3 */
+#define RADIO_DACNF_ENA3_Pos (3UL) /*!< Position of ENA3 field. */
+#define RADIO_DACNF_ENA3_Msk (0x1UL << RADIO_DACNF_ENA3_Pos) /*!< Bit mask of ENA3 field. */
+#define RADIO_DACNF_ENA3_Disabled (0UL) /*!< Disabled */
+#define RADIO_DACNF_ENA3_Enabled (1UL) /*!< Enabled */
+
+/* Bit 2 : Enable or disable device address matching using device address 2 */
+#define RADIO_DACNF_ENA2_Pos (2UL) /*!< Position of ENA2 field. */
+#define RADIO_DACNF_ENA2_Msk (0x1UL << RADIO_DACNF_ENA2_Pos) /*!< Bit mask of ENA2 field. */
+#define RADIO_DACNF_ENA2_Disabled (0UL) /*!< Disabled */
+#define RADIO_DACNF_ENA2_Enabled (1UL) /*!< Enabled */
+
+/* Bit 1 : Enable or disable device address matching using device address 1 */
+#define RADIO_DACNF_ENA1_Pos (1UL) /*!< Position of ENA1 field. */
+#define RADIO_DACNF_ENA1_Msk (0x1UL << RADIO_DACNF_ENA1_Pos) /*!< Bit mask of ENA1 field. */
+#define RADIO_DACNF_ENA1_Disabled (0UL) /*!< Disabled */
+#define RADIO_DACNF_ENA1_Enabled (1UL) /*!< Enabled */
+
+/* Bit 0 : Enable or disable device address matching using device address 0 */
+#define RADIO_DACNF_ENA0_Pos (0UL) /*!< Position of ENA0 field. */
+#define RADIO_DACNF_ENA0_Msk (0x1UL << RADIO_DACNF_ENA0_Pos) /*!< Bit mask of ENA0 field. */
+#define RADIO_DACNF_ENA0_Disabled (0UL) /*!< Disabled */
+#define RADIO_DACNF_ENA0_Enabled (1UL) /*!< Enabled */
+
+/* Register: RADIO_MODECNF0 */
+/* Description: Radio mode configuration register 0 */
+
+/* Bits 9..8 : Default TX value */
+#define RADIO_MODECNF0_DTX_Pos (8UL) /*!< Position of DTX field. */
+#define RADIO_MODECNF0_DTX_Msk (0x3UL << RADIO_MODECNF0_DTX_Pos) /*!< Bit mask of DTX field. */
+#define RADIO_MODECNF0_DTX_B1 (0UL) /*!< Transmit '1' */
+#define RADIO_MODECNF0_DTX_B0 (1UL) /*!< Transmit '0' */
+#define RADIO_MODECNF0_DTX_Center (2UL) /*!< Transmit center frequency */
+
+/* Bit 0 : Radio ramp-up time */
+#define RADIO_MODECNF0_RU_Pos (0UL) /*!< Position of RU field. */
+#define RADIO_MODECNF0_RU_Msk (0x1UL << RADIO_MODECNF0_RU_Pos) /*!< Bit mask of RU field. */
+#define RADIO_MODECNF0_RU_Default (0UL) /*!< Default ramp-up time, compatible with nRF51 */
+#define RADIO_MODECNF0_RU_Fast (1UL) /*!< Fast ramp-up, see product specification for more information */
+
+/* Register: RADIO_POWER */
+/* Description: Peripheral power control */
+
+/* Bit 0 : Peripheral power control. The peripheral and its registers will be reset to its initial state by switching the peripheral off and then back on again. */
+#define RADIO_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define RADIO_POWER_POWER_Msk (0x1UL << RADIO_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define RADIO_POWER_POWER_Disabled (0UL) /*!< Peripheral is powered off */
+#define RADIO_POWER_POWER_Enabled (1UL) /*!< Peripheral is powered on */
+
+
+/* Peripheral: RNG */
+/* Description: Random Number Generator */
+
+/* Register: RNG_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 0 : Shortcut between VALRDY event and STOP task */
+#define RNG_SHORTS_VALRDY_STOP_Pos (0UL) /*!< Position of VALRDY_STOP field. */
+#define RNG_SHORTS_VALRDY_STOP_Msk (0x1UL << RNG_SHORTS_VALRDY_STOP_Pos) /*!< Bit mask of VALRDY_STOP field. */
+#define RNG_SHORTS_VALRDY_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define RNG_SHORTS_VALRDY_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: RNG_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 0 : Write '1' to Enable interrupt for VALRDY event */
+#define RNG_INTENSET_VALRDY_Pos (0UL) /*!< Position of VALRDY field. */
+#define RNG_INTENSET_VALRDY_Msk (0x1UL << RNG_INTENSET_VALRDY_Pos) /*!< Bit mask of VALRDY field. */
+#define RNG_INTENSET_VALRDY_Disabled (0UL) /*!< Read: Disabled */
+#define RNG_INTENSET_VALRDY_Enabled (1UL) /*!< Read: Enabled */
+#define RNG_INTENSET_VALRDY_Set (1UL) /*!< Enable */
+
+/* Register: RNG_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 0 : Write '1' to Disable interrupt for VALRDY event */
+#define RNG_INTENCLR_VALRDY_Pos (0UL) /*!< Position of VALRDY field. */
+#define RNG_INTENCLR_VALRDY_Msk (0x1UL << RNG_INTENCLR_VALRDY_Pos) /*!< Bit mask of VALRDY field. */
+#define RNG_INTENCLR_VALRDY_Disabled (0UL) /*!< Read: Disabled */
+#define RNG_INTENCLR_VALRDY_Enabled (1UL) /*!< Read: Enabled */
+#define RNG_INTENCLR_VALRDY_Clear (1UL) /*!< Disable */
+
+/* Register: RNG_CONFIG */
+/* Description: Configuration register */
+
+/* Bit 0 : Bias correction */
+#define RNG_CONFIG_DERCEN_Pos (0UL) /*!< Position of DERCEN field. */
+#define RNG_CONFIG_DERCEN_Msk (0x1UL << RNG_CONFIG_DERCEN_Pos) /*!< Bit mask of DERCEN field. */
+#define RNG_CONFIG_DERCEN_Disabled (0UL) /*!< Disabled */
+#define RNG_CONFIG_DERCEN_Enabled (1UL) /*!< Enabled */
+
+/* Register: RNG_VALUE */
+/* Description: Output random number */
+
+/* Bits 7..0 : Generated random number */
+#define RNG_VALUE_VALUE_Pos (0UL) /*!< Position of VALUE field. */
+#define RNG_VALUE_VALUE_Msk (0xFFUL << RNG_VALUE_VALUE_Pos) /*!< Bit mask of VALUE field. */
+
+
+/* Peripheral: RTC */
+/* Description: Real time counter 0 */
+
+/* Register: RTC_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 19 : Write '1' to Enable interrupt for COMPARE[3] event */
+#define RTC_INTENSET_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define RTC_INTENSET_COMPARE3_Msk (0x1UL << RTC_INTENSET_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define RTC_INTENSET_COMPARE3_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENSET_COMPARE3_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENSET_COMPARE3_Set (1UL) /*!< Enable */
+
+/* Bit 18 : Write '1' to Enable interrupt for COMPARE[2] event */
+#define RTC_INTENSET_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define RTC_INTENSET_COMPARE2_Msk (0x1UL << RTC_INTENSET_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define RTC_INTENSET_COMPARE2_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENSET_COMPARE2_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENSET_COMPARE2_Set (1UL) /*!< Enable */
+
+/* Bit 17 : Write '1' to Enable interrupt for COMPARE[1] event */
+#define RTC_INTENSET_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define RTC_INTENSET_COMPARE1_Msk (0x1UL << RTC_INTENSET_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define RTC_INTENSET_COMPARE1_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENSET_COMPARE1_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENSET_COMPARE1_Set (1UL) /*!< Enable */
+
+/* Bit 16 : Write '1' to Enable interrupt for COMPARE[0] event */
+#define RTC_INTENSET_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define RTC_INTENSET_COMPARE0_Msk (0x1UL << RTC_INTENSET_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define RTC_INTENSET_COMPARE0_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENSET_COMPARE0_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENSET_COMPARE0_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for OVRFLW event */
+#define RTC_INTENSET_OVRFLW_Pos (1UL) /*!< Position of OVRFLW field. */
+#define RTC_INTENSET_OVRFLW_Msk (0x1UL << RTC_INTENSET_OVRFLW_Pos) /*!< Bit mask of OVRFLW field. */
+#define RTC_INTENSET_OVRFLW_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENSET_OVRFLW_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENSET_OVRFLW_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for TICK event */
+#define RTC_INTENSET_TICK_Pos (0UL) /*!< Position of TICK field. */
+#define RTC_INTENSET_TICK_Msk (0x1UL << RTC_INTENSET_TICK_Pos) /*!< Bit mask of TICK field. */
+#define RTC_INTENSET_TICK_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENSET_TICK_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENSET_TICK_Set (1UL) /*!< Enable */
+
+/* Register: RTC_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 19 : Write '1' to Disable interrupt for COMPARE[3] event */
+#define RTC_INTENCLR_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define RTC_INTENCLR_COMPARE3_Msk (0x1UL << RTC_INTENCLR_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define RTC_INTENCLR_COMPARE3_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENCLR_COMPARE3_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENCLR_COMPARE3_Clear (1UL) /*!< Disable */
+
+/* Bit 18 : Write '1' to Disable interrupt for COMPARE[2] event */
+#define RTC_INTENCLR_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define RTC_INTENCLR_COMPARE2_Msk (0x1UL << RTC_INTENCLR_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define RTC_INTENCLR_COMPARE2_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENCLR_COMPARE2_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENCLR_COMPARE2_Clear (1UL) /*!< Disable */
+
+/* Bit 17 : Write '1' to Disable interrupt for COMPARE[1] event */
+#define RTC_INTENCLR_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define RTC_INTENCLR_COMPARE1_Msk (0x1UL << RTC_INTENCLR_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define RTC_INTENCLR_COMPARE1_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENCLR_COMPARE1_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENCLR_COMPARE1_Clear (1UL) /*!< Disable */
+
+/* Bit 16 : Write '1' to Disable interrupt for COMPARE[0] event */
+#define RTC_INTENCLR_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define RTC_INTENCLR_COMPARE0_Msk (0x1UL << RTC_INTENCLR_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define RTC_INTENCLR_COMPARE0_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENCLR_COMPARE0_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENCLR_COMPARE0_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for OVRFLW event */
+#define RTC_INTENCLR_OVRFLW_Pos (1UL) /*!< Position of OVRFLW field. */
+#define RTC_INTENCLR_OVRFLW_Msk (0x1UL << RTC_INTENCLR_OVRFLW_Pos) /*!< Bit mask of OVRFLW field. */
+#define RTC_INTENCLR_OVRFLW_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENCLR_OVRFLW_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENCLR_OVRFLW_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for TICK event */
+#define RTC_INTENCLR_TICK_Pos (0UL) /*!< Position of TICK field. */
+#define RTC_INTENCLR_TICK_Msk (0x1UL << RTC_INTENCLR_TICK_Pos) /*!< Bit mask of TICK field. */
+#define RTC_INTENCLR_TICK_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_INTENCLR_TICK_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_INTENCLR_TICK_Clear (1UL) /*!< Disable */
+
+/* Register: RTC_EVTEN */
+/* Description: Enable or disable event routing */
+
+/* Bit 19 : Enable or disable event routing for COMPARE[3] event */
+#define RTC_EVTEN_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define RTC_EVTEN_COMPARE3_Msk (0x1UL << RTC_EVTEN_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define RTC_EVTEN_COMPARE3_Disabled (0UL) /*!< Disable */
+#define RTC_EVTEN_COMPARE3_Enabled (1UL) /*!< Enable */
+
+/* Bit 18 : Enable or disable event routing for COMPARE[2] event */
+#define RTC_EVTEN_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define RTC_EVTEN_COMPARE2_Msk (0x1UL << RTC_EVTEN_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define RTC_EVTEN_COMPARE2_Disabled (0UL) /*!< Disable */
+#define RTC_EVTEN_COMPARE2_Enabled (1UL) /*!< Enable */
+
+/* Bit 17 : Enable or disable event routing for COMPARE[1] event */
+#define RTC_EVTEN_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define RTC_EVTEN_COMPARE1_Msk (0x1UL << RTC_EVTEN_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define RTC_EVTEN_COMPARE1_Disabled (0UL) /*!< Disable */
+#define RTC_EVTEN_COMPARE1_Enabled (1UL) /*!< Enable */
+
+/* Bit 16 : Enable or disable event routing for COMPARE[0] event */
+#define RTC_EVTEN_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define RTC_EVTEN_COMPARE0_Msk (0x1UL << RTC_EVTEN_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define RTC_EVTEN_COMPARE0_Disabled (0UL) /*!< Disable */
+#define RTC_EVTEN_COMPARE0_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable event routing for OVRFLW event */
+#define RTC_EVTEN_OVRFLW_Pos (1UL) /*!< Position of OVRFLW field. */
+#define RTC_EVTEN_OVRFLW_Msk (0x1UL << RTC_EVTEN_OVRFLW_Pos) /*!< Bit mask of OVRFLW field. */
+#define RTC_EVTEN_OVRFLW_Disabled (0UL) /*!< Disable */
+#define RTC_EVTEN_OVRFLW_Enabled (1UL) /*!< Enable */
+
+/* Bit 0 : Enable or disable event routing for TICK event */
+#define RTC_EVTEN_TICK_Pos (0UL) /*!< Position of TICK field. */
+#define RTC_EVTEN_TICK_Msk (0x1UL << RTC_EVTEN_TICK_Pos) /*!< Bit mask of TICK field. */
+#define RTC_EVTEN_TICK_Disabled (0UL) /*!< Disable */
+#define RTC_EVTEN_TICK_Enabled (1UL) /*!< Enable */
+
+/* Register: RTC_EVTENSET */
+/* Description: Enable event routing */
+
+/* Bit 19 : Write '1' to Enable event routing for COMPARE[3] event */
+#define RTC_EVTENSET_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define RTC_EVTENSET_COMPARE3_Msk (0x1UL << RTC_EVTENSET_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define RTC_EVTENSET_COMPARE3_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENSET_COMPARE3_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENSET_COMPARE3_Set (1UL) /*!< Enable */
+
+/* Bit 18 : Write '1' to Enable event routing for COMPARE[2] event */
+#define RTC_EVTENSET_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define RTC_EVTENSET_COMPARE2_Msk (0x1UL << RTC_EVTENSET_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define RTC_EVTENSET_COMPARE2_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENSET_COMPARE2_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENSET_COMPARE2_Set (1UL) /*!< Enable */
+
+/* Bit 17 : Write '1' to Enable event routing for COMPARE[1] event */
+#define RTC_EVTENSET_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define RTC_EVTENSET_COMPARE1_Msk (0x1UL << RTC_EVTENSET_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define RTC_EVTENSET_COMPARE1_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENSET_COMPARE1_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENSET_COMPARE1_Set (1UL) /*!< Enable */
+
+/* Bit 16 : Write '1' to Enable event routing for COMPARE[0] event */
+#define RTC_EVTENSET_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define RTC_EVTENSET_COMPARE0_Msk (0x1UL << RTC_EVTENSET_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define RTC_EVTENSET_COMPARE0_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENSET_COMPARE0_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENSET_COMPARE0_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable event routing for OVRFLW event */
+#define RTC_EVTENSET_OVRFLW_Pos (1UL) /*!< Position of OVRFLW field. */
+#define RTC_EVTENSET_OVRFLW_Msk (0x1UL << RTC_EVTENSET_OVRFLW_Pos) /*!< Bit mask of OVRFLW field. */
+#define RTC_EVTENSET_OVRFLW_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENSET_OVRFLW_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENSET_OVRFLW_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable event routing for TICK event */
+#define RTC_EVTENSET_TICK_Pos (0UL) /*!< Position of TICK field. */
+#define RTC_EVTENSET_TICK_Msk (0x1UL << RTC_EVTENSET_TICK_Pos) /*!< Bit mask of TICK field. */
+#define RTC_EVTENSET_TICK_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENSET_TICK_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENSET_TICK_Set (1UL) /*!< Enable */
+
+/* Register: RTC_EVTENCLR */
+/* Description: Disable event routing */
+
+/* Bit 19 : Write '1' to Disable event routing for COMPARE[3] event */
+#define RTC_EVTENCLR_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define RTC_EVTENCLR_COMPARE3_Msk (0x1UL << RTC_EVTENCLR_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define RTC_EVTENCLR_COMPARE3_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENCLR_COMPARE3_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENCLR_COMPARE3_Clear (1UL) /*!< Disable */
+
+/* Bit 18 : Write '1' to Disable event routing for COMPARE[2] event */
+#define RTC_EVTENCLR_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define RTC_EVTENCLR_COMPARE2_Msk (0x1UL << RTC_EVTENCLR_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define RTC_EVTENCLR_COMPARE2_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENCLR_COMPARE2_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENCLR_COMPARE2_Clear (1UL) /*!< Disable */
+
+/* Bit 17 : Write '1' to Disable event routing for COMPARE[1] event */
+#define RTC_EVTENCLR_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define RTC_EVTENCLR_COMPARE1_Msk (0x1UL << RTC_EVTENCLR_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define RTC_EVTENCLR_COMPARE1_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENCLR_COMPARE1_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENCLR_COMPARE1_Clear (1UL) /*!< Disable */
+
+/* Bit 16 : Write '1' to Disable event routing for COMPARE[0] event */
+#define RTC_EVTENCLR_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define RTC_EVTENCLR_COMPARE0_Msk (0x1UL << RTC_EVTENCLR_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define RTC_EVTENCLR_COMPARE0_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENCLR_COMPARE0_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENCLR_COMPARE0_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable event routing for OVRFLW event */
+#define RTC_EVTENCLR_OVRFLW_Pos (1UL) /*!< Position of OVRFLW field. */
+#define RTC_EVTENCLR_OVRFLW_Msk (0x1UL << RTC_EVTENCLR_OVRFLW_Pos) /*!< Bit mask of OVRFLW field. */
+#define RTC_EVTENCLR_OVRFLW_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENCLR_OVRFLW_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENCLR_OVRFLW_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable event routing for TICK event */
+#define RTC_EVTENCLR_TICK_Pos (0UL) /*!< Position of TICK field. */
+#define RTC_EVTENCLR_TICK_Msk (0x1UL << RTC_EVTENCLR_TICK_Pos) /*!< Bit mask of TICK field. */
+#define RTC_EVTENCLR_TICK_Disabled (0UL) /*!< Read: Disabled */
+#define RTC_EVTENCLR_TICK_Enabled (1UL) /*!< Read: Enabled */
+#define RTC_EVTENCLR_TICK_Clear (1UL) /*!< Disable */
+
+/* Register: RTC_COUNTER */
+/* Description: Current COUNTER value */
+
+/* Bits 23..0 : Counter value */
+#define RTC_COUNTER_COUNTER_Pos (0UL) /*!< Position of COUNTER field. */
+#define RTC_COUNTER_COUNTER_Msk (0xFFFFFFUL << RTC_COUNTER_COUNTER_Pos) /*!< Bit mask of COUNTER field. */
+
+/* Register: RTC_PRESCALER */
+/* Description: 12 bit prescaler for COUNTER frequency (32768/(PRESCALER+1)).Must be written when RTC is stopped */
+
+/* Bits 11..0 : Prescaler value */
+#define RTC_PRESCALER_PRESCALER_Pos (0UL) /*!< Position of PRESCALER field. */
+#define RTC_PRESCALER_PRESCALER_Msk (0xFFFUL << RTC_PRESCALER_PRESCALER_Pos) /*!< Bit mask of PRESCALER field. */
+
+/* Register: RTC_CC */
+/* Description: Description collection[0]:  Compare register 0 */
+
+/* Bits 23..0 : Compare value */
+#define RTC_CC_COMPARE_Pos (0UL) /*!< Position of COMPARE field. */
+#define RTC_CC_COMPARE_Msk (0xFFFFFFUL << RTC_CC_COMPARE_Pos) /*!< Bit mask of COMPARE field. */
+
+
+/* Peripheral: SAADC */
+/* Description: Analog to Digital Converter */
+
+/* Register: SAADC_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 21 : Enable or disable interrupt for CH[7].LIMITL event */
+#define SAADC_INTEN_CH7LIMITL_Pos (21UL) /*!< Position of CH7LIMITL field. */
+#define SAADC_INTEN_CH7LIMITL_Msk (0x1UL << SAADC_INTEN_CH7LIMITL_Pos) /*!< Bit mask of CH7LIMITL field. */
+#define SAADC_INTEN_CH7LIMITL_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH7LIMITL_Enabled (1UL) /*!< Enable */
+
+/* Bit 20 : Enable or disable interrupt for CH[7].LIMITH event */
+#define SAADC_INTEN_CH7LIMITH_Pos (20UL) /*!< Position of CH7LIMITH field. */
+#define SAADC_INTEN_CH7LIMITH_Msk (0x1UL << SAADC_INTEN_CH7LIMITH_Pos) /*!< Bit mask of CH7LIMITH field. */
+#define SAADC_INTEN_CH7LIMITH_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH7LIMITH_Enabled (1UL) /*!< Enable */
+
+/* Bit 19 : Enable or disable interrupt for CH[6].LIMITL event */
+#define SAADC_INTEN_CH6LIMITL_Pos (19UL) /*!< Position of CH6LIMITL field. */
+#define SAADC_INTEN_CH6LIMITL_Msk (0x1UL << SAADC_INTEN_CH6LIMITL_Pos) /*!< Bit mask of CH6LIMITL field. */
+#define SAADC_INTEN_CH6LIMITL_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH6LIMITL_Enabled (1UL) /*!< Enable */
+
+/* Bit 18 : Enable or disable interrupt for CH[6].LIMITH event */
+#define SAADC_INTEN_CH6LIMITH_Pos (18UL) /*!< Position of CH6LIMITH field. */
+#define SAADC_INTEN_CH6LIMITH_Msk (0x1UL << SAADC_INTEN_CH6LIMITH_Pos) /*!< Bit mask of CH6LIMITH field. */
+#define SAADC_INTEN_CH6LIMITH_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH6LIMITH_Enabled (1UL) /*!< Enable */
+
+/* Bit 17 : Enable or disable interrupt for CH[5].LIMITL event */
+#define SAADC_INTEN_CH5LIMITL_Pos (17UL) /*!< Position of CH5LIMITL field. */
+#define SAADC_INTEN_CH5LIMITL_Msk (0x1UL << SAADC_INTEN_CH5LIMITL_Pos) /*!< Bit mask of CH5LIMITL field. */
+#define SAADC_INTEN_CH5LIMITL_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH5LIMITL_Enabled (1UL) /*!< Enable */
+
+/* Bit 16 : Enable or disable interrupt for CH[5].LIMITH event */
+#define SAADC_INTEN_CH5LIMITH_Pos (16UL) /*!< Position of CH5LIMITH field. */
+#define SAADC_INTEN_CH5LIMITH_Msk (0x1UL << SAADC_INTEN_CH5LIMITH_Pos) /*!< Bit mask of CH5LIMITH field. */
+#define SAADC_INTEN_CH5LIMITH_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH5LIMITH_Enabled (1UL) /*!< Enable */
+
+/* Bit 15 : Enable or disable interrupt for CH[4].LIMITL event */
+#define SAADC_INTEN_CH4LIMITL_Pos (15UL) /*!< Position of CH4LIMITL field. */
+#define SAADC_INTEN_CH4LIMITL_Msk (0x1UL << SAADC_INTEN_CH4LIMITL_Pos) /*!< Bit mask of CH4LIMITL field. */
+#define SAADC_INTEN_CH4LIMITL_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH4LIMITL_Enabled (1UL) /*!< Enable */
+
+/* Bit 14 : Enable or disable interrupt for CH[4].LIMITH event */
+#define SAADC_INTEN_CH4LIMITH_Pos (14UL) /*!< Position of CH4LIMITH field. */
+#define SAADC_INTEN_CH4LIMITH_Msk (0x1UL << SAADC_INTEN_CH4LIMITH_Pos) /*!< Bit mask of CH4LIMITH field. */
+#define SAADC_INTEN_CH4LIMITH_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH4LIMITH_Enabled (1UL) /*!< Enable */
+
+/* Bit 13 : Enable or disable interrupt for CH[3].LIMITL event */
+#define SAADC_INTEN_CH3LIMITL_Pos (13UL) /*!< Position of CH3LIMITL field. */
+#define SAADC_INTEN_CH3LIMITL_Msk (0x1UL << SAADC_INTEN_CH3LIMITL_Pos) /*!< Bit mask of CH3LIMITL field. */
+#define SAADC_INTEN_CH3LIMITL_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH3LIMITL_Enabled (1UL) /*!< Enable */
+
+/* Bit 12 : Enable or disable interrupt for CH[3].LIMITH event */
+#define SAADC_INTEN_CH3LIMITH_Pos (12UL) /*!< Position of CH3LIMITH field. */
+#define SAADC_INTEN_CH3LIMITH_Msk (0x1UL << SAADC_INTEN_CH3LIMITH_Pos) /*!< Bit mask of CH3LIMITH field. */
+#define SAADC_INTEN_CH3LIMITH_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH3LIMITH_Enabled (1UL) /*!< Enable */
+
+/* Bit 11 : Enable or disable interrupt for CH[2].LIMITL event */
+#define SAADC_INTEN_CH2LIMITL_Pos (11UL) /*!< Position of CH2LIMITL field. */
+#define SAADC_INTEN_CH2LIMITL_Msk (0x1UL << SAADC_INTEN_CH2LIMITL_Pos) /*!< Bit mask of CH2LIMITL field. */
+#define SAADC_INTEN_CH2LIMITL_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH2LIMITL_Enabled (1UL) /*!< Enable */
+
+/* Bit 10 : Enable or disable interrupt for CH[2].LIMITH event */
+#define SAADC_INTEN_CH2LIMITH_Pos (10UL) /*!< Position of CH2LIMITH field. */
+#define SAADC_INTEN_CH2LIMITH_Msk (0x1UL << SAADC_INTEN_CH2LIMITH_Pos) /*!< Bit mask of CH2LIMITH field. */
+#define SAADC_INTEN_CH2LIMITH_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH2LIMITH_Enabled (1UL) /*!< Enable */
+
+/* Bit 9 : Enable or disable interrupt for CH[1].LIMITL event */
+#define SAADC_INTEN_CH1LIMITL_Pos (9UL) /*!< Position of CH1LIMITL field. */
+#define SAADC_INTEN_CH1LIMITL_Msk (0x1UL << SAADC_INTEN_CH1LIMITL_Pos) /*!< Bit mask of CH1LIMITL field. */
+#define SAADC_INTEN_CH1LIMITL_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH1LIMITL_Enabled (1UL) /*!< Enable */
+
+/* Bit 8 : Enable or disable interrupt for CH[1].LIMITH event */
+#define SAADC_INTEN_CH1LIMITH_Pos (8UL) /*!< Position of CH1LIMITH field. */
+#define SAADC_INTEN_CH1LIMITH_Msk (0x1UL << SAADC_INTEN_CH1LIMITH_Pos) /*!< Bit mask of CH1LIMITH field. */
+#define SAADC_INTEN_CH1LIMITH_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH1LIMITH_Enabled (1UL) /*!< Enable */
+
+/* Bit 7 : Enable or disable interrupt for CH[0].LIMITL event */
+#define SAADC_INTEN_CH0LIMITL_Pos (7UL) /*!< Position of CH0LIMITL field. */
+#define SAADC_INTEN_CH0LIMITL_Msk (0x1UL << SAADC_INTEN_CH0LIMITL_Pos) /*!< Bit mask of CH0LIMITL field. */
+#define SAADC_INTEN_CH0LIMITL_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH0LIMITL_Enabled (1UL) /*!< Enable */
+
+/* Bit 6 : Enable or disable interrupt for CH[0].LIMITH event */
+#define SAADC_INTEN_CH0LIMITH_Pos (6UL) /*!< Position of CH0LIMITH field. */
+#define SAADC_INTEN_CH0LIMITH_Msk (0x1UL << SAADC_INTEN_CH0LIMITH_Pos) /*!< Bit mask of CH0LIMITH field. */
+#define SAADC_INTEN_CH0LIMITH_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CH0LIMITH_Enabled (1UL) /*!< Enable */
+
+/* Bit 5 : Enable or disable interrupt for STOPPED event */
+#define SAADC_INTEN_STOPPED_Pos (5UL) /*!< Position of STOPPED field. */
+#define SAADC_INTEN_STOPPED_Msk (0x1UL << SAADC_INTEN_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define SAADC_INTEN_STOPPED_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_STOPPED_Enabled (1UL) /*!< Enable */
+
+/* Bit 4 : Enable or disable interrupt for CALIBRATEDONE event */
+#define SAADC_INTEN_CALIBRATEDONE_Pos (4UL) /*!< Position of CALIBRATEDONE field. */
+#define SAADC_INTEN_CALIBRATEDONE_Msk (0x1UL << SAADC_INTEN_CALIBRATEDONE_Pos) /*!< Bit mask of CALIBRATEDONE field. */
+#define SAADC_INTEN_CALIBRATEDONE_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_CALIBRATEDONE_Enabled (1UL) /*!< Enable */
+
+/* Bit 3 : Enable or disable interrupt for RESULTDONE event */
+#define SAADC_INTEN_RESULTDONE_Pos (3UL) /*!< Position of RESULTDONE field. */
+#define SAADC_INTEN_RESULTDONE_Msk (0x1UL << SAADC_INTEN_RESULTDONE_Pos) /*!< Bit mask of RESULTDONE field. */
+#define SAADC_INTEN_RESULTDONE_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_RESULTDONE_Enabled (1UL) /*!< Enable */
+
+/* Bit 2 : Enable or disable interrupt for DONE event */
+#define SAADC_INTEN_DONE_Pos (2UL) /*!< Position of DONE field. */
+#define SAADC_INTEN_DONE_Msk (0x1UL << SAADC_INTEN_DONE_Pos) /*!< Bit mask of DONE field. */
+#define SAADC_INTEN_DONE_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_DONE_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for END event */
+#define SAADC_INTEN_END_Pos (1UL) /*!< Position of END field. */
+#define SAADC_INTEN_END_Msk (0x1UL << SAADC_INTEN_END_Pos) /*!< Bit mask of END field. */
+#define SAADC_INTEN_END_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_END_Enabled (1UL) /*!< Enable */
+
+/* Bit 0 : Enable or disable interrupt for STARTED event */
+#define SAADC_INTEN_STARTED_Pos (0UL) /*!< Position of STARTED field. */
+#define SAADC_INTEN_STARTED_Msk (0x1UL << SAADC_INTEN_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define SAADC_INTEN_STARTED_Disabled (0UL) /*!< Disable */
+#define SAADC_INTEN_STARTED_Enabled (1UL) /*!< Enable */
+
+/* Register: SAADC_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 21 : Write '1' to Enable interrupt for CH[7].LIMITL event */
+#define SAADC_INTENSET_CH7LIMITL_Pos (21UL) /*!< Position of CH7LIMITL field. */
+#define SAADC_INTENSET_CH7LIMITL_Msk (0x1UL << SAADC_INTENSET_CH7LIMITL_Pos) /*!< Bit mask of CH7LIMITL field. */
+#define SAADC_INTENSET_CH7LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH7LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH7LIMITL_Set (1UL) /*!< Enable */
+
+/* Bit 20 : Write '1' to Enable interrupt for CH[7].LIMITH event */
+#define SAADC_INTENSET_CH7LIMITH_Pos (20UL) /*!< Position of CH7LIMITH field. */
+#define SAADC_INTENSET_CH7LIMITH_Msk (0x1UL << SAADC_INTENSET_CH7LIMITH_Pos) /*!< Bit mask of CH7LIMITH field. */
+#define SAADC_INTENSET_CH7LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH7LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH7LIMITH_Set (1UL) /*!< Enable */
+
+/* Bit 19 : Write '1' to Enable interrupt for CH[6].LIMITL event */
+#define SAADC_INTENSET_CH6LIMITL_Pos (19UL) /*!< Position of CH6LIMITL field. */
+#define SAADC_INTENSET_CH6LIMITL_Msk (0x1UL << SAADC_INTENSET_CH6LIMITL_Pos) /*!< Bit mask of CH6LIMITL field. */
+#define SAADC_INTENSET_CH6LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH6LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH6LIMITL_Set (1UL) /*!< Enable */
+
+/* Bit 18 : Write '1' to Enable interrupt for CH[6].LIMITH event */
+#define SAADC_INTENSET_CH6LIMITH_Pos (18UL) /*!< Position of CH6LIMITH field. */
+#define SAADC_INTENSET_CH6LIMITH_Msk (0x1UL << SAADC_INTENSET_CH6LIMITH_Pos) /*!< Bit mask of CH6LIMITH field. */
+#define SAADC_INTENSET_CH6LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH6LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH6LIMITH_Set (1UL) /*!< Enable */
+
+/* Bit 17 : Write '1' to Enable interrupt for CH[5].LIMITL event */
+#define SAADC_INTENSET_CH5LIMITL_Pos (17UL) /*!< Position of CH5LIMITL field. */
+#define SAADC_INTENSET_CH5LIMITL_Msk (0x1UL << SAADC_INTENSET_CH5LIMITL_Pos) /*!< Bit mask of CH5LIMITL field. */
+#define SAADC_INTENSET_CH5LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH5LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH5LIMITL_Set (1UL) /*!< Enable */
+
+/* Bit 16 : Write '1' to Enable interrupt for CH[5].LIMITH event */
+#define SAADC_INTENSET_CH5LIMITH_Pos (16UL) /*!< Position of CH5LIMITH field. */
+#define SAADC_INTENSET_CH5LIMITH_Msk (0x1UL << SAADC_INTENSET_CH5LIMITH_Pos) /*!< Bit mask of CH5LIMITH field. */
+#define SAADC_INTENSET_CH5LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH5LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH5LIMITH_Set (1UL) /*!< Enable */
+
+/* Bit 15 : Write '1' to Enable interrupt for CH[4].LIMITL event */
+#define SAADC_INTENSET_CH4LIMITL_Pos (15UL) /*!< Position of CH4LIMITL field. */
+#define SAADC_INTENSET_CH4LIMITL_Msk (0x1UL << SAADC_INTENSET_CH4LIMITL_Pos) /*!< Bit mask of CH4LIMITL field. */
+#define SAADC_INTENSET_CH4LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH4LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH4LIMITL_Set (1UL) /*!< Enable */
+
+/* Bit 14 : Write '1' to Enable interrupt for CH[4].LIMITH event */
+#define SAADC_INTENSET_CH4LIMITH_Pos (14UL) /*!< Position of CH4LIMITH field. */
+#define SAADC_INTENSET_CH4LIMITH_Msk (0x1UL << SAADC_INTENSET_CH4LIMITH_Pos) /*!< Bit mask of CH4LIMITH field. */
+#define SAADC_INTENSET_CH4LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH4LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH4LIMITH_Set (1UL) /*!< Enable */
+
+/* Bit 13 : Write '1' to Enable interrupt for CH[3].LIMITL event */
+#define SAADC_INTENSET_CH3LIMITL_Pos (13UL) /*!< Position of CH3LIMITL field. */
+#define SAADC_INTENSET_CH3LIMITL_Msk (0x1UL << SAADC_INTENSET_CH3LIMITL_Pos) /*!< Bit mask of CH3LIMITL field. */
+#define SAADC_INTENSET_CH3LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH3LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH3LIMITL_Set (1UL) /*!< Enable */
+
+/* Bit 12 : Write '1' to Enable interrupt for CH[3].LIMITH event */
+#define SAADC_INTENSET_CH3LIMITH_Pos (12UL) /*!< Position of CH3LIMITH field. */
+#define SAADC_INTENSET_CH3LIMITH_Msk (0x1UL << SAADC_INTENSET_CH3LIMITH_Pos) /*!< Bit mask of CH3LIMITH field. */
+#define SAADC_INTENSET_CH3LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH3LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH3LIMITH_Set (1UL) /*!< Enable */
+
+/* Bit 11 : Write '1' to Enable interrupt for CH[2].LIMITL event */
+#define SAADC_INTENSET_CH2LIMITL_Pos (11UL) /*!< Position of CH2LIMITL field. */
+#define SAADC_INTENSET_CH2LIMITL_Msk (0x1UL << SAADC_INTENSET_CH2LIMITL_Pos) /*!< Bit mask of CH2LIMITL field. */
+#define SAADC_INTENSET_CH2LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH2LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH2LIMITL_Set (1UL) /*!< Enable */
+
+/* Bit 10 : Write '1' to Enable interrupt for CH[2].LIMITH event */
+#define SAADC_INTENSET_CH2LIMITH_Pos (10UL) /*!< Position of CH2LIMITH field. */
+#define SAADC_INTENSET_CH2LIMITH_Msk (0x1UL << SAADC_INTENSET_CH2LIMITH_Pos) /*!< Bit mask of CH2LIMITH field. */
+#define SAADC_INTENSET_CH2LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH2LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH2LIMITH_Set (1UL) /*!< Enable */
+
+/* Bit 9 : Write '1' to Enable interrupt for CH[1].LIMITL event */
+#define SAADC_INTENSET_CH1LIMITL_Pos (9UL) /*!< Position of CH1LIMITL field. */
+#define SAADC_INTENSET_CH1LIMITL_Msk (0x1UL << SAADC_INTENSET_CH1LIMITL_Pos) /*!< Bit mask of CH1LIMITL field. */
+#define SAADC_INTENSET_CH1LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH1LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH1LIMITL_Set (1UL) /*!< Enable */
+
+/* Bit 8 : Write '1' to Enable interrupt for CH[1].LIMITH event */
+#define SAADC_INTENSET_CH1LIMITH_Pos (8UL) /*!< Position of CH1LIMITH field. */
+#define SAADC_INTENSET_CH1LIMITH_Msk (0x1UL << SAADC_INTENSET_CH1LIMITH_Pos) /*!< Bit mask of CH1LIMITH field. */
+#define SAADC_INTENSET_CH1LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH1LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH1LIMITH_Set (1UL) /*!< Enable */
+
+/* Bit 7 : Write '1' to Enable interrupt for CH[0].LIMITL event */
+#define SAADC_INTENSET_CH0LIMITL_Pos (7UL) /*!< Position of CH0LIMITL field. */
+#define SAADC_INTENSET_CH0LIMITL_Msk (0x1UL << SAADC_INTENSET_CH0LIMITL_Pos) /*!< Bit mask of CH0LIMITL field. */
+#define SAADC_INTENSET_CH0LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH0LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH0LIMITL_Set (1UL) /*!< Enable */
+
+/* Bit 6 : Write '1' to Enable interrupt for CH[0].LIMITH event */
+#define SAADC_INTENSET_CH0LIMITH_Pos (6UL) /*!< Position of CH0LIMITH field. */
+#define SAADC_INTENSET_CH0LIMITH_Msk (0x1UL << SAADC_INTENSET_CH0LIMITH_Pos) /*!< Bit mask of CH0LIMITH field. */
+#define SAADC_INTENSET_CH0LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CH0LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CH0LIMITH_Set (1UL) /*!< Enable */
+
+/* Bit 5 : Write '1' to Enable interrupt for STOPPED event */
+#define SAADC_INTENSET_STOPPED_Pos (5UL) /*!< Position of STOPPED field. */
+#define SAADC_INTENSET_STOPPED_Msk (0x1UL << SAADC_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define SAADC_INTENSET_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_STOPPED_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable interrupt for CALIBRATEDONE event */
+#define SAADC_INTENSET_CALIBRATEDONE_Pos (4UL) /*!< Position of CALIBRATEDONE field. */
+#define SAADC_INTENSET_CALIBRATEDONE_Msk (0x1UL << SAADC_INTENSET_CALIBRATEDONE_Pos) /*!< Bit mask of CALIBRATEDONE field. */
+#define SAADC_INTENSET_CALIBRATEDONE_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_CALIBRATEDONE_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_CALIBRATEDONE_Set (1UL) /*!< Enable */
+
+/* Bit 3 : Write '1' to Enable interrupt for RESULTDONE event */
+#define SAADC_INTENSET_RESULTDONE_Pos (3UL) /*!< Position of RESULTDONE field. */
+#define SAADC_INTENSET_RESULTDONE_Msk (0x1UL << SAADC_INTENSET_RESULTDONE_Pos) /*!< Bit mask of RESULTDONE field. */
+#define SAADC_INTENSET_RESULTDONE_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_RESULTDONE_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_RESULTDONE_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for DONE event */
+#define SAADC_INTENSET_DONE_Pos (2UL) /*!< Position of DONE field. */
+#define SAADC_INTENSET_DONE_Msk (0x1UL << SAADC_INTENSET_DONE_Pos) /*!< Bit mask of DONE field. */
+#define SAADC_INTENSET_DONE_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_DONE_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_DONE_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for END event */
+#define SAADC_INTENSET_END_Pos (1UL) /*!< Position of END field. */
+#define SAADC_INTENSET_END_Msk (0x1UL << SAADC_INTENSET_END_Pos) /*!< Bit mask of END field. */
+#define SAADC_INTENSET_END_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_END_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_END_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for STARTED event */
+#define SAADC_INTENSET_STARTED_Pos (0UL) /*!< Position of STARTED field. */
+#define SAADC_INTENSET_STARTED_Msk (0x1UL << SAADC_INTENSET_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define SAADC_INTENSET_STARTED_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENSET_STARTED_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENSET_STARTED_Set (1UL) /*!< Enable */
+
+/* Register: SAADC_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 21 : Write '1' to Disable interrupt for CH[7].LIMITL event */
+#define SAADC_INTENCLR_CH7LIMITL_Pos (21UL) /*!< Position of CH7LIMITL field. */
+#define SAADC_INTENCLR_CH7LIMITL_Msk (0x1UL << SAADC_INTENCLR_CH7LIMITL_Pos) /*!< Bit mask of CH7LIMITL field. */
+#define SAADC_INTENCLR_CH7LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH7LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH7LIMITL_Clear (1UL) /*!< Disable */
+
+/* Bit 20 : Write '1' to Disable interrupt for CH[7].LIMITH event */
+#define SAADC_INTENCLR_CH7LIMITH_Pos (20UL) /*!< Position of CH7LIMITH field. */
+#define SAADC_INTENCLR_CH7LIMITH_Msk (0x1UL << SAADC_INTENCLR_CH7LIMITH_Pos) /*!< Bit mask of CH7LIMITH field. */
+#define SAADC_INTENCLR_CH7LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH7LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH7LIMITH_Clear (1UL) /*!< Disable */
+
+/* Bit 19 : Write '1' to Disable interrupt for CH[6].LIMITL event */
+#define SAADC_INTENCLR_CH6LIMITL_Pos (19UL) /*!< Position of CH6LIMITL field. */
+#define SAADC_INTENCLR_CH6LIMITL_Msk (0x1UL << SAADC_INTENCLR_CH6LIMITL_Pos) /*!< Bit mask of CH6LIMITL field. */
+#define SAADC_INTENCLR_CH6LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH6LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH6LIMITL_Clear (1UL) /*!< Disable */
+
+/* Bit 18 : Write '1' to Disable interrupt for CH[6].LIMITH event */
+#define SAADC_INTENCLR_CH6LIMITH_Pos (18UL) /*!< Position of CH6LIMITH field. */
+#define SAADC_INTENCLR_CH6LIMITH_Msk (0x1UL << SAADC_INTENCLR_CH6LIMITH_Pos) /*!< Bit mask of CH6LIMITH field. */
+#define SAADC_INTENCLR_CH6LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH6LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH6LIMITH_Clear (1UL) /*!< Disable */
+
+/* Bit 17 : Write '1' to Disable interrupt for CH[5].LIMITL event */
+#define SAADC_INTENCLR_CH5LIMITL_Pos (17UL) /*!< Position of CH5LIMITL field. */
+#define SAADC_INTENCLR_CH5LIMITL_Msk (0x1UL << SAADC_INTENCLR_CH5LIMITL_Pos) /*!< Bit mask of CH5LIMITL field. */
+#define SAADC_INTENCLR_CH5LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH5LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH5LIMITL_Clear (1UL) /*!< Disable */
+
+/* Bit 16 : Write '1' to Disable interrupt for CH[5].LIMITH event */
+#define SAADC_INTENCLR_CH5LIMITH_Pos (16UL) /*!< Position of CH5LIMITH field. */
+#define SAADC_INTENCLR_CH5LIMITH_Msk (0x1UL << SAADC_INTENCLR_CH5LIMITH_Pos) /*!< Bit mask of CH5LIMITH field. */
+#define SAADC_INTENCLR_CH5LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH5LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH5LIMITH_Clear (1UL) /*!< Disable */
+
+/* Bit 15 : Write '1' to Disable interrupt for CH[4].LIMITL event */
+#define SAADC_INTENCLR_CH4LIMITL_Pos (15UL) /*!< Position of CH4LIMITL field. */
+#define SAADC_INTENCLR_CH4LIMITL_Msk (0x1UL << SAADC_INTENCLR_CH4LIMITL_Pos) /*!< Bit mask of CH4LIMITL field. */
+#define SAADC_INTENCLR_CH4LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH4LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH4LIMITL_Clear (1UL) /*!< Disable */
+
+/* Bit 14 : Write '1' to Disable interrupt for CH[4].LIMITH event */
+#define SAADC_INTENCLR_CH4LIMITH_Pos (14UL) /*!< Position of CH4LIMITH field. */
+#define SAADC_INTENCLR_CH4LIMITH_Msk (0x1UL << SAADC_INTENCLR_CH4LIMITH_Pos) /*!< Bit mask of CH4LIMITH field. */
+#define SAADC_INTENCLR_CH4LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH4LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH4LIMITH_Clear (1UL) /*!< Disable */
+
+/* Bit 13 : Write '1' to Disable interrupt for CH[3].LIMITL event */
+#define SAADC_INTENCLR_CH3LIMITL_Pos (13UL) /*!< Position of CH3LIMITL field. */
+#define SAADC_INTENCLR_CH3LIMITL_Msk (0x1UL << SAADC_INTENCLR_CH3LIMITL_Pos) /*!< Bit mask of CH3LIMITL field. */
+#define SAADC_INTENCLR_CH3LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH3LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH3LIMITL_Clear (1UL) /*!< Disable */
+
+/* Bit 12 : Write '1' to Disable interrupt for CH[3].LIMITH event */
+#define SAADC_INTENCLR_CH3LIMITH_Pos (12UL) /*!< Position of CH3LIMITH field. */
+#define SAADC_INTENCLR_CH3LIMITH_Msk (0x1UL << SAADC_INTENCLR_CH3LIMITH_Pos) /*!< Bit mask of CH3LIMITH field. */
+#define SAADC_INTENCLR_CH3LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH3LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH3LIMITH_Clear (1UL) /*!< Disable */
+
+/* Bit 11 : Write '1' to Disable interrupt for CH[2].LIMITL event */
+#define SAADC_INTENCLR_CH2LIMITL_Pos (11UL) /*!< Position of CH2LIMITL field. */
+#define SAADC_INTENCLR_CH2LIMITL_Msk (0x1UL << SAADC_INTENCLR_CH2LIMITL_Pos) /*!< Bit mask of CH2LIMITL field. */
+#define SAADC_INTENCLR_CH2LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH2LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH2LIMITL_Clear (1UL) /*!< Disable */
+
+/* Bit 10 : Write '1' to Disable interrupt for CH[2].LIMITH event */
+#define SAADC_INTENCLR_CH2LIMITH_Pos (10UL) /*!< Position of CH2LIMITH field. */
+#define SAADC_INTENCLR_CH2LIMITH_Msk (0x1UL << SAADC_INTENCLR_CH2LIMITH_Pos) /*!< Bit mask of CH2LIMITH field. */
+#define SAADC_INTENCLR_CH2LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH2LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH2LIMITH_Clear (1UL) /*!< Disable */
+
+/* Bit 9 : Write '1' to Disable interrupt for CH[1].LIMITL event */
+#define SAADC_INTENCLR_CH1LIMITL_Pos (9UL) /*!< Position of CH1LIMITL field. */
+#define SAADC_INTENCLR_CH1LIMITL_Msk (0x1UL << SAADC_INTENCLR_CH1LIMITL_Pos) /*!< Bit mask of CH1LIMITL field. */
+#define SAADC_INTENCLR_CH1LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH1LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH1LIMITL_Clear (1UL) /*!< Disable */
+
+/* Bit 8 : Write '1' to Disable interrupt for CH[1].LIMITH event */
+#define SAADC_INTENCLR_CH1LIMITH_Pos (8UL) /*!< Position of CH1LIMITH field. */
+#define SAADC_INTENCLR_CH1LIMITH_Msk (0x1UL << SAADC_INTENCLR_CH1LIMITH_Pos) /*!< Bit mask of CH1LIMITH field. */
+#define SAADC_INTENCLR_CH1LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH1LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH1LIMITH_Clear (1UL) /*!< Disable */
+
+/* Bit 7 : Write '1' to Disable interrupt for CH[0].LIMITL event */
+#define SAADC_INTENCLR_CH0LIMITL_Pos (7UL) /*!< Position of CH0LIMITL field. */
+#define SAADC_INTENCLR_CH0LIMITL_Msk (0x1UL << SAADC_INTENCLR_CH0LIMITL_Pos) /*!< Bit mask of CH0LIMITL field. */
+#define SAADC_INTENCLR_CH0LIMITL_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH0LIMITL_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH0LIMITL_Clear (1UL) /*!< Disable */
+
+/* Bit 6 : Write '1' to Disable interrupt for CH[0].LIMITH event */
+#define SAADC_INTENCLR_CH0LIMITH_Pos (6UL) /*!< Position of CH0LIMITH field. */
+#define SAADC_INTENCLR_CH0LIMITH_Msk (0x1UL << SAADC_INTENCLR_CH0LIMITH_Pos) /*!< Bit mask of CH0LIMITH field. */
+#define SAADC_INTENCLR_CH0LIMITH_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CH0LIMITH_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CH0LIMITH_Clear (1UL) /*!< Disable */
+
+/* Bit 5 : Write '1' to Disable interrupt for STOPPED event */
+#define SAADC_INTENCLR_STOPPED_Pos (5UL) /*!< Position of STOPPED field. */
+#define SAADC_INTENCLR_STOPPED_Msk (0x1UL << SAADC_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define SAADC_INTENCLR_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_STOPPED_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable interrupt for CALIBRATEDONE event */
+#define SAADC_INTENCLR_CALIBRATEDONE_Pos (4UL) /*!< Position of CALIBRATEDONE field. */
+#define SAADC_INTENCLR_CALIBRATEDONE_Msk (0x1UL << SAADC_INTENCLR_CALIBRATEDONE_Pos) /*!< Bit mask of CALIBRATEDONE field. */
+#define SAADC_INTENCLR_CALIBRATEDONE_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_CALIBRATEDONE_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_CALIBRATEDONE_Clear (1UL) /*!< Disable */
+
+/* Bit 3 : Write '1' to Disable interrupt for RESULTDONE event */
+#define SAADC_INTENCLR_RESULTDONE_Pos (3UL) /*!< Position of RESULTDONE field. */
+#define SAADC_INTENCLR_RESULTDONE_Msk (0x1UL << SAADC_INTENCLR_RESULTDONE_Pos) /*!< Bit mask of RESULTDONE field. */
+#define SAADC_INTENCLR_RESULTDONE_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_RESULTDONE_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_RESULTDONE_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for DONE event */
+#define SAADC_INTENCLR_DONE_Pos (2UL) /*!< Position of DONE field. */
+#define SAADC_INTENCLR_DONE_Msk (0x1UL << SAADC_INTENCLR_DONE_Pos) /*!< Bit mask of DONE field. */
+#define SAADC_INTENCLR_DONE_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_DONE_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_DONE_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for END event */
+#define SAADC_INTENCLR_END_Pos (1UL) /*!< Position of END field. */
+#define SAADC_INTENCLR_END_Msk (0x1UL << SAADC_INTENCLR_END_Pos) /*!< Bit mask of END field. */
+#define SAADC_INTENCLR_END_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_END_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_END_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for STARTED event */
+#define SAADC_INTENCLR_STARTED_Pos (0UL) /*!< Position of STARTED field. */
+#define SAADC_INTENCLR_STARTED_Msk (0x1UL << SAADC_INTENCLR_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define SAADC_INTENCLR_STARTED_Disabled (0UL) /*!< Read: Disabled */
+#define SAADC_INTENCLR_STARTED_Enabled (1UL) /*!< Read: Enabled */
+#define SAADC_INTENCLR_STARTED_Clear (1UL) /*!< Disable */
+
+/* Register: SAADC_STATUS */
+/* Description: Status */
+
+/* Bit 0 : Status */
+#define SAADC_STATUS_STATUS_Pos (0UL) /*!< Position of STATUS field. */
+#define SAADC_STATUS_STATUS_Msk (0x1UL << SAADC_STATUS_STATUS_Pos) /*!< Bit mask of STATUS field. */
+#define SAADC_STATUS_STATUS_Ready (0UL) /*!< ADC is ready. No on-going conversion. */
+#define SAADC_STATUS_STATUS_Busy (1UL) /*!< ADC is busy. Conversion in progress. */
+
+/* Register: SAADC_ENABLE */
+/* Description: Enable or disable ADC */
+
+/* Bit 0 : Enable or disable ADC */
+#define SAADC_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define SAADC_ENABLE_ENABLE_Msk (0x1UL << SAADC_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define SAADC_ENABLE_ENABLE_Disabled (0UL) /*!< Disable ADC */
+#define SAADC_ENABLE_ENABLE_Enabled (1UL) /*!< Enable ADC */
+
+/* Register: SAADC_CH_PSELP */
+/* Description: Description cluster[0]:  Input positive pin selection for CH[0] */
+
+/* Bits 4..0 : Analog positive input channel */
+#define SAADC_CH_PSELP_PSELP_Pos (0UL) /*!< Position of PSELP field. */
+#define SAADC_CH_PSELP_PSELP_Msk (0x1FUL << SAADC_CH_PSELP_PSELP_Pos) /*!< Bit mask of PSELP field. */
+#define SAADC_CH_PSELP_PSELP_NC (0UL) /*!< Not connected */
+#define SAADC_CH_PSELP_PSELP_AnalogInput0 (1UL) /*!< AIN0 */
+#define SAADC_CH_PSELP_PSELP_AnalogInput1 (2UL) /*!< AIN1 */
+#define SAADC_CH_PSELP_PSELP_AnalogInput2 (3UL) /*!< AIN2 */
+#define SAADC_CH_PSELP_PSELP_AnalogInput3 (4UL) /*!< AIN3 */
+#define SAADC_CH_PSELP_PSELP_AnalogInput4 (5UL) /*!< AIN4 */
+#define SAADC_CH_PSELP_PSELP_AnalogInput5 (6UL) /*!< AIN5 */
+#define SAADC_CH_PSELP_PSELP_AnalogInput6 (7UL) /*!< AIN6 */
+#define SAADC_CH_PSELP_PSELP_AnalogInput7 (8UL) /*!< AIN7 */
+#define SAADC_CH_PSELP_PSELP_VDD (9UL) /*!< VDD */
+
+/* Register: SAADC_CH_PSELN */
+/* Description: Description cluster[0]:  Input negative pin selection for CH[0] */
+
+/* Bits 4..0 : Analog negative input, enables differential channel */
+#define SAADC_CH_PSELN_PSELN_Pos (0UL) /*!< Position of PSELN field. */
+#define SAADC_CH_PSELN_PSELN_Msk (0x1FUL << SAADC_CH_PSELN_PSELN_Pos) /*!< Bit mask of PSELN field. */
+#define SAADC_CH_PSELN_PSELN_NC (0UL) /*!< Not connected */
+#define SAADC_CH_PSELN_PSELN_AnalogInput0 (1UL) /*!< AIN0 */
+#define SAADC_CH_PSELN_PSELN_AnalogInput1 (2UL) /*!< AIN1 */
+#define SAADC_CH_PSELN_PSELN_AnalogInput2 (3UL) /*!< AIN2 */
+#define SAADC_CH_PSELN_PSELN_AnalogInput3 (4UL) /*!< AIN3 */
+#define SAADC_CH_PSELN_PSELN_AnalogInput4 (5UL) /*!< AIN4 */
+#define SAADC_CH_PSELN_PSELN_AnalogInput5 (6UL) /*!< AIN5 */
+#define SAADC_CH_PSELN_PSELN_AnalogInput6 (7UL) /*!< AIN6 */
+#define SAADC_CH_PSELN_PSELN_AnalogInput7 (8UL) /*!< AIN7 */
+#define SAADC_CH_PSELN_PSELN_VDD (9UL) /*!< VDD */
+
+/* Register: SAADC_CH_CONFIG */
+/* Description: Description cluster[0]:  Input configuration for CH[0] */
+
+/* Bit 20 : Enable differential mode */
+#define SAADC_CH_CONFIG_MODE_Pos (20UL) /*!< Position of MODE field. */
+#define SAADC_CH_CONFIG_MODE_Msk (0x1UL << SAADC_CH_CONFIG_MODE_Pos) /*!< Bit mask of MODE field. */
+#define SAADC_CH_CONFIG_MODE_SE (0UL) /*!< Single ended, PSELN will be ignored, negative input to ADC shorted to GND */
+#define SAADC_CH_CONFIG_MODE_Diff (1UL) /*!< Differential */
+
+/* Bits 18..16 : Acquisition time, the time the ADC uses to sample the input voltage */
+#define SAADC_CH_CONFIG_TACQ_Pos (16UL) /*!< Position of TACQ field. */
+#define SAADC_CH_CONFIG_TACQ_Msk (0x7UL << SAADC_CH_CONFIG_TACQ_Pos) /*!< Bit mask of TACQ field. */
+#define SAADC_CH_CONFIG_TACQ_3us (0UL) /*!< 3 us */
+#define SAADC_CH_CONFIG_TACQ_5us (1UL) /*!< 5 us */
+#define SAADC_CH_CONFIG_TACQ_10us (2UL) /*!< 10 us */
+#define SAADC_CH_CONFIG_TACQ_15us (3UL) /*!< 15 us */
+#define SAADC_CH_CONFIG_TACQ_20us (4UL) /*!< 20 us */
+#define SAADC_CH_CONFIG_TACQ_40us (5UL) /*!< 40 us */
+
+/* Bit 12 : Reference control */
+#define SAADC_CH_CONFIG_REFSEL_Pos (12UL) /*!< Position of REFSEL field. */
+#define SAADC_CH_CONFIG_REFSEL_Msk (0x1UL << SAADC_CH_CONFIG_REFSEL_Pos) /*!< Bit mask of REFSEL field. */
+#define SAADC_CH_CONFIG_REFSEL_Internal (0UL) /*!< Internal reference (0.6 V) */
+#define SAADC_CH_CONFIG_REFSEL_VDD1_4 (1UL) /*!< VDD/4 as reference */
+
+/* Bits 10..8 : Gain control */
+#define SAADC_CH_CONFIG_GAIN_Pos (8UL) /*!< Position of GAIN field. */
+#define SAADC_CH_CONFIG_GAIN_Msk (0x7UL << SAADC_CH_CONFIG_GAIN_Pos) /*!< Bit mask of GAIN field. */
+#define SAADC_CH_CONFIG_GAIN_Gain1_6 (0UL) /*!< 1/6 */
+#define SAADC_CH_CONFIG_GAIN_Gain1_5 (1UL) /*!< 1/5 */
+#define SAADC_CH_CONFIG_GAIN_Gain1_4 (2UL) /*!< 1/4 */
+#define SAADC_CH_CONFIG_GAIN_Gain1_3 (3UL) /*!< 1/3 */
+#define SAADC_CH_CONFIG_GAIN_Gain1_2 (4UL) /*!< 1/2 */
+#define SAADC_CH_CONFIG_GAIN_Gain1 (5UL) /*!< 1 */
+#define SAADC_CH_CONFIG_GAIN_Gain2 (6UL) /*!< 2 */
+#define SAADC_CH_CONFIG_GAIN_Gain4 (7UL) /*!< 4 */
+
+/* Bits 5..4 : Negative channel resistor control */
+#define SAADC_CH_CONFIG_RESN_Pos (4UL) /*!< Position of RESN field. */
+#define SAADC_CH_CONFIG_RESN_Msk (0x3UL << SAADC_CH_CONFIG_RESN_Pos) /*!< Bit mask of RESN field. */
+#define SAADC_CH_CONFIG_RESN_Bypass (0UL) /*!< Bypass resistor ladder */
+#define SAADC_CH_CONFIG_RESN_Pulldown (1UL) /*!< Pull-down to GND */
+#define SAADC_CH_CONFIG_RESN_Pullup (2UL) /*!< Pull-up to VDD */
+#define SAADC_CH_CONFIG_RESN_VDD1_2 (3UL) /*!< Set input at VDD/2 */
+
+/* Bits 1..0 : Positive channel resistor control */
+#define SAADC_CH_CONFIG_RESP_Pos (0UL) /*!< Position of RESP field. */
+#define SAADC_CH_CONFIG_RESP_Msk (0x3UL << SAADC_CH_CONFIG_RESP_Pos) /*!< Bit mask of RESP field. */
+#define SAADC_CH_CONFIG_RESP_Bypass (0UL) /*!< Bypass resistor ladder */
+#define SAADC_CH_CONFIG_RESP_Pulldown (1UL) /*!< Pull-down to GND */
+#define SAADC_CH_CONFIG_RESP_Pullup (2UL) /*!< Pull-up to VDD */
+#define SAADC_CH_CONFIG_RESP_VDD1_2 (3UL) /*!< Set input at VDD/2 */
+
+/* Register: SAADC_CH_LIMIT */
+/* Description: Description cluster[0]:  High/low limits for event monitoring a channel */
+
+/* Bits 31..16 : High level limit */
+#define SAADC_CH_LIMIT_HIGH_Pos (16UL) /*!< Position of HIGH field. */
+#define SAADC_CH_LIMIT_HIGH_Msk (0xFFFFUL << SAADC_CH_LIMIT_HIGH_Pos) /*!< Bit mask of HIGH field. */
+
+/* Bits 15..0 : Low level limit */
+#define SAADC_CH_LIMIT_LOW_Pos (0UL) /*!< Position of LOW field. */
+#define SAADC_CH_LIMIT_LOW_Msk (0xFFFFUL << SAADC_CH_LIMIT_LOW_Pos) /*!< Bit mask of LOW field. */
+
+/* Register: SAADC_RESOLUTION */
+/* Description: Resolution configuration */
+
+/* Bits 2..0 : Set the resolution */
+#define SAADC_RESOLUTION_VAL_Pos (0UL) /*!< Position of VAL field. */
+#define SAADC_RESOLUTION_VAL_Msk (0x7UL << SAADC_RESOLUTION_VAL_Pos) /*!< Bit mask of VAL field. */
+#define SAADC_RESOLUTION_VAL_8bit (0UL) /*!< 8 bit */
+#define SAADC_RESOLUTION_VAL_10bit (1UL) /*!< 10 bit */
+#define SAADC_RESOLUTION_VAL_12bit (2UL) /*!< 12 bit */
+#define SAADC_RESOLUTION_VAL_14bit (3UL) /*!< 14 bit */
+
+/* Register: SAADC_OVERSAMPLE */
+/* Description: Oversampling configuration. OVERSAMPLE should not be combined with SCAN. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used. */
+
+/* Bits 3..0 : Oversample control */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Pos (0UL) /*!< Position of OVERSAMPLE field. */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Msk (0xFUL << SAADC_OVERSAMPLE_OVERSAMPLE_Pos) /*!< Bit mask of OVERSAMPLE field. */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Bypass (0UL) /*!< Bypass oversampling */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Over2x (1UL) /*!< Oversample 2x */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Over4x (2UL) /*!< Oversample 4x */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Over8x (3UL) /*!< Oversample 8x */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Over16x (4UL) /*!< Oversample 16x */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Over32x (5UL) /*!< Oversample 32x */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Over64x (6UL) /*!< Oversample 64x */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Over128x (7UL) /*!< Oversample 128x */
+#define SAADC_OVERSAMPLE_OVERSAMPLE_Over256x (8UL) /*!< Oversample 256x */
+
+/* Register: SAADC_SAMPLERATE */
+/* Description: Controls normal or continuous sample rate */
+
+/* Bit 12 : Select mode for sample rate control */
+#define SAADC_SAMPLERATE_MODE_Pos (12UL) /*!< Position of MODE field. */
+#define SAADC_SAMPLERATE_MODE_Msk (0x1UL << SAADC_SAMPLERATE_MODE_Pos) /*!< Bit mask of MODE field. */
+#define SAADC_SAMPLERATE_MODE_Task (0UL) /*!< Rate is controlled from SAMPLE task */
+#define SAADC_SAMPLERATE_MODE_Timers (1UL) /*!< Rate is controlled from local timer (use CC to control the rate) */
+
+/* Bits 10..0 : Capture and compare value. Sample rate is 16 MHz/CC */
+#define SAADC_SAMPLERATE_CC_Pos (0UL) /*!< Position of CC field. */
+#define SAADC_SAMPLERATE_CC_Msk (0x7FFUL << SAADC_SAMPLERATE_CC_Pos) /*!< Bit mask of CC field. */
+
+/* Register: SAADC_RESULT_PTR */
+/* Description: Data pointer */
+
+/* Bits 31..0 : Data pointer */
+#define SAADC_RESULT_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define SAADC_RESULT_PTR_PTR_Msk (0xFFFFFFFFUL << SAADC_RESULT_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: SAADC_RESULT_MAXCNT */
+/* Description: Maximum number of buffer words to transfer */
+
+/* Bits 15..0 : Maximum number of buffer words to transfer */
+#define SAADC_RESULT_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define SAADC_RESULT_MAXCNT_MAXCNT_Msk (0xFFFFUL << SAADC_RESULT_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: SAADC_RESULT_AMOUNT */
+/* Description: Number of buffer words transferred since last START */
+
+/* Bits 15..0 : Number of buffer words transferred since last START. This register can be read after an END or STOPPED event. */
+#define SAADC_RESULT_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define SAADC_RESULT_AMOUNT_AMOUNT_Msk (0xFFFFUL << SAADC_RESULT_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+
+/* Peripheral: SPI */
+/* Description: Serial Peripheral Interface 0 */
+
+/* Register: SPI_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 2 : Write '1' to Enable interrupt for READY event */
+#define SPI_INTENSET_READY_Pos (2UL) /*!< Position of READY field. */
+#define SPI_INTENSET_READY_Msk (0x1UL << SPI_INTENSET_READY_Pos) /*!< Bit mask of READY field. */
+#define SPI_INTENSET_READY_Disabled (0UL) /*!< Read: Disabled */
+#define SPI_INTENSET_READY_Enabled (1UL) /*!< Read: Enabled */
+#define SPI_INTENSET_READY_Set (1UL) /*!< Enable */
+
+/* Register: SPI_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 2 : Write '1' to Disable interrupt for READY event */
+#define SPI_INTENCLR_READY_Pos (2UL) /*!< Position of READY field. */
+#define SPI_INTENCLR_READY_Msk (0x1UL << SPI_INTENCLR_READY_Pos) /*!< Bit mask of READY field. */
+#define SPI_INTENCLR_READY_Disabled (0UL) /*!< Read: Disabled */
+#define SPI_INTENCLR_READY_Enabled (1UL) /*!< Read: Enabled */
+#define SPI_INTENCLR_READY_Clear (1UL) /*!< Disable */
+
+/* Register: SPI_ENABLE */
+/* Description: Enable SPI */
+
+/* Bits 3..0 : Enable or disable SPI */
+#define SPI_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define SPI_ENABLE_ENABLE_Msk (0xFUL << SPI_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define SPI_ENABLE_ENABLE_Disabled (0UL) /*!< Disable SPI */
+#define SPI_ENABLE_ENABLE_Enabled (1UL) /*!< Enable SPI */
+
+/* Register: SPI_PSEL_SCK */
+/* Description: Pin select for SCK */
+
+/* Bits 31..0 : Pin number configuration for SPI SCK signal */
+#define SPI_PSEL_SCK_PSELSCK_Pos (0UL) /*!< Position of PSELSCK field. */
+#define SPI_PSEL_SCK_PSELSCK_Msk (0xFFFFFFFFUL << SPI_PSEL_SCK_PSELSCK_Pos) /*!< Bit mask of PSELSCK field. */
+#define SPI_PSEL_SCK_PSELSCK_Disconnected (0xFFFFFFFFUL) /*!< Disconnect */
+
+/* Register: SPI_PSEL_MOSI */
+/* Description: Pin select for MOSI */
+
+/* Bits 31..0 : Pin number configuration for SPI MOSI signal */
+#define SPI_PSEL_MOSI_PSELMOSI_Pos (0UL) /*!< Position of PSELMOSI field. */
+#define SPI_PSEL_MOSI_PSELMOSI_Msk (0xFFFFFFFFUL << SPI_PSEL_MOSI_PSELMOSI_Pos) /*!< Bit mask of PSELMOSI field. */
+#define SPI_PSEL_MOSI_PSELMOSI_Disconnected (0xFFFFFFFFUL) /*!< Disconnect */
+
+/* Register: SPI_PSEL_MISO */
+/* Description: Pin select for MISO */
+
+/* Bits 31..0 : Pin number configuration for SPI MISO signal */
+#define SPI_PSEL_MISO_PSELMISO_Pos (0UL) /*!< Position of PSELMISO field. */
+#define SPI_PSEL_MISO_PSELMISO_Msk (0xFFFFFFFFUL << SPI_PSEL_MISO_PSELMISO_Pos) /*!< Bit mask of PSELMISO field. */
+#define SPI_PSEL_MISO_PSELMISO_Disconnected (0xFFFFFFFFUL) /*!< Disconnect */
+
+/* Register: SPI_RXD */
+/* Description: RXD register */
+
+/* Bits 7..0 : RX data received. Double buffered */
+#define SPI_RXD_RXD_Pos (0UL) /*!< Position of RXD field. */
+#define SPI_RXD_RXD_Msk (0xFFUL << SPI_RXD_RXD_Pos) /*!< Bit mask of RXD field. */
+
+/* Register: SPI_TXD */
+/* Description: TXD register */
+
+/* Bits 7..0 : TX data to send. Double buffered */
+#define SPI_TXD_TXD_Pos (0UL) /*!< Position of TXD field. */
+#define SPI_TXD_TXD_Msk (0xFFUL << SPI_TXD_TXD_Pos) /*!< Bit mask of TXD field. */
+
+/* Register: SPI_FREQUENCY */
+/* Description: SPI frequency */
+
+/* Bits 31..0 : SPI master data rate */
+#define SPI_FREQUENCY_FREQUENCY_Pos (0UL) /*!< Position of FREQUENCY field. */
+#define SPI_FREQUENCY_FREQUENCY_Msk (0xFFFFFFFFUL << SPI_FREQUENCY_FREQUENCY_Pos) /*!< Bit mask of FREQUENCY field. */
+#define SPI_FREQUENCY_FREQUENCY_K125 (0x02000000UL) /*!< 125 kbps */
+#define SPI_FREQUENCY_FREQUENCY_K250 (0x04000000UL) /*!< 250 kbps */
+#define SPI_FREQUENCY_FREQUENCY_K500 (0x08000000UL) /*!< 500 kbps */
+#define SPI_FREQUENCY_FREQUENCY_M1 (0x10000000UL) /*!< 1 Mbps */
+#define SPI_FREQUENCY_FREQUENCY_M2 (0x20000000UL) /*!< 2 Mbps */
+#define SPI_FREQUENCY_FREQUENCY_M4 (0x40000000UL) /*!< 4 Mbps */
+#define SPI_FREQUENCY_FREQUENCY_M8 (0x80000000UL) /*!< 8 Mbps */
+
+/* Register: SPI_CONFIG */
+/* Description: Configuration register */
+
+/* Bit 2 : Serial clock (SCK) polarity */
+#define SPI_CONFIG_CPOL_Pos (2UL) /*!< Position of CPOL field. */
+#define SPI_CONFIG_CPOL_Msk (0x1UL << SPI_CONFIG_CPOL_Pos) /*!< Bit mask of CPOL field. */
+#define SPI_CONFIG_CPOL_ActiveHigh (0UL) /*!< Active high */
+#define SPI_CONFIG_CPOL_ActiveLow (1UL) /*!< Active low */
+
+/* Bit 1 : Serial clock (SCK) phase */
+#define SPI_CONFIG_CPHA_Pos (1UL) /*!< Position of CPHA field. */
+#define SPI_CONFIG_CPHA_Msk (0x1UL << SPI_CONFIG_CPHA_Pos) /*!< Bit mask of CPHA field. */
+#define SPI_CONFIG_CPHA_Leading (0UL) /*!< Sample on leading edge of clock, shift serial data on trailing edge */
+#define SPI_CONFIG_CPHA_Trailing (1UL) /*!< Sample on trailing edge of clock, shift serial data on leading edge */
+
+/* Bit 0 : Bit order */
+#define SPI_CONFIG_ORDER_Pos (0UL) /*!< Position of ORDER field. */
+#define SPI_CONFIG_ORDER_Msk (0x1UL << SPI_CONFIG_ORDER_Pos) /*!< Bit mask of ORDER field. */
+#define SPI_CONFIG_ORDER_MsbFirst (0UL) /*!< Most significant bit shifted out first */
+#define SPI_CONFIG_ORDER_LsbFirst (1UL) /*!< Least significant bit shifted out first */
+
+
+/* Peripheral: SPIM */
+/* Description: Serial Peripheral Interface Master with EasyDMA 0 */
+
+/* Register: SPIM_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 17 : Shortcut between END event and START task */
+#define SPIM_SHORTS_END_START_Pos (17UL) /*!< Position of END_START field. */
+#define SPIM_SHORTS_END_START_Msk (0x1UL << SPIM_SHORTS_END_START_Pos) /*!< Bit mask of END_START field. */
+#define SPIM_SHORTS_END_START_Disabled (0UL) /*!< Disable shortcut */
+#define SPIM_SHORTS_END_START_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: SPIM_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 19 : Write '1' to Enable interrupt for STARTED event */
+#define SPIM_INTENSET_STARTED_Pos (19UL) /*!< Position of STARTED field. */
+#define SPIM_INTENSET_STARTED_Msk (0x1UL << SPIM_INTENSET_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define SPIM_INTENSET_STARTED_Disabled (0UL) /*!< Read: Disabled */
+#define SPIM_INTENSET_STARTED_Enabled (1UL) /*!< Read: Enabled */
+#define SPIM_INTENSET_STARTED_Set (1UL) /*!< Enable */
+
+/* Bit 8 : Write '1' to Enable interrupt for ENDTX event */
+#define SPIM_INTENSET_ENDTX_Pos (8UL) /*!< Position of ENDTX field. */
+#define SPIM_INTENSET_ENDTX_Msk (0x1UL << SPIM_INTENSET_ENDTX_Pos) /*!< Bit mask of ENDTX field. */
+#define SPIM_INTENSET_ENDTX_Disabled (0UL) /*!< Read: Disabled */
+#define SPIM_INTENSET_ENDTX_Enabled (1UL) /*!< Read: Enabled */
+#define SPIM_INTENSET_ENDTX_Set (1UL) /*!< Enable */
+
+/* Bit 6 : Write '1' to Enable interrupt for END event */
+#define SPIM_INTENSET_END_Pos (6UL) /*!< Position of END field. */
+#define SPIM_INTENSET_END_Msk (0x1UL << SPIM_INTENSET_END_Pos) /*!< Bit mask of END field. */
+#define SPIM_INTENSET_END_Disabled (0UL) /*!< Read: Disabled */
+#define SPIM_INTENSET_END_Enabled (1UL) /*!< Read: Enabled */
+#define SPIM_INTENSET_END_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable interrupt for ENDRX event */
+#define SPIM_INTENSET_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define SPIM_INTENSET_ENDRX_Msk (0x1UL << SPIM_INTENSET_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define SPIM_INTENSET_ENDRX_Disabled (0UL) /*!< Read: Disabled */
+#define SPIM_INTENSET_ENDRX_Enabled (1UL) /*!< Read: Enabled */
+#define SPIM_INTENSET_ENDRX_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for STOPPED event */
+#define SPIM_INTENSET_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define SPIM_INTENSET_STOPPED_Msk (0x1UL << SPIM_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define SPIM_INTENSET_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define SPIM_INTENSET_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define SPIM_INTENSET_STOPPED_Set (1UL) /*!< Enable */
+
+/* Register: SPIM_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 19 : Write '1' to Disable interrupt for STARTED event */
+#define SPIM_INTENCLR_STARTED_Pos (19UL) /*!< Position of STARTED field. */
+#define SPIM_INTENCLR_STARTED_Msk (0x1UL << SPIM_INTENCLR_STARTED_Pos) /*!< Bit mask of STARTED field. */
+#define SPIM_INTENCLR_STARTED_Disabled (0UL) /*!< Read: Disabled */
+#define SPIM_INTENCLR_STARTED_Enabled (1UL) /*!< Read: Enabled */
+#define SPIM_INTENCLR_STARTED_Clear (1UL) /*!< Disable */
+
+/* Bit 8 : Write '1' to Disable interrupt for ENDTX event */
+#define SPIM_INTENCLR_ENDTX_Pos (8UL) /*!< Position of ENDTX field. */
+#define SPIM_INTENCLR_ENDTX_Msk (0x1UL << SPIM_INTENCLR_ENDTX_Pos) /*!< Bit mask of ENDTX field. */
+#define SPIM_INTENCLR_ENDTX_Disabled (0UL) /*!< Read: Disabled */
+#define SPIM_INTENCLR_ENDTX_Enabled (1UL) /*!< Read: Enabled */
+#define SPIM_INTENCLR_ENDTX_Clear (1UL) /*!< Disable */
+
+/* Bit 6 : Write '1' to Disable interrupt for END event */
+#define SPIM_INTENCLR_END_Pos (6UL) /*!< Position of END field. */
+#define SPIM_INTENCLR_END_Msk (0x1UL << SPIM_INTENCLR_END_Pos) /*!< Bit mask of END field. */
+#define SPIM_INTENCLR_END_Disabled (0UL) /*!< Read: Disabled */
+#define SPIM_INTENCLR_END_Enabled (1UL) /*!< Read: Enabled */
+#define SPIM_INTENCLR_END_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable interrupt for ENDRX event */
+#define SPIM_INTENCLR_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define SPIM_INTENCLR_ENDRX_Msk (0x1UL << SPIM_INTENCLR_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define SPIM_INTENCLR_ENDRX_Disabled (0UL) /*!< Read: Disabled */
+#define SPIM_INTENCLR_ENDRX_Enabled (1UL) /*!< Read: Enabled */
+#define SPIM_INTENCLR_ENDRX_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for STOPPED event */
+#define SPIM_INTENCLR_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define SPIM_INTENCLR_STOPPED_Msk (0x1UL << SPIM_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define SPIM_INTENCLR_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define SPIM_INTENCLR_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define SPIM_INTENCLR_STOPPED_Clear (1UL) /*!< Disable */
+
+/* Register: SPIM_ENABLE */
+/* Description: Enable SPIM */
+
+/* Bits 3..0 : Enable or disable SPIM */
+#define SPIM_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define SPIM_ENABLE_ENABLE_Msk (0xFUL << SPIM_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define SPIM_ENABLE_ENABLE_Disabled (0UL) /*!< Disable SPIM */
+#define SPIM_ENABLE_ENABLE_Enabled (7UL) /*!< Enable SPIM */
+
+/* Register: SPIM_PSEL_SCK */
+/* Description: Pin select for SCK */
+
+/* Bit 31 : Connection */
+#define SPIM_PSEL_SCK_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define SPIM_PSEL_SCK_CONNECT_Msk (0x1UL << SPIM_PSEL_SCK_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define SPIM_PSEL_SCK_CONNECT_Connected (0UL) /*!< Connect */
+#define SPIM_PSEL_SCK_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define SPIM_PSEL_SCK_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define SPIM_PSEL_SCK_PIN_Msk (0x1FUL << SPIM_PSEL_SCK_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: SPIM_PSEL_MOSI */
+/* Description: Pin select for MOSI signal */
+
+/* Bit 31 : Connection */
+#define SPIM_PSEL_MOSI_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define SPIM_PSEL_MOSI_CONNECT_Msk (0x1UL << SPIM_PSEL_MOSI_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define SPIM_PSEL_MOSI_CONNECT_Connected (0UL) /*!< Connect */
+#define SPIM_PSEL_MOSI_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define SPIM_PSEL_MOSI_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define SPIM_PSEL_MOSI_PIN_Msk (0x1FUL << SPIM_PSEL_MOSI_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: SPIM_PSEL_MISO */
+/* Description: Pin select for MISO signal */
+
+/* Bit 31 : Connection */
+#define SPIM_PSEL_MISO_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define SPIM_PSEL_MISO_CONNECT_Msk (0x1UL << SPIM_PSEL_MISO_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define SPIM_PSEL_MISO_CONNECT_Connected (0UL) /*!< Connect */
+#define SPIM_PSEL_MISO_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define SPIM_PSEL_MISO_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define SPIM_PSEL_MISO_PIN_Msk (0x1FUL << SPIM_PSEL_MISO_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: SPIM_FREQUENCY */
+/* Description: SPI frequency */
+
+/* Bits 31..0 : SPI master data rate */
+#define SPIM_FREQUENCY_FREQUENCY_Pos (0UL) /*!< Position of FREQUENCY field. */
+#define SPIM_FREQUENCY_FREQUENCY_Msk (0xFFFFFFFFUL << SPIM_FREQUENCY_FREQUENCY_Pos) /*!< Bit mask of FREQUENCY field. */
+#define SPIM_FREQUENCY_FREQUENCY_K125 (0x02000000UL) /*!< 125 kbps */
+#define SPIM_FREQUENCY_FREQUENCY_K250 (0x04000000UL) /*!< 250 kbps */
+#define SPIM_FREQUENCY_FREQUENCY_K500 (0x08000000UL) /*!< 500 kbps */
+#define SPIM_FREQUENCY_FREQUENCY_M1 (0x10000000UL) /*!< 1 Mbps */
+#define SPIM_FREQUENCY_FREQUENCY_M2 (0x20000000UL) /*!< 2 Mbps */
+#define SPIM_FREQUENCY_FREQUENCY_M4 (0x40000000UL) /*!< 4 Mbps */
+#define SPIM_FREQUENCY_FREQUENCY_M8 (0x80000000UL) /*!< 8 Mbps */
+
+/* Register: SPIM_RXD_PTR */
+/* Description: Data pointer */
+
+/* Bits 31..0 : Data pointer */
+#define SPIM_RXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define SPIM_RXD_PTR_PTR_Msk (0xFFFFFFFFUL << SPIM_RXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: SPIM_RXD_MAXCNT */
+/* Description: Maximum number of bytes in receive buffer */
+
+/* Bits 7..0 : Maximum number of bytes in receive buffer */
+#define SPIM_RXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define SPIM_RXD_MAXCNT_MAXCNT_Msk (0xFFUL << SPIM_RXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: SPIM_RXD_AMOUNT */
+/* Description: Number of bytes transferred in the last transaction */
+
+/* Bits 7..0 : Number of bytes transferred in the last transaction */
+#define SPIM_RXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define SPIM_RXD_AMOUNT_AMOUNT_Msk (0xFFUL << SPIM_RXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: SPIM_RXD_LIST */
+/* Description: EasyDMA list type */
+
+/* Bits 2..0 : List type */
+#define SPIM_RXD_LIST_LIST_Pos (0UL) /*!< Position of LIST field. */
+#define SPIM_RXD_LIST_LIST_Msk (0x7UL << SPIM_RXD_LIST_LIST_Pos) /*!< Bit mask of LIST field. */
+#define SPIM_RXD_LIST_LIST_Disabled (0UL) /*!< Disable EasyDMA list */
+#define SPIM_RXD_LIST_LIST_ArrayList (1UL) /*!< Use array list */
+
+/* Register: SPIM_TXD_PTR */
+/* Description: Data pointer */
+
+/* Bits 31..0 : Data pointer */
+#define SPIM_TXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define SPIM_TXD_PTR_PTR_Msk (0xFFFFFFFFUL << SPIM_TXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: SPIM_TXD_MAXCNT */
+/* Description: Maximum number of bytes in transmit buffer */
+
+/* Bits 7..0 : Maximum number of bytes in transmit buffer */
+#define SPIM_TXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define SPIM_TXD_MAXCNT_MAXCNT_Msk (0xFFUL << SPIM_TXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: SPIM_TXD_AMOUNT */
+/* Description: Number of bytes transferred in the last transaction */
+
+/* Bits 7..0 : Number of bytes transferred in the last transaction */
+#define SPIM_TXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define SPIM_TXD_AMOUNT_AMOUNT_Msk (0xFFUL << SPIM_TXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: SPIM_TXD_LIST */
+/* Description: EasyDMA list type */
+
+/* Bits 2..0 : List type */
+#define SPIM_TXD_LIST_LIST_Pos (0UL) /*!< Position of LIST field. */
+#define SPIM_TXD_LIST_LIST_Msk (0x7UL << SPIM_TXD_LIST_LIST_Pos) /*!< Bit mask of LIST field. */
+#define SPIM_TXD_LIST_LIST_Disabled (0UL) /*!< Disable EasyDMA list */
+#define SPIM_TXD_LIST_LIST_ArrayList (1UL) /*!< Use array list */
+
+/* Register: SPIM_CONFIG */
+/* Description: Configuration register */
+
+/* Bit 2 : Serial clock (SCK) polarity */
+#define SPIM_CONFIG_CPOL_Pos (2UL) /*!< Position of CPOL field. */
+#define SPIM_CONFIG_CPOL_Msk (0x1UL << SPIM_CONFIG_CPOL_Pos) /*!< Bit mask of CPOL field. */
+#define SPIM_CONFIG_CPOL_ActiveHigh (0UL) /*!< Active high */
+#define SPIM_CONFIG_CPOL_ActiveLow (1UL) /*!< Active low */
+
+/* Bit 1 : Serial clock (SCK) phase */
+#define SPIM_CONFIG_CPHA_Pos (1UL) /*!< Position of CPHA field. */
+#define SPIM_CONFIG_CPHA_Msk (0x1UL << SPIM_CONFIG_CPHA_Pos) /*!< Bit mask of CPHA field. */
+#define SPIM_CONFIG_CPHA_Leading (0UL) /*!< Sample on leading edge of clock, shift serial data on trailing edge */
+#define SPIM_CONFIG_CPHA_Trailing (1UL) /*!< Sample on trailing edge of clock, shift serial data on leading edge */
+
+/* Bit 0 : Bit order */
+#define SPIM_CONFIG_ORDER_Pos (0UL) /*!< Position of ORDER field. */
+#define SPIM_CONFIG_ORDER_Msk (0x1UL << SPIM_CONFIG_ORDER_Pos) /*!< Bit mask of ORDER field. */
+#define SPIM_CONFIG_ORDER_MsbFirst (0UL) /*!< Most significant bit shifted out first */
+#define SPIM_CONFIG_ORDER_LsbFirst (1UL) /*!< Least significant bit shifted out first */
+
+/* Register: SPIM_ORC */
+/* Description: Over-read character. Character clocked out in case and over-read of the TXD buffer. */
+
+/* Bits 7..0 : Over-read character. Character clocked out in case and over-read of the TXD buffer. */
+#define SPIM_ORC_ORC_Pos (0UL) /*!< Position of ORC field. */
+#define SPIM_ORC_ORC_Msk (0xFFUL << SPIM_ORC_ORC_Pos) /*!< Bit mask of ORC field. */
+
+
+/* Peripheral: SPIS */
+/* Description: SPI Slave 0 */
+
+/* Register: SPIS_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 2 : Shortcut between END event and ACQUIRE task */
+#define SPIS_SHORTS_END_ACQUIRE_Pos (2UL) /*!< Position of END_ACQUIRE field. */
+#define SPIS_SHORTS_END_ACQUIRE_Msk (0x1UL << SPIS_SHORTS_END_ACQUIRE_Pos) /*!< Bit mask of END_ACQUIRE field. */
+#define SPIS_SHORTS_END_ACQUIRE_Disabled (0UL) /*!< Disable shortcut */
+#define SPIS_SHORTS_END_ACQUIRE_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: SPIS_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 10 : Write '1' to Enable interrupt for ACQUIRED event */
+#define SPIS_INTENSET_ACQUIRED_Pos (10UL) /*!< Position of ACQUIRED field. */
+#define SPIS_INTENSET_ACQUIRED_Msk (0x1UL << SPIS_INTENSET_ACQUIRED_Pos) /*!< Bit mask of ACQUIRED field. */
+#define SPIS_INTENSET_ACQUIRED_Disabled (0UL) /*!< Read: Disabled */
+#define SPIS_INTENSET_ACQUIRED_Enabled (1UL) /*!< Read: Enabled */
+#define SPIS_INTENSET_ACQUIRED_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable interrupt for ENDRX event */
+#define SPIS_INTENSET_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define SPIS_INTENSET_ENDRX_Msk (0x1UL << SPIS_INTENSET_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define SPIS_INTENSET_ENDRX_Disabled (0UL) /*!< Read: Disabled */
+#define SPIS_INTENSET_ENDRX_Enabled (1UL) /*!< Read: Enabled */
+#define SPIS_INTENSET_ENDRX_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for END event */
+#define SPIS_INTENSET_END_Pos (1UL) /*!< Position of END field. */
+#define SPIS_INTENSET_END_Msk (0x1UL << SPIS_INTENSET_END_Pos) /*!< Bit mask of END field. */
+#define SPIS_INTENSET_END_Disabled (0UL) /*!< Read: Disabled */
+#define SPIS_INTENSET_END_Enabled (1UL) /*!< Read: Enabled */
+#define SPIS_INTENSET_END_Set (1UL) /*!< Enable */
+
+/* Register: SPIS_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 10 : Write '1' to Disable interrupt for ACQUIRED event */
+#define SPIS_INTENCLR_ACQUIRED_Pos (10UL) /*!< Position of ACQUIRED field. */
+#define SPIS_INTENCLR_ACQUIRED_Msk (0x1UL << SPIS_INTENCLR_ACQUIRED_Pos) /*!< Bit mask of ACQUIRED field. */
+#define SPIS_INTENCLR_ACQUIRED_Disabled (0UL) /*!< Read: Disabled */
+#define SPIS_INTENCLR_ACQUIRED_Enabled (1UL) /*!< Read: Enabled */
+#define SPIS_INTENCLR_ACQUIRED_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable interrupt for ENDRX event */
+#define SPIS_INTENCLR_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define SPIS_INTENCLR_ENDRX_Msk (0x1UL << SPIS_INTENCLR_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define SPIS_INTENCLR_ENDRX_Disabled (0UL) /*!< Read: Disabled */
+#define SPIS_INTENCLR_ENDRX_Enabled (1UL) /*!< Read: Enabled */
+#define SPIS_INTENCLR_ENDRX_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for END event */
+#define SPIS_INTENCLR_END_Pos (1UL) /*!< Position of END field. */
+#define SPIS_INTENCLR_END_Msk (0x1UL << SPIS_INTENCLR_END_Pos) /*!< Bit mask of END field. */
+#define SPIS_INTENCLR_END_Disabled (0UL) /*!< Read: Disabled */
+#define SPIS_INTENCLR_END_Enabled (1UL) /*!< Read: Enabled */
+#define SPIS_INTENCLR_END_Clear (1UL) /*!< Disable */
+
+/* Register: SPIS_SEMSTAT */
+/* Description: Semaphore status register */
+
+/* Bits 1..0 : Semaphore status */
+#define SPIS_SEMSTAT_SEMSTAT_Pos (0UL) /*!< Position of SEMSTAT field. */
+#define SPIS_SEMSTAT_SEMSTAT_Msk (0x3UL << SPIS_SEMSTAT_SEMSTAT_Pos) /*!< Bit mask of SEMSTAT field. */
+#define SPIS_SEMSTAT_SEMSTAT_Free (0UL) /*!< Semaphore is free */
+#define SPIS_SEMSTAT_SEMSTAT_CPU (1UL) /*!< Semaphore is assigned to CPU */
+#define SPIS_SEMSTAT_SEMSTAT_SPIS (2UL) /*!< Semaphore is assigned to SPI slave */
+#define SPIS_SEMSTAT_SEMSTAT_CPUPending (3UL) /*!< Semaphore is assigned to SPI but a handover to the CPU is pending */
+
+/* Register: SPIS_STATUS */
+/* Description: Status from last transaction */
+
+/* Bit 1 : RX buffer overflow detected, and prevented */
+#define SPIS_STATUS_OVERFLOW_Pos (1UL) /*!< Position of OVERFLOW field. */
+#define SPIS_STATUS_OVERFLOW_Msk (0x1UL << SPIS_STATUS_OVERFLOW_Pos) /*!< Bit mask of OVERFLOW field. */
+#define SPIS_STATUS_OVERFLOW_NotPresent (0UL) /*!< Read: error not present */
+#define SPIS_STATUS_OVERFLOW_Present (1UL) /*!< Read: error present */
+#define SPIS_STATUS_OVERFLOW_Clear (1UL) /*!< Write: clear error on writing '1' */
+
+/* Bit 0 : TX buffer over-read detected, and prevented */
+#define SPIS_STATUS_OVERREAD_Pos (0UL) /*!< Position of OVERREAD field. */
+#define SPIS_STATUS_OVERREAD_Msk (0x1UL << SPIS_STATUS_OVERREAD_Pos) /*!< Bit mask of OVERREAD field. */
+#define SPIS_STATUS_OVERREAD_NotPresent (0UL) /*!< Read: error not present */
+#define SPIS_STATUS_OVERREAD_Present (1UL) /*!< Read: error present */
+#define SPIS_STATUS_OVERREAD_Clear (1UL) /*!< Write: clear error on writing '1' */
+
+/* Register: SPIS_ENABLE */
+/* Description: Enable SPI slave */
+
+/* Bits 3..0 : Enable or disable SPI slave */
+#define SPIS_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define SPIS_ENABLE_ENABLE_Msk (0xFUL << SPIS_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define SPIS_ENABLE_ENABLE_Disabled (0UL) /*!< Disable SPI slave */
+#define SPIS_ENABLE_ENABLE_Enabled (2UL) /*!< Enable SPI slave */
+
+/* Register: SPIS_PSEL_SCK */
+/* Description: Pin select for SCK */
+
+/* Bit 31 : Connection */
+#define SPIS_PSEL_SCK_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define SPIS_PSEL_SCK_CONNECT_Msk (0x1UL << SPIS_PSEL_SCK_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define SPIS_PSEL_SCK_CONNECT_Connected (0UL) /*!< Connect */
+#define SPIS_PSEL_SCK_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define SPIS_PSEL_SCK_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define SPIS_PSEL_SCK_PIN_Msk (0x1FUL << SPIS_PSEL_SCK_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: SPIS_PSEL_MISO */
+/* Description: Pin select for MISO signal */
+
+/* Bit 31 : Connection */
+#define SPIS_PSEL_MISO_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define SPIS_PSEL_MISO_CONNECT_Msk (0x1UL << SPIS_PSEL_MISO_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define SPIS_PSEL_MISO_CONNECT_Connected (0UL) /*!< Connect */
+#define SPIS_PSEL_MISO_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define SPIS_PSEL_MISO_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define SPIS_PSEL_MISO_PIN_Msk (0x1FUL << SPIS_PSEL_MISO_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: SPIS_PSEL_MOSI */
+/* Description: Pin select for MOSI signal */
+
+/* Bit 31 : Connection */
+#define SPIS_PSEL_MOSI_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define SPIS_PSEL_MOSI_CONNECT_Msk (0x1UL << SPIS_PSEL_MOSI_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define SPIS_PSEL_MOSI_CONNECT_Connected (0UL) /*!< Connect */
+#define SPIS_PSEL_MOSI_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define SPIS_PSEL_MOSI_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define SPIS_PSEL_MOSI_PIN_Msk (0x1FUL << SPIS_PSEL_MOSI_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: SPIS_PSEL_CSN */
+/* Description: Pin select for CSN signal */
+
+/* Bit 31 : Connection */
+#define SPIS_PSEL_CSN_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define SPIS_PSEL_CSN_CONNECT_Msk (0x1UL << SPIS_PSEL_CSN_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define SPIS_PSEL_CSN_CONNECT_Connected (0UL) /*!< Connect */
+#define SPIS_PSEL_CSN_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define SPIS_PSEL_CSN_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define SPIS_PSEL_CSN_PIN_Msk (0x1FUL << SPIS_PSEL_CSN_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: SPIS_RXD_PTR */
+/* Description: RXD data pointer */
+
+/* Bits 31..0 : RXD data pointer */
+#define SPIS_RXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define SPIS_RXD_PTR_PTR_Msk (0xFFFFFFFFUL << SPIS_RXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: SPIS_RXD_MAXCNT */
+/* Description: Maximum number of bytes in receive buffer */
+
+/* Bits 7..0 : Maximum number of bytes in receive buffer */
+#define SPIS_RXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define SPIS_RXD_MAXCNT_MAXCNT_Msk (0xFFUL << SPIS_RXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: SPIS_RXD_AMOUNT */
+/* Description: Number of bytes received in last granted transaction */
+
+/* Bits 7..0 : Number of bytes received in the last granted transaction */
+#define SPIS_RXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define SPIS_RXD_AMOUNT_AMOUNT_Msk (0xFFUL << SPIS_RXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: SPIS_TXD_PTR */
+/* Description: TXD data pointer */
+
+/* Bits 31..0 : TXD data pointer */
+#define SPIS_TXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define SPIS_TXD_PTR_PTR_Msk (0xFFFFFFFFUL << SPIS_TXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: SPIS_TXD_MAXCNT */
+/* Description: Maximum number of bytes in transmit buffer */
+
+/* Bits 7..0 : Maximum number of bytes in transmit buffer */
+#define SPIS_TXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define SPIS_TXD_MAXCNT_MAXCNT_Msk (0xFFUL << SPIS_TXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: SPIS_TXD_AMOUNT */
+/* Description: Number of bytes transmitted in last granted transaction */
+
+/* Bits 7..0 : Number of bytes transmitted in last granted transaction */
+#define SPIS_TXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define SPIS_TXD_AMOUNT_AMOUNT_Msk (0xFFUL << SPIS_TXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: SPIS_CONFIG */
+/* Description: Configuration register */
+
+/* Bit 2 : Serial clock (SCK) polarity */
+#define SPIS_CONFIG_CPOL_Pos (2UL) /*!< Position of CPOL field. */
+#define SPIS_CONFIG_CPOL_Msk (0x1UL << SPIS_CONFIG_CPOL_Pos) /*!< Bit mask of CPOL field. */
+#define SPIS_CONFIG_CPOL_ActiveHigh (0UL) /*!< Active high */
+#define SPIS_CONFIG_CPOL_ActiveLow (1UL) /*!< Active low */
+
+/* Bit 1 : Serial clock (SCK) phase */
+#define SPIS_CONFIG_CPHA_Pos (1UL) /*!< Position of CPHA field. */
+#define SPIS_CONFIG_CPHA_Msk (0x1UL << SPIS_CONFIG_CPHA_Pos) /*!< Bit mask of CPHA field. */
+#define SPIS_CONFIG_CPHA_Leading (0UL) /*!< Sample on leading edge of clock, shift serial data on trailing edge */
+#define SPIS_CONFIG_CPHA_Trailing (1UL) /*!< Sample on trailing edge of clock, shift serial data on leading edge */
+
+/* Bit 0 : Bit order */
+#define SPIS_CONFIG_ORDER_Pos (0UL) /*!< Position of ORDER field. */
+#define SPIS_CONFIG_ORDER_Msk (0x1UL << SPIS_CONFIG_ORDER_Pos) /*!< Bit mask of ORDER field. */
+#define SPIS_CONFIG_ORDER_MsbFirst (0UL) /*!< Most significant bit shifted out first */
+#define SPIS_CONFIG_ORDER_LsbFirst (1UL) /*!< Least significant bit shifted out first */
+
+/* Register: SPIS_DEF */
+/* Description: Default character. Character clocked out in case of an ignored transaction. */
+
+/* Bits 7..0 : Default character. Character clocked out in case of an ignored transaction. */
+#define SPIS_DEF_DEF_Pos (0UL) /*!< Position of DEF field. */
+#define SPIS_DEF_DEF_Msk (0xFFUL << SPIS_DEF_DEF_Pos) /*!< Bit mask of DEF field. */
+
+/* Register: SPIS_ORC */
+/* Description: Over-read character */
+
+/* Bits 7..0 : Over-read character. Character clocked out after an over-read of the transmit buffer. */
+#define SPIS_ORC_ORC_Pos (0UL) /*!< Position of ORC field. */
+#define SPIS_ORC_ORC_Msk (0xFFUL << SPIS_ORC_ORC_Pos) /*!< Bit mask of ORC field. */
+
+
+/* Peripheral: TEMP */
+/* Description: Temperature Sensor */
+
+/* Register: TEMP_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 0 : Write '1' to Enable interrupt for DATARDY event */
+#define TEMP_INTENSET_DATARDY_Pos (0UL) /*!< Position of DATARDY field. */
+#define TEMP_INTENSET_DATARDY_Msk (0x1UL << TEMP_INTENSET_DATARDY_Pos) /*!< Bit mask of DATARDY field. */
+#define TEMP_INTENSET_DATARDY_Disabled (0UL) /*!< Read: Disabled */
+#define TEMP_INTENSET_DATARDY_Enabled (1UL) /*!< Read: Enabled */
+#define TEMP_INTENSET_DATARDY_Set (1UL) /*!< Enable */
+
+/* Register: TEMP_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 0 : Write '1' to Disable interrupt for DATARDY event */
+#define TEMP_INTENCLR_DATARDY_Pos (0UL) /*!< Position of DATARDY field. */
+#define TEMP_INTENCLR_DATARDY_Msk (0x1UL << TEMP_INTENCLR_DATARDY_Pos) /*!< Bit mask of DATARDY field. */
+#define TEMP_INTENCLR_DATARDY_Disabled (0UL) /*!< Read: Disabled */
+#define TEMP_INTENCLR_DATARDY_Enabled (1UL) /*!< Read: Enabled */
+#define TEMP_INTENCLR_DATARDY_Clear (1UL) /*!< Disable */
+
+/* Register: TEMP_TEMP */
+/* Description: Temperature in degC (0.25deg steps) */
+
+/* Bits 31..0 : Temperature in degC (0.25deg steps) */
+#define TEMP_TEMP_TEMP_Pos (0UL) /*!< Position of TEMP field. */
+#define TEMP_TEMP_TEMP_Msk (0xFFFFFFFFUL << TEMP_TEMP_TEMP_Pos) /*!< Bit mask of TEMP field. */
+
+/* Register: TEMP_A0 */
+/* Description: Slope of 1st piece wise linear function */
+
+/* Bits 11..0 : Slope of 1st piece wise linear function */
+#define TEMP_A0_A0_Pos (0UL) /*!< Position of A0 field. */
+#define TEMP_A0_A0_Msk (0xFFFUL << TEMP_A0_A0_Pos) /*!< Bit mask of A0 field. */
+
+/* Register: TEMP_A1 */
+/* Description: Slope of 2nd piece wise linear function */
+
+/* Bits 11..0 : Slope of 2nd piece wise linear function */
+#define TEMP_A1_A1_Pos (0UL) /*!< Position of A1 field. */
+#define TEMP_A1_A1_Msk (0xFFFUL << TEMP_A1_A1_Pos) /*!< Bit mask of A1 field. */
+
+/* Register: TEMP_A2 */
+/* Description: Slope of 3rd piece wise linear function */
+
+/* Bits 11..0 : Slope of 3rd piece wise linear function */
+#define TEMP_A2_A2_Pos (0UL) /*!< Position of A2 field. */
+#define TEMP_A2_A2_Msk (0xFFFUL << TEMP_A2_A2_Pos) /*!< Bit mask of A2 field. */
+
+/* Register: TEMP_A3 */
+/* Description: Slope of 4th piece wise linear function */
+
+/* Bits 11..0 : Slope of 4th piece wise linear function */
+#define TEMP_A3_A3_Pos (0UL) /*!< Position of A3 field. */
+#define TEMP_A3_A3_Msk (0xFFFUL << TEMP_A3_A3_Pos) /*!< Bit mask of A3 field. */
+
+/* Register: TEMP_A4 */
+/* Description: Slope of 5th piece wise linear function */
+
+/* Bits 11..0 : Slope of 5th piece wise linear function */
+#define TEMP_A4_A4_Pos (0UL) /*!< Position of A4 field. */
+#define TEMP_A4_A4_Msk (0xFFFUL << TEMP_A4_A4_Pos) /*!< Bit mask of A4 field. */
+
+/* Register: TEMP_A5 */
+/* Description: Slope of 6th piece wise linear function */
+
+/* Bits 11..0 : Slope of 6th piece wise linear function */
+#define TEMP_A5_A5_Pos (0UL) /*!< Position of A5 field. */
+#define TEMP_A5_A5_Msk (0xFFFUL << TEMP_A5_A5_Pos) /*!< Bit mask of A5 field. */
+
+/* Register: TEMP_B0 */
+/* Description: y-intercept of 1st piece wise linear function */
+
+/* Bits 13..0 : y-intercept of 1st piece wise linear function */
+#define TEMP_B0_B0_Pos (0UL) /*!< Position of B0 field. */
+#define TEMP_B0_B0_Msk (0x3FFFUL << TEMP_B0_B0_Pos) /*!< Bit mask of B0 field. */
+
+/* Register: TEMP_B1 */
+/* Description: y-intercept of 2nd piece wise linear function */
+
+/* Bits 13..0 : y-intercept of 2nd piece wise linear function */
+#define TEMP_B1_B1_Pos (0UL) /*!< Position of B1 field. */
+#define TEMP_B1_B1_Msk (0x3FFFUL << TEMP_B1_B1_Pos) /*!< Bit mask of B1 field. */
+
+/* Register: TEMP_B2 */
+/* Description: y-intercept of 3rd piece wise linear function */
+
+/* Bits 13..0 : y-intercept of 3rd piece wise linear function */
+#define TEMP_B2_B2_Pos (0UL) /*!< Position of B2 field. */
+#define TEMP_B2_B2_Msk (0x3FFFUL << TEMP_B2_B2_Pos) /*!< Bit mask of B2 field. */
+
+/* Register: TEMP_B3 */
+/* Description: y-intercept of 4th piece wise linear function */
+
+/* Bits 13..0 : y-intercept of 4th piece wise linear function */
+#define TEMP_B3_B3_Pos (0UL) /*!< Position of B3 field. */
+#define TEMP_B3_B3_Msk (0x3FFFUL << TEMP_B3_B3_Pos) /*!< Bit mask of B3 field. */
+
+/* Register: TEMP_B4 */
+/* Description: y-intercept of 5th piece wise linear function */
+
+/* Bits 13..0 : y-intercept of 5th piece wise linear function */
+#define TEMP_B4_B4_Pos (0UL) /*!< Position of B4 field. */
+#define TEMP_B4_B4_Msk (0x3FFFUL << TEMP_B4_B4_Pos) /*!< Bit mask of B4 field. */
+
+/* Register: TEMP_B5 */
+/* Description: y-intercept of 6th piece wise linear function */
+
+/* Bits 13..0 : y-intercept of 6th piece wise linear function */
+#define TEMP_B5_B5_Pos (0UL) /*!< Position of B5 field. */
+#define TEMP_B5_B5_Msk (0x3FFFUL << TEMP_B5_B5_Pos) /*!< Bit mask of B5 field. */
+
+/* Register: TEMP_T0 */
+/* Description: End point of 1st piece wise linear function */
+
+/* Bits 7..0 : End point of 1st piece wise linear function */
+#define TEMP_T0_T0_Pos (0UL) /*!< Position of T0 field. */
+#define TEMP_T0_T0_Msk (0xFFUL << TEMP_T0_T0_Pos) /*!< Bit mask of T0 field. */
+
+/* Register: TEMP_T1 */
+/* Description: End point of 2nd piece wise linear function */
+
+/* Bits 7..0 : End point of 2nd piece wise linear function */
+#define TEMP_T1_T1_Pos (0UL) /*!< Position of T1 field. */
+#define TEMP_T1_T1_Msk (0xFFUL << TEMP_T1_T1_Pos) /*!< Bit mask of T1 field. */
+
+/* Register: TEMP_T2 */
+/* Description: End point of 3rd piece wise linear function */
+
+/* Bits 7..0 : End point of 3rd piece wise linear function */
+#define TEMP_T2_T2_Pos (0UL) /*!< Position of T2 field. */
+#define TEMP_T2_T2_Msk (0xFFUL << TEMP_T2_T2_Pos) /*!< Bit mask of T2 field. */
+
+/* Register: TEMP_T3 */
+/* Description: End point of 4th piece wise linear function */
+
+/* Bits 7..0 : End point of 4th piece wise linear function */
+#define TEMP_T3_T3_Pos (0UL) /*!< Position of T3 field. */
+#define TEMP_T3_T3_Msk (0xFFUL << TEMP_T3_T3_Pos) /*!< Bit mask of T3 field. */
+
+/* Register: TEMP_T4 */
+/* Description: End point of 5th piece wise linear function */
+
+/* Bits 7..0 : End point of 5th piece wise linear function */
+#define TEMP_T4_T4_Pos (0UL) /*!< Position of T4 field. */
+#define TEMP_T4_T4_Msk (0xFFUL << TEMP_T4_T4_Pos) /*!< Bit mask of T4 field. */
+
+
+/* Peripheral: TIMER */
+/* Description: Timer/Counter 0 */
+
+/* Register: TIMER_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 13 : Shortcut between COMPARE[5] event and STOP task */
+#define TIMER_SHORTS_COMPARE5_STOP_Pos (13UL) /*!< Position of COMPARE5_STOP field. */
+#define TIMER_SHORTS_COMPARE5_STOP_Msk (0x1UL << TIMER_SHORTS_COMPARE5_STOP_Pos) /*!< Bit mask of COMPARE5_STOP field. */
+#define TIMER_SHORTS_COMPARE5_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE5_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 12 : Shortcut between COMPARE[4] event and STOP task */
+#define TIMER_SHORTS_COMPARE4_STOP_Pos (12UL) /*!< Position of COMPARE4_STOP field. */
+#define TIMER_SHORTS_COMPARE4_STOP_Msk (0x1UL << TIMER_SHORTS_COMPARE4_STOP_Pos) /*!< Bit mask of COMPARE4_STOP field. */
+#define TIMER_SHORTS_COMPARE4_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE4_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 11 : Shortcut between COMPARE[3] event and STOP task */
+#define TIMER_SHORTS_COMPARE3_STOP_Pos (11UL) /*!< Position of COMPARE3_STOP field. */
+#define TIMER_SHORTS_COMPARE3_STOP_Msk (0x1UL << TIMER_SHORTS_COMPARE3_STOP_Pos) /*!< Bit mask of COMPARE3_STOP field. */
+#define TIMER_SHORTS_COMPARE3_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE3_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 10 : Shortcut between COMPARE[2] event and STOP task */
+#define TIMER_SHORTS_COMPARE2_STOP_Pos (10UL) /*!< Position of COMPARE2_STOP field. */
+#define TIMER_SHORTS_COMPARE2_STOP_Msk (0x1UL << TIMER_SHORTS_COMPARE2_STOP_Pos) /*!< Bit mask of COMPARE2_STOP field. */
+#define TIMER_SHORTS_COMPARE2_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE2_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 9 : Shortcut between COMPARE[1] event and STOP task */
+#define TIMER_SHORTS_COMPARE1_STOP_Pos (9UL) /*!< Position of COMPARE1_STOP field. */
+#define TIMER_SHORTS_COMPARE1_STOP_Msk (0x1UL << TIMER_SHORTS_COMPARE1_STOP_Pos) /*!< Bit mask of COMPARE1_STOP field. */
+#define TIMER_SHORTS_COMPARE1_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE1_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 8 : Shortcut between COMPARE[0] event and STOP task */
+#define TIMER_SHORTS_COMPARE0_STOP_Pos (8UL) /*!< Position of COMPARE0_STOP field. */
+#define TIMER_SHORTS_COMPARE0_STOP_Msk (0x1UL << TIMER_SHORTS_COMPARE0_STOP_Pos) /*!< Bit mask of COMPARE0_STOP field. */
+#define TIMER_SHORTS_COMPARE0_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE0_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 5 : Shortcut between COMPARE[5] event and CLEAR task */
+#define TIMER_SHORTS_COMPARE5_CLEAR_Pos (5UL) /*!< Position of COMPARE5_CLEAR field. */
+#define TIMER_SHORTS_COMPARE5_CLEAR_Msk (0x1UL << TIMER_SHORTS_COMPARE5_CLEAR_Pos) /*!< Bit mask of COMPARE5_CLEAR field. */
+#define TIMER_SHORTS_COMPARE5_CLEAR_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE5_CLEAR_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 4 : Shortcut between COMPARE[4] event and CLEAR task */
+#define TIMER_SHORTS_COMPARE4_CLEAR_Pos (4UL) /*!< Position of COMPARE4_CLEAR field. */
+#define TIMER_SHORTS_COMPARE4_CLEAR_Msk (0x1UL << TIMER_SHORTS_COMPARE4_CLEAR_Pos) /*!< Bit mask of COMPARE4_CLEAR field. */
+#define TIMER_SHORTS_COMPARE4_CLEAR_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE4_CLEAR_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 3 : Shortcut between COMPARE[3] event and CLEAR task */
+#define TIMER_SHORTS_COMPARE3_CLEAR_Pos (3UL) /*!< Position of COMPARE3_CLEAR field. */
+#define TIMER_SHORTS_COMPARE3_CLEAR_Msk (0x1UL << TIMER_SHORTS_COMPARE3_CLEAR_Pos) /*!< Bit mask of COMPARE3_CLEAR field. */
+#define TIMER_SHORTS_COMPARE3_CLEAR_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE3_CLEAR_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 2 : Shortcut between COMPARE[2] event and CLEAR task */
+#define TIMER_SHORTS_COMPARE2_CLEAR_Pos (2UL) /*!< Position of COMPARE2_CLEAR field. */
+#define TIMER_SHORTS_COMPARE2_CLEAR_Msk (0x1UL << TIMER_SHORTS_COMPARE2_CLEAR_Pos) /*!< Bit mask of COMPARE2_CLEAR field. */
+#define TIMER_SHORTS_COMPARE2_CLEAR_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE2_CLEAR_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 1 : Shortcut between COMPARE[1] event and CLEAR task */
+#define TIMER_SHORTS_COMPARE1_CLEAR_Pos (1UL) /*!< Position of COMPARE1_CLEAR field. */
+#define TIMER_SHORTS_COMPARE1_CLEAR_Msk (0x1UL << TIMER_SHORTS_COMPARE1_CLEAR_Pos) /*!< Bit mask of COMPARE1_CLEAR field. */
+#define TIMER_SHORTS_COMPARE1_CLEAR_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE1_CLEAR_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 0 : Shortcut between COMPARE[0] event and CLEAR task */
+#define TIMER_SHORTS_COMPARE0_CLEAR_Pos (0UL) /*!< Position of COMPARE0_CLEAR field. */
+#define TIMER_SHORTS_COMPARE0_CLEAR_Msk (0x1UL << TIMER_SHORTS_COMPARE0_CLEAR_Pos) /*!< Bit mask of COMPARE0_CLEAR field. */
+#define TIMER_SHORTS_COMPARE0_CLEAR_Disabled (0UL) /*!< Disable shortcut */
+#define TIMER_SHORTS_COMPARE0_CLEAR_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: TIMER_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 21 : Write '1' to Enable interrupt for COMPARE[5] event */
+#define TIMER_INTENSET_COMPARE5_Pos (21UL) /*!< Position of COMPARE5 field. */
+#define TIMER_INTENSET_COMPARE5_Msk (0x1UL << TIMER_INTENSET_COMPARE5_Pos) /*!< Bit mask of COMPARE5 field. */
+#define TIMER_INTENSET_COMPARE5_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENSET_COMPARE5_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENSET_COMPARE5_Set (1UL) /*!< Enable */
+
+/* Bit 20 : Write '1' to Enable interrupt for COMPARE[4] event */
+#define TIMER_INTENSET_COMPARE4_Pos (20UL) /*!< Position of COMPARE4 field. */
+#define TIMER_INTENSET_COMPARE4_Msk (0x1UL << TIMER_INTENSET_COMPARE4_Pos) /*!< Bit mask of COMPARE4 field. */
+#define TIMER_INTENSET_COMPARE4_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENSET_COMPARE4_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENSET_COMPARE4_Set (1UL) /*!< Enable */
+
+/* Bit 19 : Write '1' to Enable interrupt for COMPARE[3] event */
+#define TIMER_INTENSET_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define TIMER_INTENSET_COMPARE3_Msk (0x1UL << TIMER_INTENSET_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define TIMER_INTENSET_COMPARE3_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENSET_COMPARE3_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENSET_COMPARE3_Set (1UL) /*!< Enable */
+
+/* Bit 18 : Write '1' to Enable interrupt for COMPARE[2] event */
+#define TIMER_INTENSET_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define TIMER_INTENSET_COMPARE2_Msk (0x1UL << TIMER_INTENSET_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define TIMER_INTENSET_COMPARE2_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENSET_COMPARE2_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENSET_COMPARE2_Set (1UL) /*!< Enable */
+
+/* Bit 17 : Write '1' to Enable interrupt for COMPARE[1] event */
+#define TIMER_INTENSET_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define TIMER_INTENSET_COMPARE1_Msk (0x1UL << TIMER_INTENSET_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define TIMER_INTENSET_COMPARE1_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENSET_COMPARE1_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENSET_COMPARE1_Set (1UL) /*!< Enable */
+
+/* Bit 16 : Write '1' to Enable interrupt for COMPARE[0] event */
+#define TIMER_INTENSET_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define TIMER_INTENSET_COMPARE0_Msk (0x1UL << TIMER_INTENSET_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define TIMER_INTENSET_COMPARE0_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENSET_COMPARE0_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENSET_COMPARE0_Set (1UL) /*!< Enable */
+
+/* Register: TIMER_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 21 : Write '1' to Disable interrupt for COMPARE[5] event */
+#define TIMER_INTENCLR_COMPARE5_Pos (21UL) /*!< Position of COMPARE5 field. */
+#define TIMER_INTENCLR_COMPARE5_Msk (0x1UL << TIMER_INTENCLR_COMPARE5_Pos) /*!< Bit mask of COMPARE5 field. */
+#define TIMER_INTENCLR_COMPARE5_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENCLR_COMPARE5_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENCLR_COMPARE5_Clear (1UL) /*!< Disable */
+
+/* Bit 20 : Write '1' to Disable interrupt for COMPARE[4] event */
+#define TIMER_INTENCLR_COMPARE4_Pos (20UL) /*!< Position of COMPARE4 field. */
+#define TIMER_INTENCLR_COMPARE4_Msk (0x1UL << TIMER_INTENCLR_COMPARE4_Pos) /*!< Bit mask of COMPARE4 field. */
+#define TIMER_INTENCLR_COMPARE4_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENCLR_COMPARE4_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENCLR_COMPARE4_Clear (1UL) /*!< Disable */
+
+/* Bit 19 : Write '1' to Disable interrupt for COMPARE[3] event */
+#define TIMER_INTENCLR_COMPARE3_Pos (19UL) /*!< Position of COMPARE3 field. */
+#define TIMER_INTENCLR_COMPARE3_Msk (0x1UL << TIMER_INTENCLR_COMPARE3_Pos) /*!< Bit mask of COMPARE3 field. */
+#define TIMER_INTENCLR_COMPARE3_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENCLR_COMPARE3_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENCLR_COMPARE3_Clear (1UL) /*!< Disable */
+
+/* Bit 18 : Write '1' to Disable interrupt for COMPARE[2] event */
+#define TIMER_INTENCLR_COMPARE2_Pos (18UL) /*!< Position of COMPARE2 field. */
+#define TIMER_INTENCLR_COMPARE2_Msk (0x1UL << TIMER_INTENCLR_COMPARE2_Pos) /*!< Bit mask of COMPARE2 field. */
+#define TIMER_INTENCLR_COMPARE2_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENCLR_COMPARE2_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENCLR_COMPARE2_Clear (1UL) /*!< Disable */
+
+/* Bit 17 : Write '1' to Disable interrupt for COMPARE[1] event */
+#define TIMER_INTENCLR_COMPARE1_Pos (17UL) /*!< Position of COMPARE1 field. */
+#define TIMER_INTENCLR_COMPARE1_Msk (0x1UL << TIMER_INTENCLR_COMPARE1_Pos) /*!< Bit mask of COMPARE1 field. */
+#define TIMER_INTENCLR_COMPARE1_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENCLR_COMPARE1_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENCLR_COMPARE1_Clear (1UL) /*!< Disable */
+
+/* Bit 16 : Write '1' to Disable interrupt for COMPARE[0] event */
+#define TIMER_INTENCLR_COMPARE0_Pos (16UL) /*!< Position of COMPARE0 field. */
+#define TIMER_INTENCLR_COMPARE0_Msk (0x1UL << TIMER_INTENCLR_COMPARE0_Pos) /*!< Bit mask of COMPARE0 field. */
+#define TIMER_INTENCLR_COMPARE0_Disabled (0UL) /*!< Read: Disabled */
+#define TIMER_INTENCLR_COMPARE0_Enabled (1UL) /*!< Read: Enabled */
+#define TIMER_INTENCLR_COMPARE0_Clear (1UL) /*!< Disable */
+
+/* Register: TIMER_MODE */
+/* Description: Timer mode selection */
+
+/* Bits 1..0 : Timer mode */
+#define TIMER_MODE_MODE_Pos (0UL) /*!< Position of MODE field. */
+#define TIMER_MODE_MODE_Msk (0x3UL << TIMER_MODE_MODE_Pos) /*!< Bit mask of MODE field. */
+#define TIMER_MODE_MODE_Timer (0UL) /*!< Select Timer mode */
+#define TIMER_MODE_MODE_Counter (1UL) /*!< Select Counter mode */
+#define TIMER_MODE_MODE_LowPowerCounter (2UL) /*!< Select Low Power Counter mode */
+
+/* Register: TIMER_BITMODE */
+/* Description: Configure the number of bits used by the TIMER */
+
+/* Bits 1..0 : Timer bit width */
+#define TIMER_BITMODE_BITMODE_Pos (0UL) /*!< Position of BITMODE field. */
+#define TIMER_BITMODE_BITMODE_Msk (0x3UL << TIMER_BITMODE_BITMODE_Pos) /*!< Bit mask of BITMODE field. */
+#define TIMER_BITMODE_BITMODE_16Bit (0UL) /*!< 16 bit timer bit width */
+#define TIMER_BITMODE_BITMODE_08Bit (1UL) /*!< 8 bit timer bit width */
+#define TIMER_BITMODE_BITMODE_24Bit (2UL) /*!< 24 bit timer bit width */
+#define TIMER_BITMODE_BITMODE_32Bit (3UL) /*!< 32 bit timer bit width */
+
+/* Register: TIMER_PRESCALER */
+/* Description: Timer prescaler register */
+
+/* Bits 3..0 : Prescaler value */
+#define TIMER_PRESCALER_PRESCALER_Pos (0UL) /*!< Position of PRESCALER field. */
+#define TIMER_PRESCALER_PRESCALER_Msk (0xFUL << TIMER_PRESCALER_PRESCALER_Pos) /*!< Bit mask of PRESCALER field. */
+
+/* Register: TIMER_CC */
+/* Description: Description collection[0]:  Capture/Compare register 0 */
+
+/* Bits 31..0 : Capture/Compare value */
+#define TIMER_CC_CC_Pos (0UL) /*!< Position of CC field. */
+#define TIMER_CC_CC_Msk (0xFFFFFFFFUL << TIMER_CC_CC_Pos) /*!< Bit mask of CC field. */
+
+
+/* Peripheral: TWI */
+/* Description: I2C compatible Two-Wire Interface 0 */
+
+/* Register: TWI_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 1 : Shortcut between BB event and STOP task */
+#define TWI_SHORTS_BB_STOP_Pos (1UL) /*!< Position of BB_STOP field. */
+#define TWI_SHORTS_BB_STOP_Msk (0x1UL << TWI_SHORTS_BB_STOP_Pos) /*!< Bit mask of BB_STOP field. */
+#define TWI_SHORTS_BB_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define TWI_SHORTS_BB_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 0 : Shortcut between BB event and SUSPEND task */
+#define TWI_SHORTS_BB_SUSPEND_Pos (0UL) /*!< Position of BB_SUSPEND field. */
+#define TWI_SHORTS_BB_SUSPEND_Msk (0x1UL << TWI_SHORTS_BB_SUSPEND_Pos) /*!< Bit mask of BB_SUSPEND field. */
+#define TWI_SHORTS_BB_SUSPEND_Disabled (0UL) /*!< Disable shortcut */
+#define TWI_SHORTS_BB_SUSPEND_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: TWI_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 18 : Write '1' to Enable interrupt for SUSPENDED event */
+#define TWI_INTENSET_SUSPENDED_Pos (18UL) /*!< Position of SUSPENDED field. */
+#define TWI_INTENSET_SUSPENDED_Msk (0x1UL << TWI_INTENSET_SUSPENDED_Pos) /*!< Bit mask of SUSPENDED field. */
+#define TWI_INTENSET_SUSPENDED_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENSET_SUSPENDED_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENSET_SUSPENDED_Set (1UL) /*!< Enable */
+
+/* Bit 14 : Write '1' to Enable interrupt for BB event */
+#define TWI_INTENSET_BB_Pos (14UL) /*!< Position of BB field. */
+#define TWI_INTENSET_BB_Msk (0x1UL << TWI_INTENSET_BB_Pos) /*!< Bit mask of BB field. */
+#define TWI_INTENSET_BB_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENSET_BB_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENSET_BB_Set (1UL) /*!< Enable */
+
+/* Bit 9 : Write '1' to Enable interrupt for ERROR event */
+#define TWI_INTENSET_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define TWI_INTENSET_ERROR_Msk (0x1UL << TWI_INTENSET_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define TWI_INTENSET_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENSET_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENSET_ERROR_Set (1UL) /*!< Enable */
+
+/* Bit 7 : Write '1' to Enable interrupt for TXDSENT event */
+#define TWI_INTENSET_TXDSENT_Pos (7UL) /*!< Position of TXDSENT field. */
+#define TWI_INTENSET_TXDSENT_Msk (0x1UL << TWI_INTENSET_TXDSENT_Pos) /*!< Bit mask of TXDSENT field. */
+#define TWI_INTENSET_TXDSENT_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENSET_TXDSENT_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENSET_TXDSENT_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for RXDREADY event */
+#define TWI_INTENSET_RXDREADY_Pos (2UL) /*!< Position of RXDREADY field. */
+#define TWI_INTENSET_RXDREADY_Msk (0x1UL << TWI_INTENSET_RXDREADY_Pos) /*!< Bit mask of RXDREADY field. */
+#define TWI_INTENSET_RXDREADY_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENSET_RXDREADY_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENSET_RXDREADY_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for STOPPED event */
+#define TWI_INTENSET_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define TWI_INTENSET_STOPPED_Msk (0x1UL << TWI_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define TWI_INTENSET_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENSET_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENSET_STOPPED_Set (1UL) /*!< Enable */
+
+/* Register: TWI_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 18 : Write '1' to Disable interrupt for SUSPENDED event */
+#define TWI_INTENCLR_SUSPENDED_Pos (18UL) /*!< Position of SUSPENDED field. */
+#define TWI_INTENCLR_SUSPENDED_Msk (0x1UL << TWI_INTENCLR_SUSPENDED_Pos) /*!< Bit mask of SUSPENDED field. */
+#define TWI_INTENCLR_SUSPENDED_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENCLR_SUSPENDED_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENCLR_SUSPENDED_Clear (1UL) /*!< Disable */
+
+/* Bit 14 : Write '1' to Disable interrupt for BB event */
+#define TWI_INTENCLR_BB_Pos (14UL) /*!< Position of BB field. */
+#define TWI_INTENCLR_BB_Msk (0x1UL << TWI_INTENCLR_BB_Pos) /*!< Bit mask of BB field. */
+#define TWI_INTENCLR_BB_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENCLR_BB_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENCLR_BB_Clear (1UL) /*!< Disable */
+
+/* Bit 9 : Write '1' to Disable interrupt for ERROR event */
+#define TWI_INTENCLR_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define TWI_INTENCLR_ERROR_Msk (0x1UL << TWI_INTENCLR_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define TWI_INTENCLR_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENCLR_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENCLR_ERROR_Clear (1UL) /*!< Disable */
+
+/* Bit 7 : Write '1' to Disable interrupt for TXDSENT event */
+#define TWI_INTENCLR_TXDSENT_Pos (7UL) /*!< Position of TXDSENT field. */
+#define TWI_INTENCLR_TXDSENT_Msk (0x1UL << TWI_INTENCLR_TXDSENT_Pos) /*!< Bit mask of TXDSENT field. */
+#define TWI_INTENCLR_TXDSENT_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENCLR_TXDSENT_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENCLR_TXDSENT_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for RXDREADY event */
+#define TWI_INTENCLR_RXDREADY_Pos (2UL) /*!< Position of RXDREADY field. */
+#define TWI_INTENCLR_RXDREADY_Msk (0x1UL << TWI_INTENCLR_RXDREADY_Pos) /*!< Bit mask of RXDREADY field. */
+#define TWI_INTENCLR_RXDREADY_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENCLR_RXDREADY_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENCLR_RXDREADY_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for STOPPED event */
+#define TWI_INTENCLR_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define TWI_INTENCLR_STOPPED_Msk (0x1UL << TWI_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define TWI_INTENCLR_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define TWI_INTENCLR_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define TWI_INTENCLR_STOPPED_Clear (1UL) /*!< Disable */
+
+/* Register: TWI_ERRORSRC */
+/* Description: Error source */
+
+/* Bit 2 : NACK received after sending a data byte (write '1' to clear) */
+#define TWI_ERRORSRC_DNACK_Pos (2UL) /*!< Position of DNACK field. */
+#define TWI_ERRORSRC_DNACK_Msk (0x1UL << TWI_ERRORSRC_DNACK_Pos) /*!< Bit mask of DNACK field. */
+#define TWI_ERRORSRC_DNACK_NotPresent (0UL) /*!< Read: error not present */
+#define TWI_ERRORSRC_DNACK_Present (1UL) /*!< Read: error present */
+
+/* Bit 1 : NACK received after sending the address (write '1' to clear) */
+#define TWI_ERRORSRC_ANACK_Pos (1UL) /*!< Position of ANACK field. */
+#define TWI_ERRORSRC_ANACK_Msk (0x1UL << TWI_ERRORSRC_ANACK_Pos) /*!< Bit mask of ANACK field. */
+#define TWI_ERRORSRC_ANACK_NotPresent (0UL) /*!< Read: error not present */
+#define TWI_ERRORSRC_ANACK_Present (1UL) /*!< Read: error present */
+
+/* Bit 0 : Overrun error */
+#define TWI_ERRORSRC_OVERRUN_Pos (0UL) /*!< Position of OVERRUN field. */
+#define TWI_ERRORSRC_OVERRUN_Msk (0x1UL << TWI_ERRORSRC_OVERRUN_Pos) /*!< Bit mask of OVERRUN field. */
+#define TWI_ERRORSRC_OVERRUN_NotPresent (0UL) /*!< Read: no overrun occured */
+#define TWI_ERRORSRC_OVERRUN_Present (1UL) /*!< Read: overrun occured */
+
+/* Register: TWI_ENABLE */
+/* Description: Enable TWI */
+
+/* Bits 3..0 : Enable or disable TWI */
+#define TWI_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define TWI_ENABLE_ENABLE_Msk (0xFUL << TWI_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define TWI_ENABLE_ENABLE_Disabled (0UL) /*!< Disable TWI */
+#define TWI_ENABLE_ENABLE_Enabled (5UL) /*!< Enable TWI */
+
+/* Register: TWI_PSELSCL */
+/* Description: Pin select for SCL */
+
+/* Bits 31..0 : Pin number configuration for TWI SCL signal */
+#define TWI_PSELSCL_PSELSCL_Pos (0UL) /*!< Position of PSELSCL field. */
+#define TWI_PSELSCL_PSELSCL_Msk (0xFFFFFFFFUL << TWI_PSELSCL_PSELSCL_Pos) /*!< Bit mask of PSELSCL field. */
+#define TWI_PSELSCL_PSELSCL_Disconnected (0xFFFFFFFFUL) /*!< Disconnect */
+
+/* Register: TWI_PSELSDA */
+/* Description: Pin select for SDA */
+
+/* Bits 31..0 : Pin number configuration for TWI SDA signal */
+#define TWI_PSELSDA_PSELSDA_Pos (0UL) /*!< Position of PSELSDA field. */
+#define TWI_PSELSDA_PSELSDA_Msk (0xFFFFFFFFUL << TWI_PSELSDA_PSELSDA_Pos) /*!< Bit mask of PSELSDA field. */
+#define TWI_PSELSDA_PSELSDA_Disconnected (0xFFFFFFFFUL) /*!< Disconnect */
+
+/* Register: TWI_RXD */
+/* Description: RXD register */
+
+/* Bits 7..0 : RXD register */
+#define TWI_RXD_RXD_Pos (0UL) /*!< Position of RXD field. */
+#define TWI_RXD_RXD_Msk (0xFFUL << TWI_RXD_RXD_Pos) /*!< Bit mask of RXD field. */
+
+/* Register: TWI_TXD */
+/* Description: TXD register */
+
+/* Bits 7..0 : TXD register */
+#define TWI_TXD_TXD_Pos (0UL) /*!< Position of TXD field. */
+#define TWI_TXD_TXD_Msk (0xFFUL << TWI_TXD_TXD_Pos) /*!< Bit mask of TXD field. */
+
+/* Register: TWI_FREQUENCY */
+/* Description: TWI frequency */
+
+/* Bits 31..0 : TWI master clock frequency */
+#define TWI_FREQUENCY_FREQUENCY_Pos (0UL) /*!< Position of FREQUENCY field. */
+#define TWI_FREQUENCY_FREQUENCY_Msk (0xFFFFFFFFUL << TWI_FREQUENCY_FREQUENCY_Pos) /*!< Bit mask of FREQUENCY field. */
+#define TWI_FREQUENCY_FREQUENCY_K100 (0x01980000UL) /*!< 100 kbps */
+#define TWI_FREQUENCY_FREQUENCY_K250 (0x04000000UL) /*!< 250 kbps */
+#define TWI_FREQUENCY_FREQUENCY_K400 (0x06680000UL) /*!< 400 kbps (actual rate 410.256 kbps) */
+
+/* Register: TWI_ADDRESS */
+/* Description: Address used in the TWI transfer */
+
+/* Bits 6..0 : Address used in the TWI transfer */
+#define TWI_ADDRESS_ADDRESS_Pos (0UL) /*!< Position of ADDRESS field. */
+#define TWI_ADDRESS_ADDRESS_Msk (0x7FUL << TWI_ADDRESS_ADDRESS_Pos) /*!< Bit mask of ADDRESS field. */
+
+
+/* Peripheral: TWIM */
+/* Description: I2C compatible Two-Wire Master Interface with EasyDMA 0 */
+
+/* Register: TWIM_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 12 : Shortcut between LASTRX event and STOP task */
+#define TWIM_SHORTS_LASTRX_STOP_Pos (12UL) /*!< Position of LASTRX_STOP field. */
+#define TWIM_SHORTS_LASTRX_STOP_Msk (0x1UL << TWIM_SHORTS_LASTRX_STOP_Pos) /*!< Bit mask of LASTRX_STOP field. */
+#define TWIM_SHORTS_LASTRX_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define TWIM_SHORTS_LASTRX_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 10 : Shortcut between LASTRX event and STARTTX task */
+#define TWIM_SHORTS_LASTRX_STARTTX_Pos (10UL) /*!< Position of LASTRX_STARTTX field. */
+#define TWIM_SHORTS_LASTRX_STARTTX_Msk (0x1UL << TWIM_SHORTS_LASTRX_STARTTX_Pos) /*!< Bit mask of LASTRX_STARTTX field. */
+#define TWIM_SHORTS_LASTRX_STARTTX_Disabled (0UL) /*!< Disable shortcut */
+#define TWIM_SHORTS_LASTRX_STARTTX_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 9 : Shortcut between LASTTX event and STOP task */
+#define TWIM_SHORTS_LASTTX_STOP_Pos (9UL) /*!< Position of LASTTX_STOP field. */
+#define TWIM_SHORTS_LASTTX_STOP_Msk (0x1UL << TWIM_SHORTS_LASTTX_STOP_Pos) /*!< Bit mask of LASTTX_STOP field. */
+#define TWIM_SHORTS_LASTTX_STOP_Disabled (0UL) /*!< Disable shortcut */
+#define TWIM_SHORTS_LASTTX_STOP_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 8 : Shortcut between LASTTX event and SUSPEND task */
+#define TWIM_SHORTS_LASTTX_SUSPEND_Pos (8UL) /*!< Position of LASTTX_SUSPEND field. */
+#define TWIM_SHORTS_LASTTX_SUSPEND_Msk (0x1UL << TWIM_SHORTS_LASTTX_SUSPEND_Pos) /*!< Bit mask of LASTTX_SUSPEND field. */
+#define TWIM_SHORTS_LASTTX_SUSPEND_Disabled (0UL) /*!< Disable shortcut */
+#define TWIM_SHORTS_LASTTX_SUSPEND_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 7 : Shortcut between LASTTX event and STARTRX task */
+#define TWIM_SHORTS_LASTTX_STARTRX_Pos (7UL) /*!< Position of LASTTX_STARTRX field. */
+#define TWIM_SHORTS_LASTTX_STARTRX_Msk (0x1UL << TWIM_SHORTS_LASTTX_STARTRX_Pos) /*!< Bit mask of LASTTX_STARTRX field. */
+#define TWIM_SHORTS_LASTTX_STARTRX_Disabled (0UL) /*!< Disable shortcut */
+#define TWIM_SHORTS_LASTTX_STARTRX_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: TWIM_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 24 : Enable or disable interrupt for LASTTX event */
+#define TWIM_INTEN_LASTTX_Pos (24UL) /*!< Position of LASTTX field. */
+#define TWIM_INTEN_LASTTX_Msk (0x1UL << TWIM_INTEN_LASTTX_Pos) /*!< Bit mask of LASTTX field. */
+#define TWIM_INTEN_LASTTX_Disabled (0UL) /*!< Disable */
+#define TWIM_INTEN_LASTTX_Enabled (1UL) /*!< Enable */
+
+/* Bit 23 : Enable or disable interrupt for LASTRX event */
+#define TWIM_INTEN_LASTRX_Pos (23UL) /*!< Position of LASTRX field. */
+#define TWIM_INTEN_LASTRX_Msk (0x1UL << TWIM_INTEN_LASTRX_Pos) /*!< Bit mask of LASTRX field. */
+#define TWIM_INTEN_LASTRX_Disabled (0UL) /*!< Disable */
+#define TWIM_INTEN_LASTRX_Enabled (1UL) /*!< Enable */
+
+/* Bit 20 : Enable or disable interrupt for TXSTARTED event */
+#define TWIM_INTEN_TXSTARTED_Pos (20UL) /*!< Position of TXSTARTED field. */
+#define TWIM_INTEN_TXSTARTED_Msk (0x1UL << TWIM_INTEN_TXSTARTED_Pos) /*!< Bit mask of TXSTARTED field. */
+#define TWIM_INTEN_TXSTARTED_Disabled (0UL) /*!< Disable */
+#define TWIM_INTEN_TXSTARTED_Enabled (1UL) /*!< Enable */
+
+/* Bit 19 : Enable or disable interrupt for RXSTARTED event */
+#define TWIM_INTEN_RXSTARTED_Pos (19UL) /*!< Position of RXSTARTED field. */
+#define TWIM_INTEN_RXSTARTED_Msk (0x1UL << TWIM_INTEN_RXSTARTED_Pos) /*!< Bit mask of RXSTARTED field. */
+#define TWIM_INTEN_RXSTARTED_Disabled (0UL) /*!< Disable */
+#define TWIM_INTEN_RXSTARTED_Enabled (1UL) /*!< Enable */
+
+/* Bit 9 : Enable or disable interrupt for ERROR event */
+#define TWIM_INTEN_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define TWIM_INTEN_ERROR_Msk (0x1UL << TWIM_INTEN_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define TWIM_INTEN_ERROR_Disabled (0UL) /*!< Disable */
+#define TWIM_INTEN_ERROR_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for STOPPED event */
+#define TWIM_INTEN_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define TWIM_INTEN_STOPPED_Msk (0x1UL << TWIM_INTEN_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define TWIM_INTEN_STOPPED_Disabled (0UL) /*!< Disable */
+#define TWIM_INTEN_STOPPED_Enabled (1UL) /*!< Enable */
+
+/* Register: TWIM_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 24 : Write '1' to Enable interrupt for LASTTX event */
+#define TWIM_INTENSET_LASTTX_Pos (24UL) /*!< Position of LASTTX field. */
+#define TWIM_INTENSET_LASTTX_Msk (0x1UL << TWIM_INTENSET_LASTTX_Pos) /*!< Bit mask of LASTTX field. */
+#define TWIM_INTENSET_LASTTX_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENSET_LASTTX_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENSET_LASTTX_Set (1UL) /*!< Enable */
+
+/* Bit 23 : Write '1' to Enable interrupt for LASTRX event */
+#define TWIM_INTENSET_LASTRX_Pos (23UL) /*!< Position of LASTRX field. */
+#define TWIM_INTENSET_LASTRX_Msk (0x1UL << TWIM_INTENSET_LASTRX_Pos) /*!< Bit mask of LASTRX field. */
+#define TWIM_INTENSET_LASTRX_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENSET_LASTRX_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENSET_LASTRX_Set (1UL) /*!< Enable */
+
+/* Bit 20 : Write '1' to Enable interrupt for TXSTARTED event */
+#define TWIM_INTENSET_TXSTARTED_Pos (20UL) /*!< Position of TXSTARTED field. */
+#define TWIM_INTENSET_TXSTARTED_Msk (0x1UL << TWIM_INTENSET_TXSTARTED_Pos) /*!< Bit mask of TXSTARTED field. */
+#define TWIM_INTENSET_TXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENSET_TXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENSET_TXSTARTED_Set (1UL) /*!< Enable */
+
+/* Bit 19 : Write '1' to Enable interrupt for RXSTARTED event */
+#define TWIM_INTENSET_RXSTARTED_Pos (19UL) /*!< Position of RXSTARTED field. */
+#define TWIM_INTENSET_RXSTARTED_Msk (0x1UL << TWIM_INTENSET_RXSTARTED_Pos) /*!< Bit mask of RXSTARTED field. */
+#define TWIM_INTENSET_RXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENSET_RXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENSET_RXSTARTED_Set (1UL) /*!< Enable */
+
+/* Bit 9 : Write '1' to Enable interrupt for ERROR event */
+#define TWIM_INTENSET_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define TWIM_INTENSET_ERROR_Msk (0x1UL << TWIM_INTENSET_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define TWIM_INTENSET_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENSET_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENSET_ERROR_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for STOPPED event */
+#define TWIM_INTENSET_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define TWIM_INTENSET_STOPPED_Msk (0x1UL << TWIM_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define TWIM_INTENSET_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENSET_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENSET_STOPPED_Set (1UL) /*!< Enable */
+
+/* Register: TWIM_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 24 : Write '1' to Disable interrupt for LASTTX event */
+#define TWIM_INTENCLR_LASTTX_Pos (24UL) /*!< Position of LASTTX field. */
+#define TWIM_INTENCLR_LASTTX_Msk (0x1UL << TWIM_INTENCLR_LASTTX_Pos) /*!< Bit mask of LASTTX field. */
+#define TWIM_INTENCLR_LASTTX_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENCLR_LASTTX_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENCLR_LASTTX_Clear (1UL) /*!< Disable */
+
+/* Bit 23 : Write '1' to Disable interrupt for LASTRX event */
+#define TWIM_INTENCLR_LASTRX_Pos (23UL) /*!< Position of LASTRX field. */
+#define TWIM_INTENCLR_LASTRX_Msk (0x1UL << TWIM_INTENCLR_LASTRX_Pos) /*!< Bit mask of LASTRX field. */
+#define TWIM_INTENCLR_LASTRX_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENCLR_LASTRX_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENCLR_LASTRX_Clear (1UL) /*!< Disable */
+
+/* Bit 20 : Write '1' to Disable interrupt for TXSTARTED event */
+#define TWIM_INTENCLR_TXSTARTED_Pos (20UL) /*!< Position of TXSTARTED field. */
+#define TWIM_INTENCLR_TXSTARTED_Msk (0x1UL << TWIM_INTENCLR_TXSTARTED_Pos) /*!< Bit mask of TXSTARTED field. */
+#define TWIM_INTENCLR_TXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENCLR_TXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENCLR_TXSTARTED_Clear (1UL) /*!< Disable */
+
+/* Bit 19 : Write '1' to Disable interrupt for RXSTARTED event */
+#define TWIM_INTENCLR_RXSTARTED_Pos (19UL) /*!< Position of RXSTARTED field. */
+#define TWIM_INTENCLR_RXSTARTED_Msk (0x1UL << TWIM_INTENCLR_RXSTARTED_Pos) /*!< Bit mask of RXSTARTED field. */
+#define TWIM_INTENCLR_RXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENCLR_RXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENCLR_RXSTARTED_Clear (1UL) /*!< Disable */
+
+/* Bit 9 : Write '1' to Disable interrupt for ERROR event */
+#define TWIM_INTENCLR_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define TWIM_INTENCLR_ERROR_Msk (0x1UL << TWIM_INTENCLR_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define TWIM_INTENCLR_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENCLR_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENCLR_ERROR_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for STOPPED event */
+#define TWIM_INTENCLR_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define TWIM_INTENCLR_STOPPED_Msk (0x1UL << TWIM_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define TWIM_INTENCLR_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIM_INTENCLR_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIM_INTENCLR_STOPPED_Clear (1UL) /*!< Disable */
+
+/* Register: TWIM_ERRORSRC */
+/* Description: Error source */
+
+/* Bit 2 : NACK received after sending a data byte (write '1' to clear) */
+#define TWIM_ERRORSRC_DNACK_Pos (2UL) /*!< Position of DNACK field. */
+#define TWIM_ERRORSRC_DNACK_Msk (0x1UL << TWIM_ERRORSRC_DNACK_Pos) /*!< Bit mask of DNACK field. */
+#define TWIM_ERRORSRC_DNACK_NotReceived (0UL) /*!< Error did not occur */
+#define TWIM_ERRORSRC_DNACK_Received (1UL) /*!< Error occurred */
+
+/* Bit 1 : NACK received after sending the address (write '1' to clear) */
+#define TWIM_ERRORSRC_ANACK_Pos (1UL) /*!< Position of ANACK field. */
+#define TWIM_ERRORSRC_ANACK_Msk (0x1UL << TWIM_ERRORSRC_ANACK_Pos) /*!< Bit mask of ANACK field. */
+#define TWIM_ERRORSRC_ANACK_NotReceived (0UL) /*!< Error did not occur */
+#define TWIM_ERRORSRC_ANACK_Received (1UL) /*!< Error occurred */
+
+/* Register: TWIM_ENABLE */
+/* Description: Enable TWIM */
+
+/* Bits 3..0 : Enable or disable TWIM */
+#define TWIM_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define TWIM_ENABLE_ENABLE_Msk (0xFUL << TWIM_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define TWIM_ENABLE_ENABLE_Disabled (0UL) /*!< Disable TWIM */
+#define TWIM_ENABLE_ENABLE_Enabled (6UL) /*!< Enable TWIM */
+
+/* Register: TWIM_PSEL_SCL */
+/* Description: Pin select for SCL signal */
+
+/* Bit 31 : Connection */
+#define TWIM_PSEL_SCL_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define TWIM_PSEL_SCL_CONNECT_Msk (0x1UL << TWIM_PSEL_SCL_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define TWIM_PSEL_SCL_CONNECT_Connected (0UL) /*!< Connect */
+#define TWIM_PSEL_SCL_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define TWIM_PSEL_SCL_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define TWIM_PSEL_SCL_PIN_Msk (0x1FUL << TWIM_PSEL_SCL_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: TWIM_PSEL_SDA */
+/* Description: Pin select for SDA signal */
+
+/* Bit 31 : Connection */
+#define TWIM_PSEL_SDA_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define TWIM_PSEL_SDA_CONNECT_Msk (0x1UL << TWIM_PSEL_SDA_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define TWIM_PSEL_SDA_CONNECT_Connected (0UL) /*!< Connect */
+#define TWIM_PSEL_SDA_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define TWIM_PSEL_SDA_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define TWIM_PSEL_SDA_PIN_Msk (0x1FUL << TWIM_PSEL_SDA_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: TWIM_FREQUENCY */
+/* Description: TWI frequency */
+
+/* Bits 31..0 : TWI master clock frequency */
+#define TWIM_FREQUENCY_FREQUENCY_Pos (0UL) /*!< Position of FREQUENCY field. */
+#define TWIM_FREQUENCY_FREQUENCY_Msk (0xFFFFFFFFUL << TWIM_FREQUENCY_FREQUENCY_Pos) /*!< Bit mask of FREQUENCY field. */
+#define TWIM_FREQUENCY_FREQUENCY_K100 (0x01980000UL) /*!< 100 kbps */
+#define TWIM_FREQUENCY_FREQUENCY_K250 (0x04000000UL) /*!< 250 kbps */
+#define TWIM_FREQUENCY_FREQUENCY_K400 (0x06400000UL) /*!< 400 kbps */
+
+/* Register: TWIM_RXD_PTR */
+/* Description: Data pointer */
+
+/* Bits 31..0 : Data pointer */
+#define TWIM_RXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define TWIM_RXD_PTR_PTR_Msk (0xFFFFFFFFUL << TWIM_RXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: TWIM_RXD_MAXCNT */
+/* Description: Maximum number of bytes in receive buffer */
+
+/* Bits 7..0 : Maximum number of bytes in receive buffer */
+#define TWIM_RXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define TWIM_RXD_MAXCNT_MAXCNT_Msk (0xFFUL << TWIM_RXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: TWIM_RXD_AMOUNT */
+/* Description: Number of bytes transferred in the last transaction */
+
+/* Bits 7..0 : Number of bytes transferred in the last transaction. In case of NACK error, includes the NACK'ed byte. */
+#define TWIM_RXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define TWIM_RXD_AMOUNT_AMOUNT_Msk (0xFFUL << TWIM_RXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: TWIM_RXD_LIST */
+/* Description: EasyDMA list type */
+
+/* Bits 2..0 : List type */
+#define TWIM_RXD_LIST_LIST_Pos (0UL) /*!< Position of LIST field. */
+#define TWIM_RXD_LIST_LIST_Msk (0x7UL << TWIM_RXD_LIST_LIST_Pos) /*!< Bit mask of LIST field. */
+#define TWIM_RXD_LIST_LIST_Disabled (0UL) /*!< Disable EasyDMA list */
+#define TWIM_RXD_LIST_LIST_ArrayList (1UL) /*!< Use array list */
+
+/* Register: TWIM_TXD_PTR */
+/* Description: Data pointer */
+
+/* Bits 31..0 : Data pointer */
+#define TWIM_TXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define TWIM_TXD_PTR_PTR_Msk (0xFFFFFFFFUL << TWIM_TXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: TWIM_TXD_MAXCNT */
+/* Description: Maximum number of bytes in transmit buffer */
+
+/* Bits 7..0 : Maximum number of bytes in transmit buffer */
+#define TWIM_TXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define TWIM_TXD_MAXCNT_MAXCNT_Msk (0xFFUL << TWIM_TXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: TWIM_TXD_AMOUNT */
+/* Description: Number of bytes transferred in the last transaction */
+
+/* Bits 7..0 : Number of bytes transferred in the last transaction. In case of NACK error, includes the NACK'ed byte. */
+#define TWIM_TXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define TWIM_TXD_AMOUNT_AMOUNT_Msk (0xFFUL << TWIM_TXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: TWIM_TXD_LIST */
+/* Description: EasyDMA list type */
+
+/* Bits 2..0 : List type */
+#define TWIM_TXD_LIST_LIST_Pos (0UL) /*!< Position of LIST field. */
+#define TWIM_TXD_LIST_LIST_Msk (0x7UL << TWIM_TXD_LIST_LIST_Pos) /*!< Bit mask of LIST field. */
+#define TWIM_TXD_LIST_LIST_Disabled (0UL) /*!< Disable EasyDMA list */
+#define TWIM_TXD_LIST_LIST_ArrayList (1UL) /*!< Use array list */
+
+/* Register: TWIM_ADDRESS */
+/* Description: Address used in the TWI transfer */
+
+/* Bits 6..0 : Address used in the TWI transfer */
+#define TWIM_ADDRESS_ADDRESS_Pos (0UL) /*!< Position of ADDRESS field. */
+#define TWIM_ADDRESS_ADDRESS_Msk (0x7FUL << TWIM_ADDRESS_ADDRESS_Pos) /*!< Bit mask of ADDRESS field. */
+
+
+/* Peripheral: TWIS */
+/* Description: I2C compatible Two-Wire Slave Interface with EasyDMA 0 */
+
+/* Register: TWIS_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 14 : Shortcut between READ event and SUSPEND task */
+#define TWIS_SHORTS_READ_SUSPEND_Pos (14UL) /*!< Position of READ_SUSPEND field. */
+#define TWIS_SHORTS_READ_SUSPEND_Msk (0x1UL << TWIS_SHORTS_READ_SUSPEND_Pos) /*!< Bit mask of READ_SUSPEND field. */
+#define TWIS_SHORTS_READ_SUSPEND_Disabled (0UL) /*!< Disable shortcut */
+#define TWIS_SHORTS_READ_SUSPEND_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 13 : Shortcut between WRITE event and SUSPEND task */
+#define TWIS_SHORTS_WRITE_SUSPEND_Pos (13UL) /*!< Position of WRITE_SUSPEND field. */
+#define TWIS_SHORTS_WRITE_SUSPEND_Msk (0x1UL << TWIS_SHORTS_WRITE_SUSPEND_Pos) /*!< Bit mask of WRITE_SUSPEND field. */
+#define TWIS_SHORTS_WRITE_SUSPEND_Disabled (0UL) /*!< Disable shortcut */
+#define TWIS_SHORTS_WRITE_SUSPEND_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: TWIS_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 26 : Enable or disable interrupt for READ event */
+#define TWIS_INTEN_READ_Pos (26UL) /*!< Position of READ field. */
+#define TWIS_INTEN_READ_Msk (0x1UL << TWIS_INTEN_READ_Pos) /*!< Bit mask of READ field. */
+#define TWIS_INTEN_READ_Disabled (0UL) /*!< Disable */
+#define TWIS_INTEN_READ_Enabled (1UL) /*!< Enable */
+
+/* Bit 25 : Enable or disable interrupt for WRITE event */
+#define TWIS_INTEN_WRITE_Pos (25UL) /*!< Position of WRITE field. */
+#define TWIS_INTEN_WRITE_Msk (0x1UL << TWIS_INTEN_WRITE_Pos) /*!< Bit mask of WRITE field. */
+#define TWIS_INTEN_WRITE_Disabled (0UL) /*!< Disable */
+#define TWIS_INTEN_WRITE_Enabled (1UL) /*!< Enable */
+
+/* Bit 20 : Enable or disable interrupt for TXSTARTED event */
+#define TWIS_INTEN_TXSTARTED_Pos (20UL) /*!< Position of TXSTARTED field. */
+#define TWIS_INTEN_TXSTARTED_Msk (0x1UL << TWIS_INTEN_TXSTARTED_Pos) /*!< Bit mask of TXSTARTED field. */
+#define TWIS_INTEN_TXSTARTED_Disabled (0UL) /*!< Disable */
+#define TWIS_INTEN_TXSTARTED_Enabled (1UL) /*!< Enable */
+
+/* Bit 19 : Enable or disable interrupt for RXSTARTED event */
+#define TWIS_INTEN_RXSTARTED_Pos (19UL) /*!< Position of RXSTARTED field. */
+#define TWIS_INTEN_RXSTARTED_Msk (0x1UL << TWIS_INTEN_RXSTARTED_Pos) /*!< Bit mask of RXSTARTED field. */
+#define TWIS_INTEN_RXSTARTED_Disabled (0UL) /*!< Disable */
+#define TWIS_INTEN_RXSTARTED_Enabled (1UL) /*!< Enable */
+
+/* Bit 9 : Enable or disable interrupt for ERROR event */
+#define TWIS_INTEN_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define TWIS_INTEN_ERROR_Msk (0x1UL << TWIS_INTEN_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define TWIS_INTEN_ERROR_Disabled (0UL) /*!< Disable */
+#define TWIS_INTEN_ERROR_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for STOPPED event */
+#define TWIS_INTEN_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define TWIS_INTEN_STOPPED_Msk (0x1UL << TWIS_INTEN_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define TWIS_INTEN_STOPPED_Disabled (0UL) /*!< Disable */
+#define TWIS_INTEN_STOPPED_Enabled (1UL) /*!< Enable */
+
+/* Register: TWIS_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 26 : Write '1' to Enable interrupt for READ event */
+#define TWIS_INTENSET_READ_Pos (26UL) /*!< Position of READ field. */
+#define TWIS_INTENSET_READ_Msk (0x1UL << TWIS_INTENSET_READ_Pos) /*!< Bit mask of READ field. */
+#define TWIS_INTENSET_READ_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENSET_READ_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENSET_READ_Set (1UL) /*!< Enable */
+
+/* Bit 25 : Write '1' to Enable interrupt for WRITE event */
+#define TWIS_INTENSET_WRITE_Pos (25UL) /*!< Position of WRITE field. */
+#define TWIS_INTENSET_WRITE_Msk (0x1UL << TWIS_INTENSET_WRITE_Pos) /*!< Bit mask of WRITE field. */
+#define TWIS_INTENSET_WRITE_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENSET_WRITE_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENSET_WRITE_Set (1UL) /*!< Enable */
+
+/* Bit 20 : Write '1' to Enable interrupt for TXSTARTED event */
+#define TWIS_INTENSET_TXSTARTED_Pos (20UL) /*!< Position of TXSTARTED field. */
+#define TWIS_INTENSET_TXSTARTED_Msk (0x1UL << TWIS_INTENSET_TXSTARTED_Pos) /*!< Bit mask of TXSTARTED field. */
+#define TWIS_INTENSET_TXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENSET_TXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENSET_TXSTARTED_Set (1UL) /*!< Enable */
+
+/* Bit 19 : Write '1' to Enable interrupt for RXSTARTED event */
+#define TWIS_INTENSET_RXSTARTED_Pos (19UL) /*!< Position of RXSTARTED field. */
+#define TWIS_INTENSET_RXSTARTED_Msk (0x1UL << TWIS_INTENSET_RXSTARTED_Pos) /*!< Bit mask of RXSTARTED field. */
+#define TWIS_INTENSET_RXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENSET_RXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENSET_RXSTARTED_Set (1UL) /*!< Enable */
+
+/* Bit 9 : Write '1' to Enable interrupt for ERROR event */
+#define TWIS_INTENSET_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define TWIS_INTENSET_ERROR_Msk (0x1UL << TWIS_INTENSET_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define TWIS_INTENSET_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENSET_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENSET_ERROR_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for STOPPED event */
+#define TWIS_INTENSET_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define TWIS_INTENSET_STOPPED_Msk (0x1UL << TWIS_INTENSET_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define TWIS_INTENSET_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENSET_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENSET_STOPPED_Set (1UL) /*!< Enable */
+
+/* Register: TWIS_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 26 : Write '1' to Disable interrupt for READ event */
+#define TWIS_INTENCLR_READ_Pos (26UL) /*!< Position of READ field. */
+#define TWIS_INTENCLR_READ_Msk (0x1UL << TWIS_INTENCLR_READ_Pos) /*!< Bit mask of READ field. */
+#define TWIS_INTENCLR_READ_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENCLR_READ_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENCLR_READ_Clear (1UL) /*!< Disable */
+
+/* Bit 25 : Write '1' to Disable interrupt for WRITE event */
+#define TWIS_INTENCLR_WRITE_Pos (25UL) /*!< Position of WRITE field. */
+#define TWIS_INTENCLR_WRITE_Msk (0x1UL << TWIS_INTENCLR_WRITE_Pos) /*!< Bit mask of WRITE field. */
+#define TWIS_INTENCLR_WRITE_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENCLR_WRITE_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENCLR_WRITE_Clear (1UL) /*!< Disable */
+
+/* Bit 20 : Write '1' to Disable interrupt for TXSTARTED event */
+#define TWIS_INTENCLR_TXSTARTED_Pos (20UL) /*!< Position of TXSTARTED field. */
+#define TWIS_INTENCLR_TXSTARTED_Msk (0x1UL << TWIS_INTENCLR_TXSTARTED_Pos) /*!< Bit mask of TXSTARTED field. */
+#define TWIS_INTENCLR_TXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENCLR_TXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENCLR_TXSTARTED_Clear (1UL) /*!< Disable */
+
+/* Bit 19 : Write '1' to Disable interrupt for RXSTARTED event */
+#define TWIS_INTENCLR_RXSTARTED_Pos (19UL) /*!< Position of RXSTARTED field. */
+#define TWIS_INTENCLR_RXSTARTED_Msk (0x1UL << TWIS_INTENCLR_RXSTARTED_Pos) /*!< Bit mask of RXSTARTED field. */
+#define TWIS_INTENCLR_RXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENCLR_RXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENCLR_RXSTARTED_Clear (1UL) /*!< Disable */
+
+/* Bit 9 : Write '1' to Disable interrupt for ERROR event */
+#define TWIS_INTENCLR_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define TWIS_INTENCLR_ERROR_Msk (0x1UL << TWIS_INTENCLR_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define TWIS_INTENCLR_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENCLR_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENCLR_ERROR_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for STOPPED event */
+#define TWIS_INTENCLR_STOPPED_Pos (1UL) /*!< Position of STOPPED field. */
+#define TWIS_INTENCLR_STOPPED_Msk (0x1UL << TWIS_INTENCLR_STOPPED_Pos) /*!< Bit mask of STOPPED field. */
+#define TWIS_INTENCLR_STOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define TWIS_INTENCLR_STOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define TWIS_INTENCLR_STOPPED_Clear (1UL) /*!< Disable */
+
+/* Register: TWIS_ERRORSRC */
+/* Description: Error source */
+
+/* Bit 3 : TX buffer over-read detected, and prevented */
+#define TWIS_ERRORSRC_OVERREAD_Pos (3UL) /*!< Position of OVERREAD field. */
+#define TWIS_ERRORSRC_OVERREAD_Msk (0x1UL << TWIS_ERRORSRC_OVERREAD_Pos) /*!< Bit mask of OVERREAD field. */
+#define TWIS_ERRORSRC_OVERREAD_NotDetected (0UL) /*!< Error did not occur */
+#define TWIS_ERRORSRC_OVERREAD_Detected (1UL) /*!< Error occurred */
+
+/* Bit 2 : NACK sent after receiving a data byte */
+#define TWIS_ERRORSRC_DNACK_Pos (2UL) /*!< Position of DNACK field. */
+#define TWIS_ERRORSRC_DNACK_Msk (0x1UL << TWIS_ERRORSRC_DNACK_Pos) /*!< Bit mask of DNACK field. */
+#define TWIS_ERRORSRC_DNACK_NotReceived (0UL) /*!< Error did not occur */
+#define TWIS_ERRORSRC_DNACK_Received (1UL) /*!< Error occurred */
+
+/* Bit 0 : RX buffer overflow detected, and prevented */
+#define TWIS_ERRORSRC_OVERFLOW_Pos (0UL) /*!< Position of OVERFLOW field. */
+#define TWIS_ERRORSRC_OVERFLOW_Msk (0x1UL << TWIS_ERRORSRC_OVERFLOW_Pos) /*!< Bit mask of OVERFLOW field. */
+#define TWIS_ERRORSRC_OVERFLOW_NotDetected (0UL) /*!< Error did not occur */
+#define TWIS_ERRORSRC_OVERFLOW_Detected (1UL) /*!< Error occurred */
+
+/* Register: TWIS_MATCH */
+/* Description: Status register indicating which address had a match */
+
+/* Bit 0 : Which of the addresses in {ADDRESS} matched the incoming address */
+#define TWIS_MATCH_MATCH_Pos (0UL) /*!< Position of MATCH field. */
+#define TWIS_MATCH_MATCH_Msk (0x1UL << TWIS_MATCH_MATCH_Pos) /*!< Bit mask of MATCH field. */
+
+/* Register: TWIS_ENABLE */
+/* Description: Enable TWIS */
+
+/* Bits 3..0 : Enable or disable TWIS */
+#define TWIS_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define TWIS_ENABLE_ENABLE_Msk (0xFUL << TWIS_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define TWIS_ENABLE_ENABLE_Disabled (0UL) /*!< Disable TWIS */
+#define TWIS_ENABLE_ENABLE_Enabled (9UL) /*!< Enable TWIS */
+
+/* Register: TWIS_PSEL_SCL */
+/* Description: Pin select for SCL signal */
+
+/* Bit 31 : Connection */
+#define TWIS_PSEL_SCL_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define TWIS_PSEL_SCL_CONNECT_Msk (0x1UL << TWIS_PSEL_SCL_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define TWIS_PSEL_SCL_CONNECT_Connected (0UL) /*!< Connect */
+#define TWIS_PSEL_SCL_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define TWIS_PSEL_SCL_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define TWIS_PSEL_SCL_PIN_Msk (0x1FUL << TWIS_PSEL_SCL_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: TWIS_PSEL_SDA */
+/* Description: Pin select for SDA signal */
+
+/* Bit 31 : Connection */
+#define TWIS_PSEL_SDA_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define TWIS_PSEL_SDA_CONNECT_Msk (0x1UL << TWIS_PSEL_SDA_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define TWIS_PSEL_SDA_CONNECT_Connected (0UL) /*!< Connect */
+#define TWIS_PSEL_SDA_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define TWIS_PSEL_SDA_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define TWIS_PSEL_SDA_PIN_Msk (0x1FUL << TWIS_PSEL_SDA_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: TWIS_RXD_PTR */
+/* Description: RXD Data pointer */
+
+/* Bits 31..0 : RXD Data pointer */
+#define TWIS_RXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define TWIS_RXD_PTR_PTR_Msk (0xFFFFFFFFUL << TWIS_RXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: TWIS_RXD_MAXCNT */
+/* Description: Maximum number of bytes in RXD buffer */
+
+/* Bits 7..0 : Maximum number of bytes in RXD buffer */
+#define TWIS_RXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define TWIS_RXD_MAXCNT_MAXCNT_Msk (0xFFUL << TWIS_RXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: TWIS_RXD_AMOUNT */
+/* Description: Number of bytes transferred in the last RXD transaction */
+
+/* Bits 7..0 : Number of bytes transferred in the last RXD transaction */
+#define TWIS_RXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define TWIS_RXD_AMOUNT_AMOUNT_Msk (0xFFUL << TWIS_RXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: TWIS_TXD_PTR */
+/* Description: TXD Data pointer */
+
+/* Bits 31..0 : TXD Data pointer */
+#define TWIS_TXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define TWIS_TXD_PTR_PTR_Msk (0xFFFFFFFFUL << TWIS_TXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: TWIS_TXD_MAXCNT */
+/* Description: Maximum number of bytes in TXD buffer */
+
+/* Bits 7..0 : Maximum number of bytes in TXD buffer */
+#define TWIS_TXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define TWIS_TXD_MAXCNT_MAXCNT_Msk (0xFFUL << TWIS_TXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: TWIS_TXD_AMOUNT */
+/* Description: Number of bytes transferred in the last TXD transaction */
+
+/* Bits 7..0 : Number of bytes transferred in the last TXD transaction */
+#define TWIS_TXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define TWIS_TXD_AMOUNT_AMOUNT_Msk (0xFFUL << TWIS_TXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: TWIS_ADDRESS */
+/* Description: Description collection[0]:  TWI slave address 0 */
+
+/* Bits 6..0 : TWI slave address */
+#define TWIS_ADDRESS_ADDRESS_Pos (0UL) /*!< Position of ADDRESS field. */
+#define TWIS_ADDRESS_ADDRESS_Msk (0x7FUL << TWIS_ADDRESS_ADDRESS_Pos) /*!< Bit mask of ADDRESS field. */
+
+/* Register: TWIS_CONFIG */
+/* Description: Configuration register for the address match mechanism */
+
+/* Bit 1 : Enable or disable address matching on ADDRESS[1] */
+#define TWIS_CONFIG_ADDRESS1_Pos (1UL) /*!< Position of ADDRESS1 field. */
+#define TWIS_CONFIG_ADDRESS1_Msk (0x1UL << TWIS_CONFIG_ADDRESS1_Pos) /*!< Bit mask of ADDRESS1 field. */
+#define TWIS_CONFIG_ADDRESS1_Disabled (0UL) /*!< Disabled */
+#define TWIS_CONFIG_ADDRESS1_Enabled (1UL) /*!< Enabled */
+
+/* Bit 0 : Enable or disable address matching on ADDRESS[0] */
+#define TWIS_CONFIG_ADDRESS0_Pos (0UL) /*!< Position of ADDRESS0 field. */
+#define TWIS_CONFIG_ADDRESS0_Msk (0x1UL << TWIS_CONFIG_ADDRESS0_Pos) /*!< Bit mask of ADDRESS0 field. */
+#define TWIS_CONFIG_ADDRESS0_Disabled (0UL) /*!< Disabled */
+#define TWIS_CONFIG_ADDRESS0_Enabled (1UL) /*!< Enabled */
+
+/* Register: TWIS_ORC */
+/* Description: Over-read character. Character sent out in case of an over-read of the transmit buffer. */
+
+/* Bits 7..0 : Over-read character. Character sent out in case of an over-read of the transmit buffer. */
+#define TWIS_ORC_ORC_Pos (0UL) /*!< Position of ORC field. */
+#define TWIS_ORC_ORC_Msk (0xFFUL << TWIS_ORC_ORC_Pos) /*!< Bit mask of ORC field. */
+
+
+/* Peripheral: UART */
+/* Description: Universal Asynchronous Receiver/Transmitter */
+
+/* Register: UART_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 4 : Shortcut between NCTS event and STOPRX task */
+#define UART_SHORTS_NCTS_STOPRX_Pos (4UL) /*!< Position of NCTS_STOPRX field. */
+#define UART_SHORTS_NCTS_STOPRX_Msk (0x1UL << UART_SHORTS_NCTS_STOPRX_Pos) /*!< Bit mask of NCTS_STOPRX field. */
+#define UART_SHORTS_NCTS_STOPRX_Disabled (0UL) /*!< Disable shortcut */
+#define UART_SHORTS_NCTS_STOPRX_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 3 : Shortcut between CTS event and STARTRX task */
+#define UART_SHORTS_CTS_STARTRX_Pos (3UL) /*!< Position of CTS_STARTRX field. */
+#define UART_SHORTS_CTS_STARTRX_Msk (0x1UL << UART_SHORTS_CTS_STARTRX_Pos) /*!< Bit mask of CTS_STARTRX field. */
+#define UART_SHORTS_CTS_STARTRX_Disabled (0UL) /*!< Disable shortcut */
+#define UART_SHORTS_CTS_STARTRX_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: UART_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 17 : Write '1' to Enable interrupt for RXTO event */
+#define UART_INTENSET_RXTO_Pos (17UL) /*!< Position of RXTO field. */
+#define UART_INTENSET_RXTO_Msk (0x1UL << UART_INTENSET_RXTO_Pos) /*!< Bit mask of RXTO field. */
+#define UART_INTENSET_RXTO_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENSET_RXTO_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENSET_RXTO_Set (1UL) /*!< Enable */
+
+/* Bit 9 : Write '1' to Enable interrupt for ERROR event */
+#define UART_INTENSET_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define UART_INTENSET_ERROR_Msk (0x1UL << UART_INTENSET_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define UART_INTENSET_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENSET_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENSET_ERROR_Set (1UL) /*!< Enable */
+
+/* Bit 7 : Write '1' to Enable interrupt for TXDRDY event */
+#define UART_INTENSET_TXDRDY_Pos (7UL) /*!< Position of TXDRDY field. */
+#define UART_INTENSET_TXDRDY_Msk (0x1UL << UART_INTENSET_TXDRDY_Pos) /*!< Bit mask of TXDRDY field. */
+#define UART_INTENSET_TXDRDY_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENSET_TXDRDY_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENSET_TXDRDY_Set (1UL) /*!< Enable */
+
+/* Bit 2 : Write '1' to Enable interrupt for RXDRDY event */
+#define UART_INTENSET_RXDRDY_Pos (2UL) /*!< Position of RXDRDY field. */
+#define UART_INTENSET_RXDRDY_Msk (0x1UL << UART_INTENSET_RXDRDY_Pos) /*!< Bit mask of RXDRDY field. */
+#define UART_INTENSET_RXDRDY_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENSET_RXDRDY_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENSET_RXDRDY_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for NCTS event */
+#define UART_INTENSET_NCTS_Pos (1UL) /*!< Position of NCTS field. */
+#define UART_INTENSET_NCTS_Msk (0x1UL << UART_INTENSET_NCTS_Pos) /*!< Bit mask of NCTS field. */
+#define UART_INTENSET_NCTS_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENSET_NCTS_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENSET_NCTS_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for CTS event */
+#define UART_INTENSET_CTS_Pos (0UL) /*!< Position of CTS field. */
+#define UART_INTENSET_CTS_Msk (0x1UL << UART_INTENSET_CTS_Pos) /*!< Bit mask of CTS field. */
+#define UART_INTENSET_CTS_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENSET_CTS_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENSET_CTS_Set (1UL) /*!< Enable */
+
+/* Register: UART_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 17 : Write '1' to Disable interrupt for RXTO event */
+#define UART_INTENCLR_RXTO_Pos (17UL) /*!< Position of RXTO field. */
+#define UART_INTENCLR_RXTO_Msk (0x1UL << UART_INTENCLR_RXTO_Pos) /*!< Bit mask of RXTO field. */
+#define UART_INTENCLR_RXTO_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENCLR_RXTO_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENCLR_RXTO_Clear (1UL) /*!< Disable */
+
+/* Bit 9 : Write '1' to Disable interrupt for ERROR event */
+#define UART_INTENCLR_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define UART_INTENCLR_ERROR_Msk (0x1UL << UART_INTENCLR_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define UART_INTENCLR_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENCLR_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENCLR_ERROR_Clear (1UL) /*!< Disable */
+
+/* Bit 7 : Write '1' to Disable interrupt for TXDRDY event */
+#define UART_INTENCLR_TXDRDY_Pos (7UL) /*!< Position of TXDRDY field. */
+#define UART_INTENCLR_TXDRDY_Msk (0x1UL << UART_INTENCLR_TXDRDY_Pos) /*!< Bit mask of TXDRDY field. */
+#define UART_INTENCLR_TXDRDY_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENCLR_TXDRDY_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENCLR_TXDRDY_Clear (1UL) /*!< Disable */
+
+/* Bit 2 : Write '1' to Disable interrupt for RXDRDY event */
+#define UART_INTENCLR_RXDRDY_Pos (2UL) /*!< Position of RXDRDY field. */
+#define UART_INTENCLR_RXDRDY_Msk (0x1UL << UART_INTENCLR_RXDRDY_Pos) /*!< Bit mask of RXDRDY field. */
+#define UART_INTENCLR_RXDRDY_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENCLR_RXDRDY_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENCLR_RXDRDY_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for NCTS event */
+#define UART_INTENCLR_NCTS_Pos (1UL) /*!< Position of NCTS field. */
+#define UART_INTENCLR_NCTS_Msk (0x1UL << UART_INTENCLR_NCTS_Pos) /*!< Bit mask of NCTS field. */
+#define UART_INTENCLR_NCTS_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENCLR_NCTS_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENCLR_NCTS_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for CTS event */
+#define UART_INTENCLR_CTS_Pos (0UL) /*!< Position of CTS field. */
+#define UART_INTENCLR_CTS_Msk (0x1UL << UART_INTENCLR_CTS_Pos) /*!< Bit mask of CTS field. */
+#define UART_INTENCLR_CTS_Disabled (0UL) /*!< Read: Disabled */
+#define UART_INTENCLR_CTS_Enabled (1UL) /*!< Read: Enabled */
+#define UART_INTENCLR_CTS_Clear (1UL) /*!< Disable */
+
+/* Register: UART_ERRORSRC */
+/* Description: Error source */
+
+/* Bit 3 : Break condition */
+#define UART_ERRORSRC_BREAK_Pos (3UL) /*!< Position of BREAK field. */
+#define UART_ERRORSRC_BREAK_Msk (0x1UL << UART_ERRORSRC_BREAK_Pos) /*!< Bit mask of BREAK field. */
+#define UART_ERRORSRC_BREAK_NotPresent (0UL) /*!< Read: error not present */
+#define UART_ERRORSRC_BREAK_Present (1UL) /*!< Read: error present */
+
+/* Bit 2 : Framing error occurred */
+#define UART_ERRORSRC_FRAMING_Pos (2UL) /*!< Position of FRAMING field. */
+#define UART_ERRORSRC_FRAMING_Msk (0x1UL << UART_ERRORSRC_FRAMING_Pos) /*!< Bit mask of FRAMING field. */
+#define UART_ERRORSRC_FRAMING_NotPresent (0UL) /*!< Read: error not present */
+#define UART_ERRORSRC_FRAMING_Present (1UL) /*!< Read: error present */
+
+/* Bit 1 : Parity error */
+#define UART_ERRORSRC_PARITY_Pos (1UL) /*!< Position of PARITY field. */
+#define UART_ERRORSRC_PARITY_Msk (0x1UL << UART_ERRORSRC_PARITY_Pos) /*!< Bit mask of PARITY field. */
+#define UART_ERRORSRC_PARITY_NotPresent (0UL) /*!< Read: error not present */
+#define UART_ERRORSRC_PARITY_Present (1UL) /*!< Read: error present */
+
+/* Bit 0 : Overrun error */
+#define UART_ERRORSRC_OVERRUN_Pos (0UL) /*!< Position of OVERRUN field. */
+#define UART_ERRORSRC_OVERRUN_Msk (0x1UL << UART_ERRORSRC_OVERRUN_Pos) /*!< Bit mask of OVERRUN field. */
+#define UART_ERRORSRC_OVERRUN_NotPresent (0UL) /*!< Read: error not present */
+#define UART_ERRORSRC_OVERRUN_Present (1UL) /*!< Read: error present */
+
+/* Register: UART_ENABLE */
+/* Description: Enable UART */
+
+/* Bits 3..0 : Enable or disable UART */
+#define UART_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define UART_ENABLE_ENABLE_Msk (0xFUL << UART_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define UART_ENABLE_ENABLE_Disabled (0UL) /*!< Disable UART */
+#define UART_ENABLE_ENABLE_Enabled (4UL) /*!< Enable UART */
+
+/* Register: UART_PSELRTS */
+/* Description: Pin select for RTS */
+
+/* Bits 31..0 : Pin number configuration for UART RTS signal */
+#define UART_PSELRTS_PSELRTS_Pos (0UL) /*!< Position of PSELRTS field. */
+#define UART_PSELRTS_PSELRTS_Msk (0xFFFFFFFFUL << UART_PSELRTS_PSELRTS_Pos) /*!< Bit mask of PSELRTS field. */
+#define UART_PSELRTS_PSELRTS_Disconnected (0xFFFFFFFFUL) /*!< Disconnect */
+
+/* Register: UART_PSELTXD */
+/* Description: Pin select for TXD */
+
+/* Bits 31..0 : Pin number configuration for UART TXD signal */
+#define UART_PSELTXD_PSELTXD_Pos (0UL) /*!< Position of PSELTXD field. */
+#define UART_PSELTXD_PSELTXD_Msk (0xFFFFFFFFUL << UART_PSELTXD_PSELTXD_Pos) /*!< Bit mask of PSELTXD field. */
+#define UART_PSELTXD_PSELTXD_Disconnected (0xFFFFFFFFUL) /*!< Disconnect */
+
+/* Register: UART_PSELCTS */
+/* Description: Pin select for CTS */
+
+/* Bits 31..0 : Pin number configuration for UART CTS signal */
+#define UART_PSELCTS_PSELCTS_Pos (0UL) /*!< Position of PSELCTS field. */
+#define UART_PSELCTS_PSELCTS_Msk (0xFFFFFFFFUL << UART_PSELCTS_PSELCTS_Pos) /*!< Bit mask of PSELCTS field. */
+#define UART_PSELCTS_PSELCTS_Disconnected (0xFFFFFFFFUL) /*!< Disconnect */
+
+/* Register: UART_PSELRXD */
+/* Description: Pin select for RXD */
+
+/* Bits 31..0 : Pin number configuration for UART RXD signal */
+#define UART_PSELRXD_PSELRXD_Pos (0UL) /*!< Position of PSELRXD field. */
+#define UART_PSELRXD_PSELRXD_Msk (0xFFFFFFFFUL << UART_PSELRXD_PSELRXD_Pos) /*!< Bit mask of PSELRXD field. */
+#define UART_PSELRXD_PSELRXD_Disconnected (0xFFFFFFFFUL) /*!< Disconnect */
+
+/* Register: UART_RXD */
+/* Description: RXD register */
+
+/* Bits 7..0 : RX data received in previous transfers, double buffered */
+#define UART_RXD_RXD_Pos (0UL) /*!< Position of RXD field. */
+#define UART_RXD_RXD_Msk (0xFFUL << UART_RXD_RXD_Pos) /*!< Bit mask of RXD field. */
+
+/* Register: UART_TXD */
+/* Description: TXD register */
+
+/* Bits 7..0 : TX data to be transferred */
+#define UART_TXD_TXD_Pos (0UL) /*!< Position of TXD field. */
+#define UART_TXD_TXD_Msk (0xFFUL << UART_TXD_TXD_Pos) /*!< Bit mask of TXD field. */
+
+/* Register: UART_BAUDRATE */
+/* Description: Baud rate */
+
+/* Bits 31..0 : Baud-rate */
+#define UART_BAUDRATE_BAUDRATE_Pos (0UL) /*!< Position of BAUDRATE field. */
+#define UART_BAUDRATE_BAUDRATE_Msk (0xFFFFFFFFUL << UART_BAUDRATE_BAUDRATE_Pos) /*!< Bit mask of BAUDRATE field. */
+#define UART_BAUDRATE_BAUDRATE_Baud1200 (0x0004F000UL) /*!< 1200 baud (actual rate: 1205) */
+#define UART_BAUDRATE_BAUDRATE_Baud2400 (0x0009D000UL) /*!< 2400 baud (actual rate: 2396) */
+#define UART_BAUDRATE_BAUDRATE_Baud4800 (0x0013B000UL) /*!< 4800 baud (actual rate: 4808) */
+#define UART_BAUDRATE_BAUDRATE_Baud9600 (0x00275000UL) /*!< 9600 baud (actual rate: 9598) */
+#define UART_BAUDRATE_BAUDRATE_Baud14400 (0x003B0000UL) /*!< 14400 baud (actual rate: 14414) */
+#define UART_BAUDRATE_BAUDRATE_Baud19200 (0x004EA000UL) /*!< 19200 baud (actual rate: 19208) */
+#define UART_BAUDRATE_BAUDRATE_Baud28800 (0x0075F000UL) /*!< 28800 baud (actual rate: 28829) */
+#define UART_BAUDRATE_BAUDRATE_Baud38400 (0x009D5000UL) /*!< 38400 baud (actual rate: 38462) */
+#define UART_BAUDRATE_BAUDRATE_Baud57600 (0x00EBF000UL) /*!< 57600 baud (actual rate: 57762) */
+#define UART_BAUDRATE_BAUDRATE_Baud76800 (0x013A9000UL) /*!< 76800 baud (actual rate: 76923) */
+#define UART_BAUDRATE_BAUDRATE_Baud115200 (0x01D7E000UL) /*!< 115200 baud (actual rate: 115942) */
+#define UART_BAUDRATE_BAUDRATE_Baud230400 (0x03AFB000UL) /*!< 230400 baud (actual rate: 231884) */
+#define UART_BAUDRATE_BAUDRATE_Baud250000 (0x04000000UL) /*!< 250000 baud */
+#define UART_BAUDRATE_BAUDRATE_Baud460800 (0x075F7000UL) /*!< 460800 baud (actual rate: 470588) */
+#define UART_BAUDRATE_BAUDRATE_Baud921600 (0x0EBED000UL) /*!< 921600 baud (actual rate: 941176) */
+#define UART_BAUDRATE_BAUDRATE_Baud1M (0x10000000UL) /*!< 1Mega baud */
+
+/* Register: UART_CONFIG */
+/* Description: Configuration of parity and hardware flow control */
+
+/* Bits 3..1 : Parity */
+#define UART_CONFIG_PARITY_Pos (1UL) /*!< Position of PARITY field. */
+#define UART_CONFIG_PARITY_Msk (0x7UL << UART_CONFIG_PARITY_Pos) /*!< Bit mask of PARITY field. */
+#define UART_CONFIG_PARITY_Excluded (0x0UL) /*!< Exclude parity bit */
+#define UART_CONFIG_PARITY_Included (0x7UL) /*!< Include parity bit */
+
+/* Bit 0 : Hardware flow control */
+#define UART_CONFIG_HWFC_Pos (0UL) /*!< Position of HWFC field. */
+#define UART_CONFIG_HWFC_Msk (0x1UL << UART_CONFIG_HWFC_Pos) /*!< Bit mask of HWFC field. */
+#define UART_CONFIG_HWFC_Disabled (0UL) /*!< Disabled */
+#define UART_CONFIG_HWFC_Enabled (1UL) /*!< Enabled */
+
+
+/* Peripheral: UARTE */
+/* Description: UART with EasyDMA */
+
+/* Register: UARTE_SHORTS */
+/* Description: Shortcut register */
+
+/* Bit 6 : Shortcut between ENDRX event and STOPRX task */
+#define UARTE_SHORTS_ENDRX_STOPRX_Pos (6UL) /*!< Position of ENDRX_STOPRX field. */
+#define UARTE_SHORTS_ENDRX_STOPRX_Msk (0x1UL << UARTE_SHORTS_ENDRX_STOPRX_Pos) /*!< Bit mask of ENDRX_STOPRX field. */
+#define UARTE_SHORTS_ENDRX_STOPRX_Disabled (0UL) /*!< Disable shortcut */
+#define UARTE_SHORTS_ENDRX_STOPRX_Enabled (1UL) /*!< Enable shortcut */
+
+/* Bit 5 : Shortcut between ENDRX event and STARTRX task */
+#define UARTE_SHORTS_ENDRX_STARTRX_Pos (5UL) /*!< Position of ENDRX_STARTRX field. */
+#define UARTE_SHORTS_ENDRX_STARTRX_Msk (0x1UL << UARTE_SHORTS_ENDRX_STARTRX_Pos) /*!< Bit mask of ENDRX_STARTRX field. */
+#define UARTE_SHORTS_ENDRX_STARTRX_Disabled (0UL) /*!< Disable shortcut */
+#define UARTE_SHORTS_ENDRX_STARTRX_Enabled (1UL) /*!< Enable shortcut */
+
+/* Register: UARTE_INTEN */
+/* Description: Enable or disable interrupt */
+
+/* Bit 22 : Enable or disable interrupt for TXSTOPPED event */
+#define UARTE_INTEN_TXSTOPPED_Pos (22UL) /*!< Position of TXSTOPPED field. */
+#define UARTE_INTEN_TXSTOPPED_Msk (0x1UL << UARTE_INTEN_TXSTOPPED_Pos) /*!< Bit mask of TXSTOPPED field. */
+#define UARTE_INTEN_TXSTOPPED_Disabled (0UL) /*!< Disable */
+#define UARTE_INTEN_TXSTOPPED_Enabled (1UL) /*!< Enable */
+
+/* Bit 20 : Enable or disable interrupt for TXSTARTED event */
+#define UARTE_INTEN_TXSTARTED_Pos (20UL) /*!< Position of TXSTARTED field. */
+#define UARTE_INTEN_TXSTARTED_Msk (0x1UL << UARTE_INTEN_TXSTARTED_Pos) /*!< Bit mask of TXSTARTED field. */
+#define UARTE_INTEN_TXSTARTED_Disabled (0UL) /*!< Disable */
+#define UARTE_INTEN_TXSTARTED_Enabled (1UL) /*!< Enable */
+
+/* Bit 19 : Enable or disable interrupt for RXSTARTED event */
+#define UARTE_INTEN_RXSTARTED_Pos (19UL) /*!< Position of RXSTARTED field. */
+#define UARTE_INTEN_RXSTARTED_Msk (0x1UL << UARTE_INTEN_RXSTARTED_Pos) /*!< Bit mask of RXSTARTED field. */
+#define UARTE_INTEN_RXSTARTED_Disabled (0UL) /*!< Disable */
+#define UARTE_INTEN_RXSTARTED_Enabled (1UL) /*!< Enable */
+
+/* Bit 17 : Enable or disable interrupt for RXTO event */
+#define UARTE_INTEN_RXTO_Pos (17UL) /*!< Position of RXTO field. */
+#define UARTE_INTEN_RXTO_Msk (0x1UL << UARTE_INTEN_RXTO_Pos) /*!< Bit mask of RXTO field. */
+#define UARTE_INTEN_RXTO_Disabled (0UL) /*!< Disable */
+#define UARTE_INTEN_RXTO_Enabled (1UL) /*!< Enable */
+
+/* Bit 9 : Enable or disable interrupt for ERROR event */
+#define UARTE_INTEN_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define UARTE_INTEN_ERROR_Msk (0x1UL << UARTE_INTEN_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define UARTE_INTEN_ERROR_Disabled (0UL) /*!< Disable */
+#define UARTE_INTEN_ERROR_Enabled (1UL) /*!< Enable */
+
+/* Bit 8 : Enable or disable interrupt for ENDTX event */
+#define UARTE_INTEN_ENDTX_Pos (8UL) /*!< Position of ENDTX field. */
+#define UARTE_INTEN_ENDTX_Msk (0x1UL << UARTE_INTEN_ENDTX_Pos) /*!< Bit mask of ENDTX field. */
+#define UARTE_INTEN_ENDTX_Disabled (0UL) /*!< Disable */
+#define UARTE_INTEN_ENDTX_Enabled (1UL) /*!< Enable */
+
+/* Bit 4 : Enable or disable interrupt for ENDRX event */
+#define UARTE_INTEN_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define UARTE_INTEN_ENDRX_Msk (0x1UL << UARTE_INTEN_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define UARTE_INTEN_ENDRX_Disabled (0UL) /*!< Disable */
+#define UARTE_INTEN_ENDRX_Enabled (1UL) /*!< Enable */
+
+/* Bit 1 : Enable or disable interrupt for NCTS event */
+#define UARTE_INTEN_NCTS_Pos (1UL) /*!< Position of NCTS field. */
+#define UARTE_INTEN_NCTS_Msk (0x1UL << UARTE_INTEN_NCTS_Pos) /*!< Bit mask of NCTS field. */
+#define UARTE_INTEN_NCTS_Disabled (0UL) /*!< Disable */
+#define UARTE_INTEN_NCTS_Enabled (1UL) /*!< Enable */
+
+/* Bit 0 : Enable or disable interrupt for CTS event */
+#define UARTE_INTEN_CTS_Pos (0UL) /*!< Position of CTS field. */
+#define UARTE_INTEN_CTS_Msk (0x1UL << UARTE_INTEN_CTS_Pos) /*!< Bit mask of CTS field. */
+#define UARTE_INTEN_CTS_Disabled (0UL) /*!< Disable */
+#define UARTE_INTEN_CTS_Enabled (1UL) /*!< Enable */
+
+/* Register: UARTE_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 22 : Write '1' to Enable interrupt for TXSTOPPED event */
+#define UARTE_INTENSET_TXSTOPPED_Pos (22UL) /*!< Position of TXSTOPPED field. */
+#define UARTE_INTENSET_TXSTOPPED_Msk (0x1UL << UARTE_INTENSET_TXSTOPPED_Pos) /*!< Bit mask of TXSTOPPED field. */
+#define UARTE_INTENSET_TXSTOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENSET_TXSTOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENSET_TXSTOPPED_Set (1UL) /*!< Enable */
+
+/* Bit 20 : Write '1' to Enable interrupt for TXSTARTED event */
+#define UARTE_INTENSET_TXSTARTED_Pos (20UL) /*!< Position of TXSTARTED field. */
+#define UARTE_INTENSET_TXSTARTED_Msk (0x1UL << UARTE_INTENSET_TXSTARTED_Pos) /*!< Bit mask of TXSTARTED field. */
+#define UARTE_INTENSET_TXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENSET_TXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENSET_TXSTARTED_Set (1UL) /*!< Enable */
+
+/* Bit 19 : Write '1' to Enable interrupt for RXSTARTED event */
+#define UARTE_INTENSET_RXSTARTED_Pos (19UL) /*!< Position of RXSTARTED field. */
+#define UARTE_INTENSET_RXSTARTED_Msk (0x1UL << UARTE_INTENSET_RXSTARTED_Pos) /*!< Bit mask of RXSTARTED field. */
+#define UARTE_INTENSET_RXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENSET_RXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENSET_RXSTARTED_Set (1UL) /*!< Enable */
+
+/* Bit 17 : Write '1' to Enable interrupt for RXTO event */
+#define UARTE_INTENSET_RXTO_Pos (17UL) /*!< Position of RXTO field. */
+#define UARTE_INTENSET_RXTO_Msk (0x1UL << UARTE_INTENSET_RXTO_Pos) /*!< Bit mask of RXTO field. */
+#define UARTE_INTENSET_RXTO_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENSET_RXTO_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENSET_RXTO_Set (1UL) /*!< Enable */
+
+/* Bit 9 : Write '1' to Enable interrupt for ERROR event */
+#define UARTE_INTENSET_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define UARTE_INTENSET_ERROR_Msk (0x1UL << UARTE_INTENSET_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define UARTE_INTENSET_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENSET_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENSET_ERROR_Set (1UL) /*!< Enable */
+
+/* Bit 8 : Write '1' to Enable interrupt for ENDTX event */
+#define UARTE_INTENSET_ENDTX_Pos (8UL) /*!< Position of ENDTX field. */
+#define UARTE_INTENSET_ENDTX_Msk (0x1UL << UARTE_INTENSET_ENDTX_Pos) /*!< Bit mask of ENDTX field. */
+#define UARTE_INTENSET_ENDTX_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENSET_ENDTX_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENSET_ENDTX_Set (1UL) /*!< Enable */
+
+/* Bit 4 : Write '1' to Enable interrupt for ENDRX event */
+#define UARTE_INTENSET_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define UARTE_INTENSET_ENDRX_Msk (0x1UL << UARTE_INTENSET_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define UARTE_INTENSET_ENDRX_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENSET_ENDRX_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENSET_ENDRX_Set (1UL) /*!< Enable */
+
+/* Bit 1 : Write '1' to Enable interrupt for NCTS event */
+#define UARTE_INTENSET_NCTS_Pos (1UL) /*!< Position of NCTS field. */
+#define UARTE_INTENSET_NCTS_Msk (0x1UL << UARTE_INTENSET_NCTS_Pos) /*!< Bit mask of NCTS field. */
+#define UARTE_INTENSET_NCTS_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENSET_NCTS_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENSET_NCTS_Set (1UL) /*!< Enable */
+
+/* Bit 0 : Write '1' to Enable interrupt for CTS event */
+#define UARTE_INTENSET_CTS_Pos (0UL) /*!< Position of CTS field. */
+#define UARTE_INTENSET_CTS_Msk (0x1UL << UARTE_INTENSET_CTS_Pos) /*!< Bit mask of CTS field. */
+#define UARTE_INTENSET_CTS_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENSET_CTS_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENSET_CTS_Set (1UL) /*!< Enable */
+
+/* Register: UARTE_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 22 : Write '1' to Disable interrupt for TXSTOPPED event */
+#define UARTE_INTENCLR_TXSTOPPED_Pos (22UL) /*!< Position of TXSTOPPED field. */
+#define UARTE_INTENCLR_TXSTOPPED_Msk (0x1UL << UARTE_INTENCLR_TXSTOPPED_Pos) /*!< Bit mask of TXSTOPPED field. */
+#define UARTE_INTENCLR_TXSTOPPED_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENCLR_TXSTOPPED_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENCLR_TXSTOPPED_Clear (1UL) /*!< Disable */
+
+/* Bit 20 : Write '1' to Disable interrupt for TXSTARTED event */
+#define UARTE_INTENCLR_TXSTARTED_Pos (20UL) /*!< Position of TXSTARTED field. */
+#define UARTE_INTENCLR_TXSTARTED_Msk (0x1UL << UARTE_INTENCLR_TXSTARTED_Pos) /*!< Bit mask of TXSTARTED field. */
+#define UARTE_INTENCLR_TXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENCLR_TXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENCLR_TXSTARTED_Clear (1UL) /*!< Disable */
+
+/* Bit 19 : Write '1' to Disable interrupt for RXSTARTED event */
+#define UARTE_INTENCLR_RXSTARTED_Pos (19UL) /*!< Position of RXSTARTED field. */
+#define UARTE_INTENCLR_RXSTARTED_Msk (0x1UL << UARTE_INTENCLR_RXSTARTED_Pos) /*!< Bit mask of RXSTARTED field. */
+#define UARTE_INTENCLR_RXSTARTED_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENCLR_RXSTARTED_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENCLR_RXSTARTED_Clear (1UL) /*!< Disable */
+
+/* Bit 17 : Write '1' to Disable interrupt for RXTO event */
+#define UARTE_INTENCLR_RXTO_Pos (17UL) /*!< Position of RXTO field. */
+#define UARTE_INTENCLR_RXTO_Msk (0x1UL << UARTE_INTENCLR_RXTO_Pos) /*!< Bit mask of RXTO field. */
+#define UARTE_INTENCLR_RXTO_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENCLR_RXTO_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENCLR_RXTO_Clear (1UL) /*!< Disable */
+
+/* Bit 9 : Write '1' to Disable interrupt for ERROR event */
+#define UARTE_INTENCLR_ERROR_Pos (9UL) /*!< Position of ERROR field. */
+#define UARTE_INTENCLR_ERROR_Msk (0x1UL << UARTE_INTENCLR_ERROR_Pos) /*!< Bit mask of ERROR field. */
+#define UARTE_INTENCLR_ERROR_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENCLR_ERROR_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENCLR_ERROR_Clear (1UL) /*!< Disable */
+
+/* Bit 8 : Write '1' to Disable interrupt for ENDTX event */
+#define UARTE_INTENCLR_ENDTX_Pos (8UL) /*!< Position of ENDTX field. */
+#define UARTE_INTENCLR_ENDTX_Msk (0x1UL << UARTE_INTENCLR_ENDTX_Pos) /*!< Bit mask of ENDTX field. */
+#define UARTE_INTENCLR_ENDTX_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENCLR_ENDTX_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENCLR_ENDTX_Clear (1UL) /*!< Disable */
+
+/* Bit 4 : Write '1' to Disable interrupt for ENDRX event */
+#define UARTE_INTENCLR_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define UARTE_INTENCLR_ENDRX_Msk (0x1UL << UARTE_INTENCLR_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define UARTE_INTENCLR_ENDRX_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENCLR_ENDRX_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENCLR_ENDRX_Clear (1UL) /*!< Disable */
+
+/* Bit 1 : Write '1' to Disable interrupt for NCTS event */
+#define UARTE_INTENCLR_NCTS_Pos (1UL) /*!< Position of NCTS field. */
+#define UARTE_INTENCLR_NCTS_Msk (0x1UL << UARTE_INTENCLR_NCTS_Pos) /*!< Bit mask of NCTS field. */
+#define UARTE_INTENCLR_NCTS_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENCLR_NCTS_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENCLR_NCTS_Clear (1UL) /*!< Disable */
+
+/* Bit 0 : Write '1' to Disable interrupt for CTS event */
+#define UARTE_INTENCLR_CTS_Pos (0UL) /*!< Position of CTS field. */
+#define UARTE_INTENCLR_CTS_Msk (0x1UL << UARTE_INTENCLR_CTS_Pos) /*!< Bit mask of CTS field. */
+#define UARTE_INTENCLR_CTS_Disabled (0UL) /*!< Read: Disabled */
+#define UARTE_INTENCLR_CTS_Enabled (1UL) /*!< Read: Enabled */
+#define UARTE_INTENCLR_CTS_Clear (1UL) /*!< Disable */
+
+/* Register: UARTE_ERRORSRC */
+/* Description: Error source */
+
+/* Bit 3 : Break condition */
+#define UARTE_ERRORSRC_BREAK_Pos (3UL) /*!< Position of BREAK field. */
+#define UARTE_ERRORSRC_BREAK_Msk (0x1UL << UARTE_ERRORSRC_BREAK_Pos) /*!< Bit mask of BREAK field. */
+#define UARTE_ERRORSRC_BREAK_NotPresent (0UL) /*!< Read: error not present */
+#define UARTE_ERRORSRC_BREAK_Present (1UL) /*!< Read: error present */
+
+/* Bit 2 : Framing error occurred */
+#define UARTE_ERRORSRC_FRAMING_Pos (2UL) /*!< Position of FRAMING field. */
+#define UARTE_ERRORSRC_FRAMING_Msk (0x1UL << UARTE_ERRORSRC_FRAMING_Pos) /*!< Bit mask of FRAMING field. */
+#define UARTE_ERRORSRC_FRAMING_NotPresent (0UL) /*!< Read: error not present */
+#define UARTE_ERRORSRC_FRAMING_Present (1UL) /*!< Read: error present */
+
+/* Bit 1 : Parity error */
+#define UARTE_ERRORSRC_PARITY_Pos (1UL) /*!< Position of PARITY field. */
+#define UARTE_ERRORSRC_PARITY_Msk (0x1UL << UARTE_ERRORSRC_PARITY_Pos) /*!< Bit mask of PARITY field. */
+#define UARTE_ERRORSRC_PARITY_NotPresent (0UL) /*!< Read: error not present */
+#define UARTE_ERRORSRC_PARITY_Present (1UL) /*!< Read: error present */
+
+/* Bit 0 : Overrun error */
+#define UARTE_ERRORSRC_OVERRUN_Pos (0UL) /*!< Position of OVERRUN field. */
+#define UARTE_ERRORSRC_OVERRUN_Msk (0x1UL << UARTE_ERRORSRC_OVERRUN_Pos) /*!< Bit mask of OVERRUN field. */
+#define UARTE_ERRORSRC_OVERRUN_NotPresent (0UL) /*!< Read: error not present */
+#define UARTE_ERRORSRC_OVERRUN_Present (1UL) /*!< Read: error present */
+
+/* Register: UARTE_ENABLE */
+/* Description: Enable UART */
+
+/* Bits 3..0 : Enable or disable UARTE */
+#define UARTE_ENABLE_ENABLE_Pos (0UL) /*!< Position of ENABLE field. */
+#define UARTE_ENABLE_ENABLE_Msk (0xFUL << UARTE_ENABLE_ENABLE_Pos) /*!< Bit mask of ENABLE field. */
+#define UARTE_ENABLE_ENABLE_Disabled (0UL) /*!< Disable UARTE */
+#define UARTE_ENABLE_ENABLE_Enabled (8UL) /*!< Enable UARTE */
+
+/* Register: UARTE_PSEL_RTS */
+/* Description: Pin select for RTS signal */
+
+/* Bit 31 : Connection */
+#define UARTE_PSEL_RTS_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define UARTE_PSEL_RTS_CONNECT_Msk (0x1UL << UARTE_PSEL_RTS_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define UARTE_PSEL_RTS_CONNECT_Connected (0UL) /*!< Connect */
+#define UARTE_PSEL_RTS_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define UARTE_PSEL_RTS_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define UARTE_PSEL_RTS_PIN_Msk (0x1FUL << UARTE_PSEL_RTS_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: UARTE_PSEL_TXD */
+/* Description: Pin select for TXD signal */
+
+/* Bit 31 : Connection */
+#define UARTE_PSEL_TXD_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define UARTE_PSEL_TXD_CONNECT_Msk (0x1UL << UARTE_PSEL_TXD_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define UARTE_PSEL_TXD_CONNECT_Connected (0UL) /*!< Connect */
+#define UARTE_PSEL_TXD_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define UARTE_PSEL_TXD_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define UARTE_PSEL_TXD_PIN_Msk (0x1FUL << UARTE_PSEL_TXD_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: UARTE_PSEL_CTS */
+/* Description: Pin select for CTS signal */
+
+/* Bit 31 : Connection */
+#define UARTE_PSEL_CTS_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define UARTE_PSEL_CTS_CONNECT_Msk (0x1UL << UARTE_PSEL_CTS_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define UARTE_PSEL_CTS_CONNECT_Connected (0UL) /*!< Connect */
+#define UARTE_PSEL_CTS_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define UARTE_PSEL_CTS_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define UARTE_PSEL_CTS_PIN_Msk (0x1FUL << UARTE_PSEL_CTS_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: UARTE_PSEL_RXD */
+/* Description: Pin select for RXD signal */
+
+/* Bit 31 : Connection */
+#define UARTE_PSEL_RXD_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define UARTE_PSEL_RXD_CONNECT_Msk (0x1UL << UARTE_PSEL_RXD_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define UARTE_PSEL_RXD_CONNECT_Connected (0UL) /*!< Connect */
+#define UARTE_PSEL_RXD_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : Pin number */
+#define UARTE_PSEL_RXD_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define UARTE_PSEL_RXD_PIN_Msk (0x1FUL << UARTE_PSEL_RXD_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: UARTE_BAUDRATE */
+/* Description: Baud rate */
+
+/* Bits 31..0 : Baud-rate */
+#define UARTE_BAUDRATE_BAUDRATE_Pos (0UL) /*!< Position of BAUDRATE field. */
+#define UARTE_BAUDRATE_BAUDRATE_Msk (0xFFFFFFFFUL << UARTE_BAUDRATE_BAUDRATE_Pos) /*!< Bit mask of BAUDRATE field. */
+#define UARTE_BAUDRATE_BAUDRATE_Baud1200 (0x0004F000UL) /*!< 1200 baud (actual rate: 1205) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud2400 (0x0009D000UL) /*!< 2400 baud (actual rate: 2396) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud4800 (0x0013B000UL) /*!< 4800 baud (actual rate: 4808) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud9600 (0x00275000UL) /*!< 9600 baud (actual rate: 9598) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud14400 (0x003AF000UL) /*!< 14400 baud (actual rate: 14401) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud19200 (0x004EA000UL) /*!< 19200 baud (actual rate: 19208) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud28800 (0x0075C000UL) /*!< 28800 baud (actual rate: 28777) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud38400 (0x009D0000UL) /*!< 38400 baud (actual rate: 38369) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud57600 (0x00EB0000UL) /*!< 57600 baud (actual rate: 57554) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud76800 (0x013A9000UL) /*!< 76800 baud (actual rate: 76923) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud115200 (0x01D60000UL) /*!< 115200 baud (actual rate: 115108) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud230400 (0x03B00000UL) /*!< 230400 baud (actual rate: 231884) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud250000 (0x04000000UL) /*!< 250000 baud */
+#define UARTE_BAUDRATE_BAUDRATE_Baud460800 (0x07400000UL) /*!< 460800 baud (actual rate: 457143) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud921600 (0x0F000000UL) /*!< 921600 baud (actual rate: 941176) */
+#define UARTE_BAUDRATE_BAUDRATE_Baud1M (0x10000000UL) /*!< 1Mega baud */
+
+/* Register: UARTE_RXD_PTR */
+/* Description: Data pointer */
+
+/* Bits 31..0 : Data pointer */
+#define UARTE_RXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define UARTE_RXD_PTR_PTR_Msk (0xFFFFFFFFUL << UARTE_RXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: UARTE_RXD_MAXCNT */
+/* Description: Maximum number of bytes in receive buffer */
+
+/* Bits 7..0 : Maximum number of bytes in receive buffer */
+#define UARTE_RXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define UARTE_RXD_MAXCNT_MAXCNT_Msk (0xFFUL << UARTE_RXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: UARTE_RXD_AMOUNT */
+/* Description: Number of bytes transferred in the last transaction */
+
+/* Bits 7..0 : Number of bytes transferred in the last transaction */
+#define UARTE_RXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define UARTE_RXD_AMOUNT_AMOUNT_Msk (0xFFUL << UARTE_RXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: UARTE_TXD_PTR */
+/* Description: Data pointer */
+
+/* Bits 31..0 : Data pointer */
+#define UARTE_TXD_PTR_PTR_Pos (0UL) /*!< Position of PTR field. */
+#define UARTE_TXD_PTR_PTR_Msk (0xFFFFFFFFUL << UARTE_TXD_PTR_PTR_Pos) /*!< Bit mask of PTR field. */
+
+/* Register: UARTE_TXD_MAXCNT */
+/* Description: Maximum number of bytes in transmit buffer */
+
+/* Bits 7..0 : Maximum number of bytes in transmit buffer */
+#define UARTE_TXD_MAXCNT_MAXCNT_Pos (0UL) /*!< Position of MAXCNT field. */
+#define UARTE_TXD_MAXCNT_MAXCNT_Msk (0xFFUL << UARTE_TXD_MAXCNT_MAXCNT_Pos) /*!< Bit mask of MAXCNT field. */
+
+/* Register: UARTE_TXD_AMOUNT */
+/* Description: Number of bytes transferred in the last transaction */
+
+/* Bits 7..0 : Number of bytes transferred in the last transaction */
+#define UARTE_TXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
+#define UARTE_TXD_AMOUNT_AMOUNT_Msk (0xFFUL << UARTE_TXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
+
+/* Register: UARTE_CONFIG */
+/* Description: Configuration of parity and hardware flow control */
+
+/* Bits 3..1 : Parity */
+#define UARTE_CONFIG_PARITY_Pos (1UL) /*!< Position of PARITY field. */
+#define UARTE_CONFIG_PARITY_Msk (0x7UL << UARTE_CONFIG_PARITY_Pos) /*!< Bit mask of PARITY field. */
+#define UARTE_CONFIG_PARITY_Excluded (0x0UL) /*!< Exclude parity bit */
+#define UARTE_CONFIG_PARITY_Included (0x7UL) /*!< Include parity bit */
+
+/* Bit 0 : Hardware flow control */
+#define UARTE_CONFIG_HWFC_Pos (0UL) /*!< Position of HWFC field. */
+#define UARTE_CONFIG_HWFC_Msk (0x1UL << UARTE_CONFIG_HWFC_Pos) /*!< Bit mask of HWFC field. */
+#define UARTE_CONFIG_HWFC_Disabled (0UL) /*!< Disabled */
+#define UARTE_CONFIG_HWFC_Enabled (1UL) /*!< Enabled */
+
+
+/* Peripheral: UICR */
+/* Description: User Information Configuration Registers */
+
+/* Register: UICR_NRFFW */
+/* Description: Description collection[0]:  Reserved for Nordic firmware design */
+
+/* Bits 31..0 : Reserved for Nordic firmware design */
+#define UICR_NRFFW_NRFFW_Pos (0UL) /*!< Position of NRFFW field. */
+#define UICR_NRFFW_NRFFW_Msk (0xFFFFFFFFUL << UICR_NRFFW_NRFFW_Pos) /*!< Bit mask of NRFFW field. */
+
+/* Register: UICR_NRFHW */
+/* Description: Description collection[0]:  Reserved for Nordic hardware design */
+
+/* Bits 31..0 : Reserved for Nordic hardware design */
+#define UICR_NRFHW_NRFHW_Pos (0UL) /*!< Position of NRFHW field. */
+#define UICR_NRFHW_NRFHW_Msk (0xFFFFFFFFUL << UICR_NRFHW_NRFHW_Pos) /*!< Bit mask of NRFHW field. */
+
+/* Register: UICR_CUSTOMER */
+/* Description: Description collection[0]:  Reserved for customer */
+
+/* Bits 31..0 : Reserved for customer */
+#define UICR_CUSTOMER_CUSTOMER_Pos (0UL) /*!< Position of CUSTOMER field. */
+#define UICR_CUSTOMER_CUSTOMER_Msk (0xFFFFFFFFUL << UICR_CUSTOMER_CUSTOMER_Pos) /*!< Bit mask of CUSTOMER field. */
+
+/* Register: UICR_PSELRESET */
+/* Description: Description collection[0]:  Mapping of the nRESET function (see POWER chapter for details) */
+
+/* Bit 31 : Connection */
+#define UICR_PSELRESET_CONNECT_Pos (31UL) /*!< Position of CONNECT field. */
+#define UICR_PSELRESET_CONNECT_Msk (0x1UL << UICR_PSELRESET_CONNECT_Pos) /*!< Bit mask of CONNECT field. */
+#define UICR_PSELRESET_CONNECT_Connected (0UL) /*!< Connect */
+#define UICR_PSELRESET_CONNECT_Disconnected (1UL) /*!< Disconnect */
+
+/* Bits 4..0 : GPIO number P0.n onto which Reset is exposed */
+#define UICR_PSELRESET_PIN_Pos (0UL) /*!< Position of PIN field. */
+#define UICR_PSELRESET_PIN_Msk (0x1FUL << UICR_PSELRESET_PIN_Pos) /*!< Bit mask of PIN field. */
+
+/* Register: UICR_APPROTECT */
+/* Description: Access port protection */
+
+/* Bits 7..0 : Blocks debugger read/write access to all CPU registers and memory mapped addresses */
+#define UICR_APPROTECT_PALL_Pos (0UL) /*!< Position of PALL field. */
+#define UICR_APPROTECT_PALL_Msk (0xFFUL << UICR_APPROTECT_PALL_Pos) /*!< Bit mask of PALL field. */
+#define UICR_APPROTECT_PALL_Enabled (0x00UL) /*!< Enable */
+#define UICR_APPROTECT_PALL_Disabled (0xFFUL) /*!< Disable */
+
+/* Register: UICR_NFCPINS */
+/* Description: Setting of pins dedicated to NFC functionality: NFC antenna or GPIO */
+
+/* Bit 0 : Setting of pins dedicated to NFC functionality */
+#define UICR_NFCPINS_PROTECT_Pos (0UL) /*!< Position of PROTECT field. */
+#define UICR_NFCPINS_PROTECT_Msk (0x1UL << UICR_NFCPINS_PROTECT_Pos) /*!< Bit mask of PROTECT field. */
+#define UICR_NFCPINS_PROTECT_Disabled (0UL) /*!< Operation as GPIO pins. Same protection as normal GPIO pins */
+#define UICR_NFCPINS_PROTECT_NFC (1UL) /*!< Operation as NFC antenna pins. Configures the protection for NFC operation */
+
+
+/* Peripheral: WDT */
+/* Description: Watchdog Timer */
+
+/* Register: WDT_INTENSET */
+/* Description: Enable interrupt */
+
+/* Bit 0 : Write '1' to Enable interrupt for TIMEOUT event */
+#define WDT_INTENSET_TIMEOUT_Pos (0UL) /*!< Position of TIMEOUT field. */
+#define WDT_INTENSET_TIMEOUT_Msk (0x1UL << WDT_INTENSET_TIMEOUT_Pos) /*!< Bit mask of TIMEOUT field. */
+#define WDT_INTENSET_TIMEOUT_Disabled (0UL) /*!< Read: Disabled */
+#define WDT_INTENSET_TIMEOUT_Enabled (1UL) /*!< Read: Enabled */
+#define WDT_INTENSET_TIMEOUT_Set (1UL) /*!< Enable */
+
+/* Register: WDT_INTENCLR */
+/* Description: Disable interrupt */
+
+/* Bit 0 : Write '1' to Disable interrupt for TIMEOUT event */
+#define WDT_INTENCLR_TIMEOUT_Pos (0UL) /*!< Position of TIMEOUT field. */
+#define WDT_INTENCLR_TIMEOUT_Msk (0x1UL << WDT_INTENCLR_TIMEOUT_Pos) /*!< Bit mask of TIMEOUT field. */
+#define WDT_INTENCLR_TIMEOUT_Disabled (0UL) /*!< Read: Disabled */
+#define WDT_INTENCLR_TIMEOUT_Enabled (1UL) /*!< Read: Enabled */
+#define WDT_INTENCLR_TIMEOUT_Clear (1UL) /*!< Disable */
+
+/* Register: WDT_RUNSTATUS */
+/* Description: Run status */
+
+/* Bit 0 : Indicates whether or not the watchdog is running */
+#define WDT_RUNSTATUS_RUNSTATUS_Pos (0UL) /*!< Position of RUNSTATUS field. */
+#define WDT_RUNSTATUS_RUNSTATUS_Msk (0x1UL << WDT_RUNSTATUS_RUNSTATUS_Pos) /*!< Bit mask of RUNSTATUS field. */
+#define WDT_RUNSTATUS_RUNSTATUS_NotRunning (0UL) /*!< Watchdog not running */
+#define WDT_RUNSTATUS_RUNSTATUS_Running (1UL) /*!< Watchdog is running */
+
+/* Register: WDT_REQSTATUS */
+/* Description: Request status */
+
+/* Bit 7 : Request status for RR[7] register */
+#define WDT_REQSTATUS_RR7_Pos (7UL) /*!< Position of RR7 field. */
+#define WDT_REQSTATUS_RR7_Msk (0x1UL << WDT_REQSTATUS_RR7_Pos) /*!< Bit mask of RR7 field. */
+#define WDT_REQSTATUS_RR7_DisabledOrRequested (0UL) /*!< RR[7] register is not enabled, or are already requesting reload */
+#define WDT_REQSTATUS_RR7_EnabledAndUnrequested (1UL) /*!< RR[7] register is enabled, and are not yet requesting reload */
+
+/* Bit 6 : Request status for RR[6] register */
+#define WDT_REQSTATUS_RR6_Pos (6UL) /*!< Position of RR6 field. */
+#define WDT_REQSTATUS_RR6_Msk (0x1UL << WDT_REQSTATUS_RR6_Pos) /*!< Bit mask of RR6 field. */
+#define WDT_REQSTATUS_RR6_DisabledOrRequested (0UL) /*!< RR[6] register is not enabled, or are already requesting reload */
+#define WDT_REQSTATUS_RR6_EnabledAndUnrequested (1UL) /*!< RR[6] register is enabled, and are not yet requesting reload */
+
+/* Bit 5 : Request status for RR[5] register */
+#define WDT_REQSTATUS_RR5_Pos (5UL) /*!< Position of RR5 field. */
+#define WDT_REQSTATUS_RR5_Msk (0x1UL << WDT_REQSTATUS_RR5_Pos) /*!< Bit mask of RR5 field. */
+#define WDT_REQSTATUS_RR5_DisabledOrRequested (0UL) /*!< RR[5] register is not enabled, or are already requesting reload */
+#define WDT_REQSTATUS_RR5_EnabledAndUnrequested (1UL) /*!< RR[5] register is enabled, and are not yet requesting reload */
+
+/* Bit 4 : Request status for RR[4] register */
+#define WDT_REQSTATUS_RR4_Pos (4UL) /*!< Position of RR4 field. */
+#define WDT_REQSTATUS_RR4_Msk (0x1UL << WDT_REQSTATUS_RR4_Pos) /*!< Bit mask of RR4 field. */
+#define WDT_REQSTATUS_RR4_DisabledOrRequested (0UL) /*!< RR[4] register is not enabled, or are already requesting reload */
+#define WDT_REQSTATUS_RR4_EnabledAndUnrequested (1UL) /*!< RR[4] register is enabled, and are not yet requesting reload */
+
+/* Bit 3 : Request status for RR[3] register */
+#define WDT_REQSTATUS_RR3_Pos (3UL) /*!< Position of RR3 field. */
+#define WDT_REQSTATUS_RR3_Msk (0x1UL << WDT_REQSTATUS_RR3_Pos) /*!< Bit mask of RR3 field. */
+#define WDT_REQSTATUS_RR3_DisabledOrRequested (0UL) /*!< RR[3] register is not enabled, or are already requesting reload */
+#define WDT_REQSTATUS_RR3_EnabledAndUnrequested (1UL) /*!< RR[3] register is enabled, and are not yet requesting reload */
+
+/* Bit 2 : Request status for RR[2] register */
+#define WDT_REQSTATUS_RR2_Pos (2UL) /*!< Position of RR2 field. */
+#define WDT_REQSTATUS_RR2_Msk (0x1UL << WDT_REQSTATUS_RR2_Pos) /*!< Bit mask of RR2 field. */
+#define WDT_REQSTATUS_RR2_DisabledOrRequested (0UL) /*!< RR[2] register is not enabled, or are already requesting reload */
+#define WDT_REQSTATUS_RR2_EnabledAndUnrequested (1UL) /*!< RR[2] register is enabled, and are not yet requesting reload */
+
+/* Bit 1 : Request status for RR[1] register */
+#define WDT_REQSTATUS_RR1_Pos (1UL) /*!< Position of RR1 field. */
+#define WDT_REQSTATUS_RR1_Msk (0x1UL << WDT_REQSTATUS_RR1_Pos) /*!< Bit mask of RR1 field. */
+#define WDT_REQSTATUS_RR1_DisabledOrRequested (0UL) /*!< RR[1] register is not enabled, or are already requesting reload */
+#define WDT_REQSTATUS_RR1_EnabledAndUnrequested (1UL) /*!< RR[1] register is enabled, and are not yet requesting reload */
+
+/* Bit 0 : Request status for RR[0] register */
+#define WDT_REQSTATUS_RR0_Pos (0UL) /*!< Position of RR0 field. */
+#define WDT_REQSTATUS_RR0_Msk (0x1UL << WDT_REQSTATUS_RR0_Pos) /*!< Bit mask of RR0 field. */
+#define WDT_REQSTATUS_RR0_DisabledOrRequested (0UL) /*!< RR[0] register is not enabled, or are already requesting reload */
+#define WDT_REQSTATUS_RR0_EnabledAndUnrequested (1UL) /*!< RR[0] register is enabled, and are not yet requesting reload */
+
+/* Register: WDT_CRV */
+/* Description: Counter reload value */
+
+/* Bits 31..0 : Counter reload value in number of cycles of the 32.768 kHz clock */
+#define WDT_CRV_CRV_Pos (0UL) /*!< Position of CRV field. */
+#define WDT_CRV_CRV_Msk (0xFFFFFFFFUL << WDT_CRV_CRV_Pos) /*!< Bit mask of CRV field. */
+
+/* Register: WDT_RREN */
+/* Description: Enable register for reload request registers */
+
+/* Bit 7 : Enable or disable RR[7] register */
+#define WDT_RREN_RR7_Pos (7UL) /*!< Position of RR7 field. */
+#define WDT_RREN_RR7_Msk (0x1UL << WDT_RREN_RR7_Pos) /*!< Bit mask of RR7 field. */
+#define WDT_RREN_RR7_Disabled (0UL) /*!< Disable RR[7] register */
+#define WDT_RREN_RR7_Enabled (1UL) /*!< Enable RR[7] register */
+
+/* Bit 6 : Enable or disable RR[6] register */
+#define WDT_RREN_RR6_Pos (6UL) /*!< Position of RR6 field. */
+#define WDT_RREN_RR6_Msk (0x1UL << WDT_RREN_RR6_Pos) /*!< Bit mask of RR6 field. */
+#define WDT_RREN_RR6_Disabled (0UL) /*!< Disable RR[6] register */
+#define WDT_RREN_RR6_Enabled (1UL) /*!< Enable RR[6] register */
+
+/* Bit 5 : Enable or disable RR[5] register */
+#define WDT_RREN_RR5_Pos (5UL) /*!< Position of RR5 field. */
+#define WDT_RREN_RR5_Msk (0x1UL << WDT_RREN_RR5_Pos) /*!< Bit mask of RR5 field. */
+#define WDT_RREN_RR5_Disabled (0UL) /*!< Disable RR[5] register */
+#define WDT_RREN_RR5_Enabled (1UL) /*!< Enable RR[5] register */
+
+/* Bit 4 : Enable or disable RR[4] register */
+#define WDT_RREN_RR4_Pos (4UL) /*!< Position of RR4 field. */
+#define WDT_RREN_RR4_Msk (0x1UL << WDT_RREN_RR4_Pos) /*!< Bit mask of RR4 field. */
+#define WDT_RREN_RR4_Disabled (0UL) /*!< Disable RR[4] register */
+#define WDT_RREN_RR4_Enabled (1UL) /*!< Enable RR[4] register */
+
+/* Bit 3 : Enable or disable RR[3] register */
+#define WDT_RREN_RR3_Pos (3UL) /*!< Position of RR3 field. */
+#define WDT_RREN_RR3_Msk (0x1UL << WDT_RREN_RR3_Pos) /*!< Bit mask of RR3 field. */
+#define WDT_RREN_RR3_Disabled (0UL) /*!< Disable RR[3] register */
+#define WDT_RREN_RR3_Enabled (1UL) /*!< Enable RR[3] register */
+
+/* Bit 2 : Enable or disable RR[2] register */
+#define WDT_RREN_RR2_Pos (2UL) /*!< Position of RR2 field. */
+#define WDT_RREN_RR2_Msk (0x1UL << WDT_RREN_RR2_Pos) /*!< Bit mask of RR2 field. */
+#define WDT_RREN_RR2_Disabled (0UL) /*!< Disable RR[2] register */
+#define WDT_RREN_RR2_Enabled (1UL) /*!< Enable RR[2] register */
+
+/* Bit 1 : Enable or disable RR[1] register */
+#define WDT_RREN_RR1_Pos (1UL) /*!< Position of RR1 field. */
+#define WDT_RREN_RR1_Msk (0x1UL << WDT_RREN_RR1_Pos) /*!< Bit mask of RR1 field. */
+#define WDT_RREN_RR1_Disabled (0UL) /*!< Disable RR[1] register */
+#define WDT_RREN_RR1_Enabled (1UL) /*!< Enable RR[1] register */
+
+/* Bit 0 : Enable or disable RR[0] register */
+#define WDT_RREN_RR0_Pos (0UL) /*!< Position of RR0 field. */
+#define WDT_RREN_RR0_Msk (0x1UL << WDT_RREN_RR0_Pos) /*!< Bit mask of RR0 field. */
+#define WDT_RREN_RR0_Disabled (0UL) /*!< Disable RR[0] register */
+#define WDT_RREN_RR0_Enabled (1UL) /*!< Enable RR[0] register */
+
+/* Register: WDT_CONFIG */
+/* Description: Configuration register */
+
+/* Bit 3 : Configure the watchdog to either be paused, or kept running, while the CPU is halted by the debugger */
+#define WDT_CONFIG_HALT_Pos (3UL) /*!< Position of HALT field. */
+#define WDT_CONFIG_HALT_Msk (0x1UL << WDT_CONFIG_HALT_Pos) /*!< Bit mask of HALT field. */
+#define WDT_CONFIG_HALT_Pause (0UL) /*!< Pause watchdog while the CPU is halted by the debugger */
+#define WDT_CONFIG_HALT_Run (1UL) /*!< Keep the watchdog running while the CPU is halted by the debugger */
+
+/* Bit 0 : Configure the watchdog to either be paused, or kept running, while the CPU is sleeping */
+#define WDT_CONFIG_SLEEP_Pos (0UL) /*!< Position of SLEEP field. */
+#define WDT_CONFIG_SLEEP_Msk (0x1UL << WDT_CONFIG_SLEEP_Pos) /*!< Bit mask of SLEEP field. */
+#define WDT_CONFIG_SLEEP_Pause (0UL) /*!< Pause watchdog while the CPU is sleeping */
+#define WDT_CONFIG_SLEEP_Run (1UL) /*!< Keep the watchdog running while the CPU is sleeping */
+
+/* Register: WDT_RR */
+/* Description: Description collection[0]:  Reload request 0 */
+
+/* Bits 31..0 : Reload request register */
+#define WDT_RR_RR_Pos (0UL) /*!< Position of RR field. */
+#define WDT_RR_RR_Msk (0xFFFFFFFFUL << WDT_RR_RR_Pos) /*!< Bit mask of RR field. */
+#define WDT_RR_RR_Reload (0x6E524635UL) /*!< Value to request a reload of the watchdog timer */
+
+
+/*lint --flb "Leave library region" */
+#endif

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf52_common.ld
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf52_common.ld
@@ -1,0 +1,164 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ * 
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.Vectors))
+		*(.text*)
+
+		KEEP(*(.init))
+		KEEP(*(.fini))
+
+		/* .ctors */
+		*crtbegin.o(.ctors)
+		*crtbegin?.o(.ctors)
+		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+		*(SORT(.ctors.*))
+		*(.ctors)
+
+		/* .dtors */
+ 		*crtbegin.o(.dtors)
+ 		*crtbegin?.o(.dtors)
+ 		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+ 		*(SORT(.dtors.*))
+ 		*(.dtors)
+
+		*(.rodata*)
+
+		*(.eh_frame*)
+		. = ALIGN(4);
+	} > FLASH
+    
+
+	.ARM.extab : 
+	{
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		. = ALIGN(4);
+	} > FLASH
+
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+		. = ALIGN(4);
+	} > FLASH
+	__exidx_end = .;
+
+	__etext = .;
+		
+	.data : AT (__etext)
+	{
+		__data_start__ = .;
+		*(vtable)
+		*(.data*)
+
+		. = ALIGN(4);
+		/* preinit data */
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		*(.preinit_array)
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+
+		. = ALIGN(4);
+		/* init data */
+		PROVIDE_HIDDEN (__init_array_start = .);
+		*(SORT(.init_array.*))
+		*(.init_array)
+		PROVIDE_HIDDEN (__init_array_end = .);
+
+
+		. = ALIGN(4);
+		/* finit data */
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		*(SORT(.fini_array.*))
+		*(.fini_array)
+		PROVIDE_HIDDEN (__fini_array_end = .);
+
+		*(.jcr)
+		. = ALIGN(4);
+		/* All data end */
+		__data_end__ = .;
+
+	} > RAM
+
+	.bss :
+	{
+		. = ALIGN(4);
+		__bss_start__ = .;
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);
+		__bss_end__ = .;
+	} > RAM
+	
+	.heap (COPY):
+	{
+		__end__ = .;
+		end = __end__;
+		*(.heap*)
+		__HeapLimit = .;
+	} > RAM
+
+	/* .stack_dummy section doesn't contains any symbols. It is only
+	 * used for linker to calculate size of stack sections, and assign
+	 * values to stack symbols later */
+	.stack_dummy (COPY):
+	{
+		*(.stack*)
+	} > RAM
+
+	/* Set stack top to end of RAM, and stack limit move down by
+	 * size of stack_dummy section */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
+	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
+	PROVIDE(__stack = __StackTop);
+	
+	/* Check if data + heap + stack exceeds RAM limit */
+	ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}
+

--- a/common/nRF5x_MDK_8_1_0_GCC/nrf52_xxaa.ld
+++ b/common/nRF5x_MDK_8_1_0_GCC/nrf52_xxaa.ld
@@ -1,0 +1,13 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x80000
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x10000
+}
+
+
+INCLUDE "nrf52_common.ld"

--- a/common/nRF5x_MDK_8_1_0_GCC/system_nrf51.c
+++ b/common/nRF5x_MDK_8_1_0_GCC/system_nrf51.c
@@ -1,0 +1,121 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* NOTE: Template files (including this one) are application specific and therefore expected to 
+   be copied into the application project folder prior to its use! */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "nrf.h"
+#include "system_nrf51.h"
+
+/*lint ++flb "Enter library region" */
+
+
+#define __SYSTEM_CLOCK      (16000000UL)     /*!< nRF51 devices use a fixed System Clock Frequency of 16MHz */
+
+static bool is_manual_peripheral_setup_needed(void);
+static bool is_disabled_in_debug_needed(void);
+
+
+#if defined ( __CC_ARM )
+    uint32_t SystemCoreClock __attribute__((used)) = __SYSTEM_CLOCK;  
+#elif defined ( __ICCARM__ )
+    __root uint32_t SystemCoreClock = __SYSTEM_CLOCK;
+#elif defined   ( __GNUC__ )
+    uint32_t SystemCoreClock __attribute__((used)) = __SYSTEM_CLOCK;
+#endif
+
+void SystemCoreClockUpdate(void)
+{
+    SystemCoreClock = __SYSTEM_CLOCK;
+}
+
+void SystemInit(void)
+{
+    /* If desired, switch off the unused RAM to lower consumption by the use of RAMON register.
+       It can also be done in the application main() function. */
+
+    /* Prepare the peripherals for use as indicated by the PAN 26 "System: Manual setup is required
+       to enable the use of peripherals" found at Product Anomaly document for your device found at
+       https://www.nordicsemi.com/. The side effect of executing these instructions in the devices 
+       that do not need it is that the new peripherals in the second generation devices (LPCOMP for
+       example) will not be available. */
+    if (is_manual_peripheral_setup_needed())
+    {
+        *(uint32_t volatile *)0x40000504 = 0xC007FFDF;
+        *(uint32_t volatile *)0x40006C18 = 0x00008000;
+    }
+    
+    /* Disable PROTENSET registers under debug, as indicated by PAN 59 "MPU: Reset value of DISABLEINDEBUG
+       register is incorrect" found at Product Anomaly document four your device found at 
+       https://www.nordicsemi.com/. There is no side effect of using these instruction if not needed. */
+    if (is_disabled_in_debug_needed())
+    {
+        NRF_MPU->DISABLEINDEBUG = MPU_DISABLEINDEBUG_DISABLEINDEBUG_Disabled << MPU_DISABLEINDEBUG_DISABLEINDEBUG_Pos;
+    }
+}
+
+
+static bool is_manual_peripheral_setup_needed(void) 
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x1) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0))
+    {
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x00) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x10) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+static bool is_disabled_in_debug_needed(void) 
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x1) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0))
+    {
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x40) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+/*lint --flb "Leave library region" */

--- a/common/nRF5x_MDK_8_1_0_GCC/system_nrf51.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/system_nrf51.h
@@ -1,0 +1,69 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef SYSTEM_NRF51_H
+#define SYSTEM_NRF51_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+
+extern uint32_t SystemCoreClock;    /*!< System Clock Frequency (Core Clock)  */
+
+/**
+ * Initialize the system
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Setup the microcontroller system.
+ *         Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+/**
+ * Update SystemCoreClock variable
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Updates the SystemCoreClock with current core Clock 
+ *         retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_NRF51_H */

--- a/common/nRF5x_MDK_8_1_0_GCC/system_nrf52.c
+++ b/common/nRF5x_MDK_8_1_0_GCC/system_nrf52.c
@@ -1,0 +1,263 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "nrf.h"
+#include "system_nrf52.h"
+
+/*lint ++flb "Enter library region" */
+
+#define __SYSTEM_CLOCK_16M      (16000000UL)     
+#define __SYSTEM_CLOCK_64M      (64000000UL)   
+
+static bool errata_31(void); 
+static bool errata_32(void); 
+static bool errata_36(void); 
+static bool errata_37(void); 
+static bool errata_66(void); 
+
+
+#if defined ( __CC_ARM )
+    uint32_t SystemCoreClock __attribute__((used)) = __SYSTEM_CLOCK_64M;
+#elif defined ( __ICCARM__ )
+    __root uint32_t SystemCoreClock = __SYSTEM_CLOCK_64M;
+#elif defined   ( __GNUC__ )
+    uint32_t SystemCoreClock __attribute__((used)) = __SYSTEM_CLOCK_64M;
+#endif
+
+void SystemCoreClockUpdate(void)
+{
+    SystemCoreClock = __SYSTEM_CLOCK_64M;
+}
+
+void SystemInit(void)
+{
+    /* Workaround for Errata 31 "CLOCK: Calibration values are not correctly loaded from FICR at reset" found at the Errata document 
+       for your device located at https://infocenter.nordicsemi.com/ */
+    if (errata_31()){        
+        *(volatile uint32_t *)0x4000053C = ((*(volatile uint32_t *)0x10000244) & 0x0000E000) >> 13;
+    }
+    
+    /* Workaround for Errata 32 "DIF: Debug session automatically enables TracePort pins" found at the Errata document 
+       for your device located at https://infocenter.nordicsemi.com/ */
+    if (errata_32()){        
+        CoreDebug->DEMCR &= ~CoreDebug_DEMCR_TRCENA_Msk;
+    }
+    
+    /* Workaround for Errata 36 "CLOCK: Some registers are not reset when expected" found at the Errata document 
+       for your device located at https://infocenter.nordicsemi.com/  */
+    if (errata_36()){        
+        NRF_CLOCK->EVENTS_DONE = 0;
+        NRF_CLOCK->EVENTS_CTTO = 0;
+        NRF_CLOCK->CTIV = 0;
+    }
+    
+    /* Workaround for Errata 37 "RADIO: Encryption engine is slow by default" found at the Errata document 
+       for your device located at https://infocenter.nordicsemi.com/  */
+    if (errata_37()){        
+        *(volatile uint32_t *)0x400005A0 = 0x3;
+    }
+    
+    /* Workaround for Errata 66 "TEMP: Linearity spec not met with default settings" found at the Errata document 
+       for your device located at https://infocenter.nordicsemi.com/  */
+    if (errata_66()){        
+        NRF_TEMP->A0 = NRF_FICR->TEMP.A0;
+        NRF_TEMP->A1 = NRF_FICR->TEMP.A1;
+        NRF_TEMP->A2 = NRF_FICR->TEMP.A2;
+        NRF_TEMP->A3 = NRF_FICR->TEMP.A3;
+        NRF_TEMP->A4 = NRF_FICR->TEMP.A4;
+        NRF_TEMP->A5 = NRF_FICR->TEMP.A5;
+        NRF_TEMP->B0 = NRF_FICR->TEMP.B0;
+        NRF_TEMP->B1 = NRF_FICR->TEMP.B1;
+        NRF_TEMP->B2 = NRF_FICR->TEMP.B2;
+        NRF_TEMP->B3 = NRF_FICR->TEMP.B3;
+        NRF_TEMP->B4 = NRF_FICR->TEMP.B4;
+        NRF_TEMP->B5 = NRF_FICR->TEMP.B5;
+        NRF_TEMP->T0 = NRF_FICR->TEMP.T0;
+        NRF_TEMP->T1 = NRF_FICR->TEMP.T1;
+        NRF_TEMP->T2 = NRF_FICR->TEMP.T2;
+        NRF_TEMP->T3 = NRF_FICR->TEMP.T3;
+        NRF_TEMP->T4 = NRF_FICR->TEMP.T4;
+    }
+    
+    /* Enable the FPU if the compiler used floating point unit instructions. __FPU_USED is a MACRO defined by the 
+     * compiler. Since the FPU consumes energy, remember to disable FPU use in the compiler if floating point unit 
+     * operations are not used in your code. */
+    #if (__FPU_USED == 1)
+        SCB->CPACR |= (3UL << 20) | (3UL << 22); 
+        __DSB();
+        __ISB();
+    #endif
+    
+    /* Configure NFCT pins as GPIOs if NFCT is not to be used in your code. If CONFIG_NFCT_PINS_AS_GPIOS is not defined, 
+       two GPIOs (see Product Specification to see which ones) will be reserved for NFC and will not be available as 
+       normal GPIOs. */
+    #if defined (CONFIG_NFCT_PINS_AS_GPIOS)
+        if ((NRF_UICR->NFCPINS & UICR_NFCPINS_PROTECT_Msk) == (UICR_NFCPINS_PROTECT_NFC << UICR_NFCPINS_PROTECT_Pos)){
+            NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}            
+            NRF_UICR->NFCPINS &= ~UICR_NFCPINS_PROTECT_Msk;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}            
+            NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}            
+            NVIC_SystemReset();
+        }
+    #endif
+    
+    /* Configure GPIO pads as pPin Reset pin if Pin Reset capabilities desired. If CONFIG_GPIO_AS_PINRESET is not
+      defined, pin reset will not be available. One GPIO (see Product Specification to see which one) will then be 
+      reserved for PinReset and not available as normal GPIO. */
+    #if defined (CONFIG_GPIO_AS_PINRESET)
+        if (((NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) != (UICR_PSELRESET_CONNECT_Connected << UICR_PSELRESET_CONNECT_Pos)) || 
+            ((NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) != (UICR_PSELRESET_CONNECT_Connected << UICR_PSELRESET_CONNECT_Pos))){
+            NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NRF_UICR->PSELRESET[0] = 21;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NRF_UICR->PSELRESET[1] = 21;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NVIC_SystemReset();
+        }
+    #endif
+    
+    /* Enable SWO trace functionality. If ENABLE_SWO is not defined, SWO pin will be used as GPIO (see Product 
+       Specification to see which one). */
+    #if defined (ENABLE_SWO)
+        CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+        NRF_CLOCK->TRACECONFIG |= CLOCK_TRACECONFIG_TRACEMUX_Serial << CLOCK_TRACECONFIG_TRACEMUX_Pos;
+        NRF_P0->PIN_CNF[18] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+    #endif
+    
+    /* Enable Trace functionality. If ENABLE_TRACE is not defined, TRACE pins will be used as GPIOs (see Product 
+       Specification to see which ones). */
+    #if defined (ENABLE_TRACE)
+        CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+        NRF_CLOCK->TRACECONFIG |= CLOCK_TRACECONFIG_TRACEMUX_Parallel << CLOCK_TRACECONFIG_TRACEMUX_Pos;
+        NRF_P0->PIN_CNF[14] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+        NRF_P0->PIN_CNF[15] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+        NRF_P0->PIN_CNF[16] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+        NRF_P0->PIN_CNF[18] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+        NRF_P0->PIN_CNF[20] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+    #endif
+
+    SystemCoreClockUpdate();
+}
+
+
+static bool errata_31(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0))
+    {
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x40) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x50) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+static bool errata_32(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0))
+    {
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+static bool errata_36(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0))
+    {
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x40) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x50) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+static bool errata_37(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0))
+    {
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+static bool errata_66(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0))
+    {
+        if ((((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x50) && (((*(uint32_t *)0xF0000FEC) & 0x000000F0) == 0x0))
+        {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+
+
+
+
+
+/*lint --flb "Leave library region" */

--- a/common/nRF5x_MDK_8_1_0_GCC/system_nrf52.h
+++ b/common/nRF5x_MDK_8_1_0_GCC/system_nrf52.h
@@ -1,0 +1,69 @@
+/* Copyright (c) 2015, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of Nordic Semiconductor ASA nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef SYSTEM_NRF52_H
+#define SYSTEM_NRF52_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+
+extern uint32_t SystemCoreClock;    /*!< System Clock Frequency (Core Clock)  */
+
+/**
+ * Initialize the system
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Setup the microcontroller system.
+ *         Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+/**
+ * Update SystemCoreClock variable
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Updates the SystemCoreClock with current core Clock 
+ *         retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_NRF52_H */

--- a/examples/gpio_toggle/main.c
+++ b/examples/gpio_toggle/main.c
@@ -1,6 +1,6 @@
 #include <nrf.h>
 
-#define PIN_GPIO  (11UL)
+#define PIN_GPIO  (17UL)
 
 int main(void)
 {
@@ -15,15 +15,14 @@ int main(void)
   // Toggle GPIO ON/OFF.
   while (1)
   {
-    uint32_t tmo;
+    uint32_t volatile tmo;
     
-    tmo = 300;
+    tmo = 10000000;
     while (tmo--);
     NRF_GPIO->OUTSET = (1UL << PIN_GPIO);    
     
-    tmo = 300;
+    tmo = 10000000;
     while (tmo--);
-    NRF_GPIO->OUTCLR = (1UL << PIN_GPIO);    
+    NRF_GPIO->OUTCLR = (1UL << PIN_GPIO);  
   }
 }
-


### PR DESCRIPTION
feel free to reject this pull request if its not the intention

If we choose this implementation, developers wont need to work about having an SDK in the correct place relative to NordicSnippets. They also don't have to see the MDK or CMSIS. NordicSnippets would rely on the releases of our MDK and the realeses of ARMS CMSIS.